### PR TITLE
chore(release): 1.3.0 [skip ci]

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.2.0-SNAPSHOT"
+version = "1.3.0"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.2.0</Version>
+      <Version>1.3.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * **dafny:** Local Service Constructors MUST return concrete ([64f72c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/64f72c121fef31a83bcf3a5346d7efc1e84ab25f))
 * dir name in java mpl release process ([#162](https://github.com/aws/aws-cryptographic-material-providers-library/issues/162)) ([d92c06a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d92c06a2fd355290f27df669c866157e14da9793))
-* KeyStore: JavaDocs for KMS Configuration ([#293] (https://github.com/aws/aws-cryptographic-material-providers-library/issues/293)) ([63ffff5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/63ffff59847cdcdbcf659de5fb2d69e272ba8b2e))
+* KeyStore: JavaDocs for KMS Configuration ([#293](https://github.com/aws/aws-cryptographic-material-providers-library/issues/293)) ([63ffff5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/63ffff59847cdcdbcf659de5fb2d69e272ba8b2e))
 * Re-Polymorph w/ Smithy-Dafny@3378be16 & fix Java Testing ([#190](https://github.com/aws/aws-cryptographic-material-providers-library/issues/190)) ([58d74f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/58d74f6d20cc649742f2c73426b0f19a6b516dbb))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+# [1.3.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.2.0...v1.3.0) (2024-04-23)
+
+
+### Bug Fixes
+
+* **dafny:** Local Service Constructors MUST return concrete ([64f72c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/64f72c121fef31a83bcf3a5346d7efc1e84ab25f))
+* dir name in java mpl release process ([#162](https://github.com/aws/aws-cryptographic-material-providers-library/issues/162)) ([d92c06a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d92c06a2fd355290f27df669c866157e14da9793))
+* Re-Polymorph w/ Smithy-Dafny@3378be16 & fix Java Testing ([#190](https://github.com/aws/aws-cryptographic-material-providers-library/issues/190)) ([58d74f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/58d74f6d20cc649742f2c73426b0f19a6b516dbb))
+
+
+### Features
+
+* enable KMS MRK Keys in KeyStore ([#285](https://github.com/aws/aws-cryptographic-material-providers-library/issues/285)) ([d924395](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d924395e7895187aee59279f7ba1f4dcdf1f893e))
+* remove quantifier-syntax ([#218](https://github.com/aws/aws-cryptographic-material-providers-library/issues/218)) ([76ab6ef](https://github.com/aws/aws-cryptographic-material-providers-library/commit/76ab6ef7d2ff9580919671cde0719b93facb5b67))
+* repolymorph to get dotnet constraint checking ([#281](https://github.com/aws/aws-cryptographic-material-providers-library/issues/281)) ([04102d7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/04102d7e30c04167df9fb76de86d2aeb0508536e))
+
 ## 1.2.0 (2024-01-08)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * **dafny:** Local Service Constructors MUST return concrete ([64f72c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/64f72c121fef31a83bcf3a5346d7efc1e84ab25f))
 * dir name in java mpl release process ([#162](https://github.com/aws/aws-cryptographic-material-providers-library/issues/162)) ([d92c06a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d92c06a2fd355290f27df669c866157e14da9793))
+* KeyStore: JavaDocs for KMS Configuration ([#293] (https://github.com/aws/aws-cryptographic-material-providers-library/issues/293)) ([63ffff5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/63ffff59847cdcdbcf659de5fb2d69e272ba8b2e))
 * Re-Polymorph w/ Smithy-Dafny@3378be16 & fix Java Testing ([#190](https://github.com/aws/aws-cryptographic-material-providers-library/issues/190)) ([58d74f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/58d74f6d20cc649742f2c73426b0f19a6b516dbb))
 
 

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyVersion("1.3.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>


### PR DESCRIPTION
# [1.3.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.2.0...v1.3.0) (2024-04-23)

### Bug Fixes

* **dafny:** Local Service Constructors MUST return concrete ([64f72c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/64f72c121fef31a83bcf3a5346d7efc1e84ab25f))
* dir name in java mpl release process ([#162](https://github.com/aws/aws-cryptographic-material-providers-library/issues/162)) ([d92c06a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d92c06a2fd355290f27df669c866157e14da9793))
* KeyStore: JavaDocs for KMS Configuration ([#293](https://github.com/aws/aws-cryptographic-material-providers-library/issues/293)) ([63ffff5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/63ffff59847cdcdbcf659de5fb2d69e272ba8b2e))
* Re-Polymorph w/ Smithy-Dafny@3378be16 & fix Java Testing ([#190](https://github.com/aws/aws-cryptographic-material-providers-library/issues/190)) ([58d74f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/58d74f6d20cc649742f2c73426b0f19a6b516dbb))

### Features

* enable KMS MRK Keys in KeyStore ([#285](https://github.com/aws/aws-cryptographic-material-providers-library/issues/285)) ([d924395](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d924395e7895187aee59279f7ba1f4dcdf1f893e))
* remove quantifier-syntax ([#218](https://github.com/aws/aws-cryptographic-material-providers-library/issues/218)) ([76ab6ef](https://github.com/aws/aws-cryptographic-material-providers-library/commit/76ab6ef7d2ff9580919671cde0719b93facb5b67))
* repolymorph to get dotnet constraint checking ([#281](https://github.com/aws/aws-cryptographic-material-providers-library/issues/281)) ([04102d7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/04102d7e30c04167df9fb76de86d2aeb0508536e))

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
