### PR TITLE
chore(CFN): add another KMS Key ARN for Key Store Testing

### DIFF
--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -1,0 +1,259 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: "DDB Table and IAM Managed Policies/Role for AWS KMS Hierarchical Keyring Testing"
+
+Parameters:
+  TableName:
+    Type: String
+    Description: Test Table Name
+    Default: HierarchicalKeyringTestTable
+  KeyStoreTable:
+    Type: String
+    Description: Key Store Test Table Name
+    Default: KeyStoreTestTable
+  ProjectName:
+    Type: String
+    Description: A prefix that will be applied to any names
+    Default: MPL-Dafny
+  GitHubRepo:
+    Type: String
+    Description: GitHub Repo that invokes CI
+    Default: aws/aws-cryptographic-material-providers-library
+
+Resources:
+  KeyStoreTestTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "branch-key-id"
+          AttributeType: "S"
+        - AttributeName: "type"
+          AttributeType: "S"
+        - AttributeName: "status"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "branch-key-id"
+          KeyType: "HASH"
+        - AttributeName: "type"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "5"
+        WriteCapacityUnits: "5"
+      TableName: !Ref KeyStoreTable
+      GlobalSecondaryIndexes:
+      - IndexName: !Sub "Active-Keys"
+        KeySchema:
+          - AttributeName: "branch-key-id"
+            KeyType: "HASH"
+          - AttributeName: "status"
+            KeyType: "RANGE"
+        Projection:
+          ProjectionType: "ALL"
+        ProvisionedThroughput:
+          ReadCapacityUnits: "5"
+          WriteCapacityUnits: "5"
+
+  HierarchicalKeyringTestTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "branch-key-id"
+          AttributeType: "S"
+        - AttributeName: "version"
+          AttributeType: "S"
+        - AttributeName: "status"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "branch-key-id"
+          KeyType: "HASH"
+        - AttributeName: "version"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "5"
+        WriteCapacityUnits: "5"
+      TableName: !Ref TableName
+      GlobalSecondaryIndexes:
+      - IndexName: "Active-Keys"
+        KeySchema:
+          - AttributeName: "status"
+            KeyType: "HASH"
+          - AttributeName: "branch-key-id"
+            KeyType: "RANGE"
+        Projection:
+          ProjectionType: "ALL"
+        ProvisionedThroughput:
+          ReadCapacityUnits: "5"
+          WriteCapacityUnits: "5"
+
+  # This policy SHOULD be given to:
+  #  - aws/private-aws-encryption-sdk-dafny-staging
+  #  - ToolsDevelopment
+  HierarchicalKeyringTestTableUsage:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      Description: "Allow Read, Write, and Delete of Items in HierarchicalKeyringTestTable"
+      ManagedPolicyName: !Sub "${ProjectName}-DDB-ReadWriteDelete-${AWS::Region}"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:DeleteItem
+              - dynamodb:GetItem
+              - dynamodb:Query
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TableName}"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TableName}/index/*"
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:CreateTable
+              - dynamodb:PutItem
+              - dynamodb:DeleteItem
+              - dynamodb:GetItem
+              - dynamodb:Query
+              - dynamodb:ConditionCheckItem
+              - dynamodb:UpdateItem
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}/index/*"
+
+  
+  HierarchicalGitHubKMSKeyID:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: KMS Key for GitHub Action Workflow
+      Enabled: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+
+  HierarchicalGitHubKMSKeyIDTwo:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: Another KMS Key for GitHub Action Workflow
+      Enabled: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'            
+            
+  KMSUsage:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:ReEncrypt*"
+              ],
+              "Resource": [
+                "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyID}",
+                "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyIDTwo}",
+            }
+          ]
+        }
+      ManagedPolicyName: Hierarchical-GitHub-KMS-Key-Policy
+
+  RSAGitHubKMSKeyID:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: KMS RSA Key for GitHub Action Workflow
+      Enabled: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+      KeySpec: "RSA_2048"
+      KeyUsage: "ENCRYPT_DECRYPT"
+      MultiRegion: true
+
+  RSAKMSUsage:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:ReEncrypt*",
+                "kms:Generate*",
+                "kms:GetPublicKey",
+                "kms:DescribeKey"
+              ],
+              "Resource": "arn:aws:kms:*:${AWS::AccountId}:key/${RSAGitHubKMSKeyID}"
+            }
+          ]
+        }
+      ManagedPolicyName: RSA-GitHub-KMS-Key-Policy
+
+  GitHubCIRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: !Sub "GitHub-CI-${ProjectName}-Role-${AWS::Region}"
+      Description: "Access DDB, KMS, Resources for CI from GitHub"
+      ManagedPolicyArns:
+        - "arn:aws:iam::370957321024:policy/PolymorphTestModels-KMS-us-west-2"
+        - !Ref KMSUsage
+        - !Ref RSAKMSUsage  
+        - "arn:aws:iam::370957321024:policy/PolymorphTestModels-DDB-ReadWriteDelete-us-west-2"
+        - !Ref HierarchicalKeyringTestTableUsage
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",   
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:${GitHubRepo}:*"
+                }
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                "StringEquals": {
+                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                },
+                "StringLike": {
+                  "token.actions.githubusercontent.com:sub": "repo:aws/private-aws-encryption-sdk-dafny-staging:*"
+                }
+              }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::${AWS::AccountId}:role/ToolsDevelopment" },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        }

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -41,17 +41,17 @@ Resources:
         WriteCapacityUnits: "5"
       TableName: !Ref KeyStoreTable
       GlobalSecondaryIndexes:
-      - IndexName: !Sub "Active-Keys"
-        KeySchema:
-          - AttributeName: "branch-key-id"
-            KeyType: "HASH"
-          - AttributeName: "status"
-            KeyType: "RANGE"
-        Projection:
-          ProjectionType: "ALL"
-        ProvisionedThroughput:
-          ReadCapacityUnits: "5"
-          WriteCapacityUnits: "5"
+        - IndexName: !Sub "Active-Keys"
+          KeySchema:
+            - AttributeName: "branch-key-id"
+              KeyType: "HASH"
+            - AttributeName: "status"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: "ALL"
+          ProvisionedThroughput:
+            ReadCapacityUnits: "5"
+            WriteCapacityUnits: "5"
 
   HierarchicalKeyringTestTable:
     Type: AWS::DynamoDB::Table
@@ -73,17 +73,17 @@ Resources:
         WriteCapacityUnits: "5"
       TableName: !Ref TableName
       GlobalSecondaryIndexes:
-      - IndexName: "Active-Keys"
-        KeySchema:
-          - AttributeName: "status"
-            KeyType: "HASH"
-          - AttributeName: "branch-key-id"
-            KeyType: "RANGE"
-        Projection:
-          ProjectionType: "ALL"
-        ProvisionedThroughput:
-          ReadCapacityUnits: "5"
-          WriteCapacityUnits: "5"
+        - IndexName: "Active-Keys"
+          KeySchema:
+            - AttributeName: "status"
+              KeyType: "HASH"
+            - AttributeName: "branch-key-id"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: "ALL"
+          ProvisionedThroughput:
+            ReadCapacityUnits: "5"
+            WriteCapacityUnits: "5"
 
   # This policy SHOULD be given to:
   #  - aws/private-aws-encryption-sdk-dafny-staging
@@ -94,7 +94,7 @@ Resources:
       Description: "Allow Read, Write, and Delete of Items in HierarchicalKeyringTestTable"
       ManagedPolicyName: !Sub "${ProjectName}-DDB-ReadWriteDelete-${AWS::Region}"
       PolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Action:
@@ -119,9 +119,8 @@ Resources:
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}"
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}/index/*"
 
-  
   HierarchicalGitHubKMSKeyID:
-    Type: 'AWS::KMS::Key'
+    Type: "AWS::KMS::Key"
     Properties:
       Description: KMS Key for GitHub Action Workflow
       Enabled: true
@@ -130,12 +129,12 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
 
   HierarchicalGitHubKMSKeyIDTwo:
-    Type: 'AWS::KMS::Key'
+    Type: "AWS::KMS::Key"
     Properties:
       Description: Another KMS Key for GitHub Action Workflow
       Enabled: true
@@ -144,12 +143,12 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'            
-            
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+
   KMSUsage:
-    Type: 'AWS::IAM::ManagedPolicy'
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
       PolicyDocument: !Sub |
         {
@@ -171,7 +170,7 @@ Resources:
       ManagedPolicyName: Hierarchical-GitHub-KMS-Key-Policy
 
   RSAGitHubKMSKeyID:
-    Type: 'AWS::KMS::Key'
+    Type: "AWS::KMS::Key"
     Properties:
       Description: KMS RSA Key for GitHub Action Workflow
       Enabled: true
@@ -180,15 +179,15 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
-            Action: 'kms:*'
-            Resource: '*'
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
       KeySpec: "RSA_2048"
       KeyUsage: "ENCRYPT_DECRYPT"
       MultiRegion: true
 
   RSAKMSUsage:
-    Type: 'AWS::IAM::ManagedPolicy'
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
       PolicyDocument: !Sub |
         {
@@ -213,14 +212,14 @@ Resources:
   # The MPL-Dafny Repo gets access to everything here
   # via the CI.yaml#GitHubCIRole
   GitHubCIRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       RoleName: !Sub "GitHub-CI-${ProjectName}-Role-${AWS::Region}"
       Description: "Access DDB, KMS, Resources for CI from GitHub"
       ManagedPolicyArns:
         - "arn:aws:iam::370957321024:policy/PolymorphTestModels-KMS-us-west-2"
         - !Ref KMSUsage
-        - !Ref RSAKMSUsage  
+        - !Ref RSAKMSUsage
         - "arn:aws:iam::370957321024:policy/PolymorphTestModels-DDB-ReadWriteDelete-us-west-2"
         - !Ref HierarchicalKeyringTestTableUsage
       AssumeRolePolicyDocument: !Sub |

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -10,6 +10,10 @@ Parameters:
     Type: String
     Description: Key Store Test Table Name
     Default: KeyStoreTestTable
+  KeyStoreDdbTable:
+    Type: String
+    Description: Key Store DynamoDB Table Name
+    Default: KeyStoreDdbTable
   ProjectName:
     Type: String
     Description: A prefix that will be applied to any names
@@ -52,6 +56,34 @@ Resources:
           ProvisionedThroughput:
             ReadCapacityUnits: "5"
             WriteCapacityUnits: "5"
+        - IndexName: !Sub "Active-Keys-KeyStoreTestTable"
+          KeySchema:
+            - AttributeName: "branch-key-id"
+              KeyType: "HASH"
+            - AttributeName: "status"
+              KeyType: "RANGE"
+          Projection:
+            ProjectionType: "ALL"
+          ProvisionedThroughput:
+            ReadCapacityUnits: "5"
+            WriteCapacityUnits: "5"
+  KeyStoreTestDdbTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "branch-key-id"
+          AttributeType: "S"
+        - AttributeName: "type"
+          AttributeType: "S"
+      KeySchema:
+        - AttributeName: "branch-key-id"
+          KeyType: "HASH"
+        - AttributeName: "type"
+          KeyType: "RANGE"
+      ProvisionedThroughput:
+        ReadCapacityUnits: "5"
+        WriteCapacityUnits: "5"
+      TableName: !Ref KeyStoreDdbTable
 
   HierarchicalKeyringTestTable:
     Type: AWS::DynamoDB::Table
@@ -118,6 +150,19 @@ Resources:
             Resource:
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}"
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreTable}/index/*"
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:CreateTable
+              - dynamodb:PutItem
+              - dynamodb:DeleteItem
+              - dynamodb:GetItem
+              - dynamodb:Query
+              - dynamodb:ConditionCheckItem
+              - dynamodb:UpdateItem
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreDdbTable}"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreDdbTable}/index/*"
 
   HierarchicalGitHubKMSKeyID:
     Type: "AWS::KMS::Key"
@@ -159,11 +204,16 @@ Resources:
               "Action": [
                 "kms:Decrypt",
                 "kms:GenerateDataKeyWithoutPlaintext",
-                "kms:ReEncrypt*"
+                "kms:ReEncrypt*",
+                "kms:DescribeKey",
+                "kms:CreateGrant",
+                "kms:ListGrant",
+                "kms:RevokeGrant"
               ],
               "Resource": [
                 "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyID}",
                 "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyIDTwo}",
+              ]
             }
           ]
         }
@@ -209,7 +259,7 @@ Resources:
         }
       ManagedPolicyName: RSA-GitHub-KMS-Key-Policy
 
-  # The MPL-Dafny Repo gets access to everything here
+  # The MPL-Dafny Repo get access to everything here
   # via the CI.yaml#GitHubCIRole
   GitHubCIRole:
     Type: "AWS::IAM::Role"

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -212,7 +212,7 @@ Resources:
               ],
               "Resource": [
                 "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyID}",
-                "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyIDTwo}",
+                "arn:aws:kms:*:${AWS::AccountId}:key/${HierarchicalGitHubKMSKeyIDTwo}"
               ]
             }
           ]

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -13,11 +13,12 @@ Parameters:
   ProjectName:
     Type: String
     Description: A prefix that will be applied to any names
-    Default: MPL-Dafny
+    # This must remain ESDK-Dafny, or several GHWs will break
+    Default: ESDK-Dafny
   GitHubRepo:
     Type: String
     Description: GitHub Repo that invokes CI
-    Default: aws/aws-cryptographic-material-providers-library
+    Default: aws/private-aws-encryption-sdk-dafny-staging
 
 Resources:
   KeyStoreTestTable:
@@ -209,6 +210,8 @@ Resources:
         }
       ManagedPolicyName: RSA-GitHub-KMS-Key-Policy
 
+  # The MPL-Dafny Repo gets access to everything here
+  # via the CI.yaml#GitHubCIRole
   GitHubCIRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -234,19 +237,6 @@ Resources:
                 },
                 "StringLike": {
                   "token.actions.githubusercontent.com:sub": "repo:${GitHubRepo}:*"
-                }
-              }
-            },
-            {
-              "Effect": "Allow",
-              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
-              "Action": "sts:AssumeRoleWithWebIdentity",
-              "Condition": {
-                "StringEquals": {
-                  "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-                },
-                "StringLike": {
-                  "token.actions.githubusercontent.com:sub": "repo:aws/private-aws-encryption-sdk-dafny-staging:*"
                 }
               }
             },


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Move Private[ ESDK Dafny's CI yaml to this Repo](https://github.com/aws/private-aws-encryption-sdk-dafny-staging/blob/v4-seperate-modules/cfn/CI.yaml)
since it defines the DDB Table and KMS Keys several Repos have been using 
to test the H-Keyring,
and this template is only on a now dead branch.

Add another normal KMS Key to it.


_Squash/merge commit message, if applicable:_
```
chore(CFN): add another KMS Key ARN for Key Store Testing
```

I will deploy to the correct account once approved but before merging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
