### PR TITLE
fix(KeyStore): JavaDocs for KMS Configuration

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -232,7 +232,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
   )
   datatype KMSConfiguration =
     | kmsKeyArn(kmsKeyArn: ComAmazonawsKmsTypes.KeyIdType)
-    | mrkKmsKeyArn(mrkKmsKeyArn: ComAmazonawsKmsTypes.KeyIdType)
+    | kmsMRKeyArn(kmsMRKeyArn: ComAmazonawsKmsTypes.KeyIdType)
   type Secret = seq<uint8>
   type Utf8Bytes = ValidUTF8Bytes
   datatype VersionKeyInput = | VersionKeyInput (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
@@ -76,10 +76,10 @@ structure KeyStoreConfig {
   @javadoc("The DynamoDB table name that backs this Key Store.")
   ddbTableName: TableName,
   @required
-  @javadoc("The AWS KMS Key that protects this Key Store.")
+  @javadoc("Configures this Keystore's KMS Key ARN restrictions.")
   kmsConfiguration: KMSConfiguration,
   @required
-  @javadoc("The logical name for this Key Store, which is cryptographically bound to the keys it holds.")
+  @javadoc("The logical name for this Key Store, which is cryptographically bound to the keys it holds. This appears in the Encryption Context of KMS requests as `tablename`.")
   logicalKeyStoreName: String,
 
   //= aws-encryption-sdk-specification/framework/branch-key-store.md#initialization
@@ -95,15 +95,18 @@ structure KeyStoreConfig {
   id: String,
   @javadoc("The AWS KMS grant tokens that are used when this Key Store calls to AWS KMS.")
   grantTokens: GrantTokenList,
-  @javadoc("The DynamoDB client this Key Store uses to call Amazon DynamoDB.")
+  @javadoc("The DynamoDB client this Key Store uses to call Amazon DynamoDB. If None is provided, a default DynamoDB Client is created using the Region from the KMS ARN.")
   ddbClient: DdbClientReference,
-  @javadoc("The KMS client this Key Store uses to call AWS KMS.")
+  @javadoc("The KMS client this Key Store uses to call AWS KMS. If None is provided, a default KMS Client is created using the Region from the KMS ARN.")
   kmsClient: KmsClientReference,
 }
 
+@javadoc("Configures this Keystore's KMS Key ARN restrictions.")
 union KMSConfiguration {
-  kmsKeyArn: com.amazonaws.kms#KeyIdType,
-  mrkKmsKeyArn: com.amazonaws.kms#KeyIdType
+  @javadoc("Keystore is restricted to only this KMS Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. While a Multi-Region Key (MRK) may be provided, the whole ARN, including the Region, is persisted in Branch Keys and MUST strictly equal this value to be considered valid.")
+  kmsKeyArn: com.amazonaws.kms#KeyIdType,  
+  @javadoc("Keystore is restricted to only this replication of the KMS Multi-Region Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. For Get* Operations, the Keystore compares the configured MRK ARN with the ARN recorded on the Branch Key. If all elements of the ARN are equal except for the Region, the Branch Key is allowed and KMS is called. Otherwise, the Branch Key is denied.")
+  kmsMRKeyArn: com.amazonaws.kms#KeyIdType
 }
 
 @javadoc("Returns the configuration information for a Key Store.")
@@ -126,7 +129,7 @@ structure GetKeyStoreInfoOutput {
   @javadoc("The AWS KMS grant tokens that are used when this Key Store calls to AWS KMS.")
   grantTokens: GrantTokenList,
   @required
-  @javadoc("The AWS KMS Key that protects this Key Store.")
+  @javadoc("Configures this Keystore's KMS Key ARN restrictions.")
   kmsConfiguration: KMSConfiguration
 }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
@@ -87,7 +87,6 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
               && AwsArnParsing.ParseAmazonDynamodbTableName(output.value.tableArn).Success?
               && AwsArnParsing.ParseAmazonDynamodbTableName(output.value.tableArn).value == config.ddbTableName
   {
-    :- Need(config.kmsConfiguration.kmsKeyArn?, Types.KeyStoreException(message := "CreateKeyStore requires a single region KMS Key ARN."));
     var ddbTableArn :- CreateKeyStoreTable.CreateKeyStoreTable(config.ddbTableName, config.ddbClient);
     var tableName := AwsArnParsing.ParseAmazonDynamodbTableName(ddbTableArn);
     :- Need(
@@ -114,8 +113,6 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
       && input.encryptionContext.None?
       ==> output.Failure?
   {
-
-    :- Need(config.kmsConfiguration.kmsKeyArn?, Types.KeyStoreException(message := "CreateKey requires a single region KMS Key ARN."));
     :- Need(input.branchKeyIdentifier.Some? ==>
               && input.encryptionContext.Some?
               && 0 < |input.encryptionContext.value|,
@@ -192,7 +189,6 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
   method VersionKey(config: InternalConfig, input: VersionKeyInput)
     returns (output: Result<VersionKeyOutput, Error>)
   {
-    :- Need(config.kmsConfiguration.kmsKeyArn?, Types.KeyStoreException(message := "VersionKey requires a single region KMS Key ARN."));
     :- Need(0 < |input.branchKeyIdentifier|, Types.KeyStoreException(message := "Empty string not supported for identifier."));
 
     var timestamp :- Time.GetCurrentTimeStamp()

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
@@ -20,7 +20,7 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
   {
     match kmsConfiguration
     case kmsKeyArn(arn) => arn == encryptionContext[Structure.KMS_FIELD]
-    case mrkKmsKeyArn(arn) =>
+    case kmsMRKeyArn(arn) =>
       var ecArn := ParseAwsKmsArn(encryptionContext[Structure.KMS_FIELD]);
       var kmsArn := ParseAwsKmsArn(arn);
       if ecArn.Failure? || kmsArn.Failure? then
@@ -33,7 +33,7 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
   {
     match kmsConfiguration
     case kmsKeyArn(arn) => arn
-    case mrkKmsKeyArn(arn) => arn
+    case kmsMRKeyArn(arn) => arn
   }
 
   method GenerateKey(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -33,9 +33,9 @@ module Fixtures {
   const MrkArnAP : string := "arn:aws:kms:ap-south-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7"
   const KmsConfigEast : Types.KMSConfiguration := Types.KMSConfiguration.kmsKeyArn(MrkArnEast)
   const KmsConfigWest : Types.KMSConfiguration := Types.KMSConfiguration.kmsKeyArn(MrkArnWest)
-  const KmsMrkConfigEast : Types.KMSConfiguration := Types.KMSConfiguration.mrkKmsKeyArn(MrkArnEast)
-  const KmsMrkConfigWest : Types.KMSConfiguration := Types.KMSConfiguration.mrkKmsKeyArn(MrkArnWest)
-  const KmsMrkConfigAP : Types.KMSConfiguration := Types.KMSConfiguration.mrkKmsKeyArn(MrkArnAP)
+  const KmsMrkConfigEast : Types.KMSConfiguration := Types.KMSConfiguration.kmsMRKeyArn(MrkArnEast)
+  const KmsMrkConfigWest : Types.KMSConfiguration := Types.KMSConfiguration.kmsMRKeyArn(MrkArnWest)
+  const KmsMrkConfigAP : Types.KMSConfiguration := Types.KMSConfiguration.kmsMRKeyArn(MrkArnAP)
   const KmsMrkEC : Types.EncryptionContext := map[UTF8.EncodeAscii("abc") := UTF8.EncodeAscii("123")]
   const EastBranchKey : string := "MyEastBranch2"
   const WestBranchKey : string := "MyWestBranch2"

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -398,10 +398,10 @@ public class ToDafny {
         )
       );
     }
-    if (Objects.nonNull(nativeValue.mrkKmsKeyArn())) {
-      return KMSConfiguration.create_mrkKmsKeyArn(
+    if (Objects.nonNull(nativeValue.kmsMRKeyArn())) {
+      return KMSConfiguration.create_kmsMRKeyArn(
         software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-          nativeValue.mrkKmsKeyArn()
+          nativeValue.kmsMRKeyArn()
         )
       );
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -381,10 +381,10 @@ public class ToNative {
         )
       );
     }
-    if (dafnyValue.is_mrkKmsKeyArn()) {
-      nativeBuilder.mrkKmsKeyArn(
+    if (dafnyValue.is_kmsMRKeyArn()) {
+      nativeBuilder.kmsMRKeyArn(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-          dafnyValue.dtor_mrkKmsKeyArn()
+          dafnyValue.dtor_kmsMRKeyArn()
         )
       );
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetKeyStoreInfoOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetKeyStoreInfoOutput.java
@@ -32,7 +32,7 @@ public class GetKeyStoreInfoOutput {
   private final List<String> grantTokens;
 
   /**
-   * The AWS KMS Key that protects this Key Store.
+   * Configures this Keystore's KMS Key ARN restrictions.
    */
   private final KMSConfiguration kmsConfiguration;
 
@@ -73,7 +73,7 @@ public class GetKeyStoreInfoOutput {
   }
 
   /**
-   * @return The AWS KMS Key that protects this Key Store.
+   * @return Configures this Keystore's KMS Key ARN restrictions.
    */
   public KMSConfiguration kmsConfiguration() {
     return this.kmsConfiguration;
@@ -129,12 +129,12 @@ public class GetKeyStoreInfoOutput {
     List<String> grantTokens();
 
     /**
-     * @param kmsConfiguration The AWS KMS Key that protects this Key Store.
+     * @param kmsConfiguration Configures this Keystore's KMS Key ARN restrictions.
      */
     Builder kmsConfiguration(KMSConfiguration kmsConfiguration);
 
     /**
-     * @return The AWS KMS Key that protects this Key Store.
+     * @return Configures this Keystore's KMS Key ARN restrictions.
      */
     KMSConfiguration kmsConfiguration();
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KMSConfiguration.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KMSConfiguration.java
@@ -5,23 +5,38 @@ package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
+/**
+ * Configures this Keystore's KMS Key ARN restrictions.
+ */
 public class KMSConfiguration {
 
+  /**
+   * Keystore is restricted to only this KMS Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. While a Multi-Region Key (MRK) may be provided, the whole ARN, including the Region, is persisted in Branch Keys and MUST strictly equal this value to be considered valid.
+   */
   private final String kmsKeyArn;
 
-  private final String mrkKmsKeyArn;
+  /**
+   * Keystore is restricted to only this replication of the KMS Multi-Region Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. For Get* Operations, the Keystore compares the configured MRK ARN with the ARN recorded on the Branch Key. If all elements of the ARN are equal except for the Region, the Branch Key is allowed and KMS is called. Otherwise, the Branch Key is denied.
+   */
+  private final String kmsMRKeyArn;
 
   protected KMSConfiguration(BuilderImpl builder) {
     this.kmsKeyArn = builder.kmsKeyArn();
-    this.mrkKmsKeyArn = builder.mrkKmsKeyArn();
+    this.kmsMRKeyArn = builder.kmsMRKeyArn();
   }
 
+  /**
+   * @return Keystore is restricted to only this KMS Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. While a Multi-Region Key (MRK) may be provided, the whole ARN, including the Region, is persisted in Branch Keys and MUST strictly equal this value to be considered valid.
+   */
   public String kmsKeyArn() {
     return this.kmsKeyArn;
   }
 
-  public String mrkKmsKeyArn() {
-    return this.mrkKmsKeyArn;
+  /**
+   * @return Keystore is restricted to only this replication of the KMS Multi-Region Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. For Get* Operations, the Keystore compares the configured MRK ARN with the ARN recorded on the Branch Key. If all elements of the ARN are equal except for the Region, the Branch Key is allowed and KMS is called. Otherwise, the Branch Key is denied.
+   */
+  public String kmsMRKeyArn() {
+    return this.kmsMRKeyArn;
   }
 
   public Builder toBuilder() {
@@ -33,13 +48,25 @@ public class KMSConfiguration {
   }
 
   public interface Builder {
+    /**
+     * @param kmsKeyArn Keystore is restricted to only this KMS Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. While a Multi-Region Key (MRK) may be provided, the whole ARN, including the Region, is persisted in Branch Keys and MUST strictly equal this value to be considered valid.
+     */
     Builder kmsKeyArn(String kmsKeyArn);
 
+    /**
+     * @return Keystore is restricted to only this KMS Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. While a Multi-Region Key (MRK) may be provided, the whole ARN, including the Region, is persisted in Branch Keys and MUST strictly equal this value to be considered valid.
+     */
     String kmsKeyArn();
 
-    Builder mrkKmsKeyArn(String mrkKmsKeyArn);
+    /**
+     * @param kmsMRKeyArn Keystore is restricted to only this replication of the KMS Multi-Region Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. For Get* Operations, the Keystore compares the configured MRK ARN with the ARN recorded on the Branch Key. If all elements of the ARN are equal except for the Region, the Branch Key is allowed and KMS is called. Otherwise, the Branch Key is denied.
+     */
+    Builder kmsMRKeyArn(String kmsMRKeyArn);
 
-    String mrkKmsKeyArn();
+    /**
+     * @return Keystore is restricted to only this replication of the KMS Multi-Region Key ARN. If a different KMS Key ARN is encountered when creating, versioning, or getting a Branch Key or Beacon Key, KMS is never called and an exception is thrown. For Get* Operations, the Keystore compares the configured MRK ARN with the ARN recorded on the Branch Key. If all elements of the ARN are equal except for the Region, the Branch Key is allowed and KMS is called. Otherwise, the Branch Key is denied.
+     */
+    String kmsMRKeyArn();
 
     KMSConfiguration build();
   }
@@ -48,13 +75,13 @@ public class KMSConfiguration {
 
     protected String kmsKeyArn;
 
-    protected String mrkKmsKeyArn;
+    protected String kmsMRKeyArn;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(KMSConfiguration model) {
       this.kmsKeyArn = model.kmsKeyArn();
-      this.mrkKmsKeyArn = model.mrkKmsKeyArn();
+      this.kmsMRKeyArn = model.kmsMRKeyArn();
     }
 
     public Builder kmsKeyArn(String kmsKeyArn) {
@@ -66,13 +93,13 @@ public class KMSConfiguration {
       return this.kmsKeyArn;
     }
 
-    public Builder mrkKmsKeyArn(String mrkKmsKeyArn) {
-      this.mrkKmsKeyArn = mrkKmsKeyArn;
+    public Builder kmsMRKeyArn(String kmsMRKeyArn) {
+      this.kmsMRKeyArn = kmsMRKeyArn;
       return this;
     }
 
-    public String mrkKmsKeyArn() {
-      return this.mrkKmsKeyArn;
+    public String kmsMRKeyArn() {
+      return this.kmsMRKeyArn;
     }
 
     public KMSConfiguration build() {
@@ -89,18 +116,18 @@ public class KMSConfiguration {
         );
       }
       if (
-        Objects.nonNull(this.mrkKmsKeyArn()) && this.mrkKmsKeyArn().length() < 1
+        Objects.nonNull(this.kmsMRKeyArn()) && this.kmsMRKeyArn().length() < 1
       ) {
         throw new IllegalArgumentException(
-          "The size of `mrkKmsKeyArn` must be greater than or equal to 1"
+          "The size of `kmsMRKeyArn` must be greater than or equal to 1"
         );
       }
       if (
-        Objects.nonNull(this.mrkKmsKeyArn()) &&
-        this.mrkKmsKeyArn().length() > 2048
+        Objects.nonNull(this.kmsMRKeyArn()) &&
+        this.kmsMRKeyArn().length() > 2048
       ) {
         throw new IllegalArgumentException(
-          "The size of `mrkKmsKeyArn` must be less than or equal to 2048"
+          "The size of `kmsMRKeyArn` must be less than or equal to 2048"
         );
       }
       if (!onlyOneNonNull()) {
@@ -112,7 +139,7 @@ public class KMSConfiguration {
     }
 
     private boolean onlyOneNonNull() {
-      Object[] allValues = { this.kmsKeyArn, this.mrkKmsKeyArn };
+      Object[] allValues = { this.kmsKeyArn, this.kmsMRKeyArn };
       boolean haveOneNonNull = false;
       for (Object o : allValues) {
         if (Objects.nonNull(o)) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyStoreConfig.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyStoreConfig.java
@@ -16,12 +16,12 @@ public class KeyStoreConfig {
   private final String ddbTableName;
 
   /**
-   * The AWS KMS Key that protects this Key Store.
+   * Configures this Keystore's KMS Key ARN restrictions.
    */
   private final KMSConfiguration kmsConfiguration;
 
   /**
-   * The logical name for this Key Store, which is cryptographically bound to the keys it holds.
+   * The logical name for this Key Store, which is cryptographically bound to the keys it holds. This appears in the Encryption Context of KMS requests as `tablename`.
    */
   private final String logicalKeyStoreName;
 
@@ -36,12 +36,12 @@ public class KeyStoreConfig {
   private final List<String> grantTokens;
 
   /**
-   * The DynamoDB client this Key Store uses to call Amazon DynamoDB.
+   * The DynamoDB client this Key Store uses to call Amazon DynamoDB. If None is provided, a default DynamoDB Client is created using the Region from the KMS ARN.
    */
   private final DynamoDbClient ddbClient;
 
   /**
-   * The KMS client this Key Store uses to call AWS KMS.
+   * The KMS client this Key Store uses to call AWS KMS. If None is provided, a default KMS Client is created using the Region from the KMS ARN.
    */
   private final KmsClient kmsClient;
 
@@ -63,14 +63,14 @@ public class KeyStoreConfig {
   }
 
   /**
-   * @return The AWS KMS Key that protects this Key Store.
+   * @return Configures this Keystore's KMS Key ARN restrictions.
    */
   public KMSConfiguration kmsConfiguration() {
     return this.kmsConfiguration;
   }
 
   /**
-   * @return The logical name for this Key Store, which is cryptographically bound to the keys it holds.
+   * @return The logical name for this Key Store, which is cryptographically bound to the keys it holds. This appears in the Encryption Context of KMS requests as `tablename`.
    */
   public String logicalKeyStoreName() {
     return this.logicalKeyStoreName;
@@ -91,14 +91,14 @@ public class KeyStoreConfig {
   }
 
   /**
-   * @return The DynamoDB client this Key Store uses to call Amazon DynamoDB.
+   * @return The DynamoDB client this Key Store uses to call Amazon DynamoDB. If None is provided, a default DynamoDB Client is created using the Region from the KMS ARN.
    */
   public DynamoDbClient ddbClient() {
     return this.ddbClient;
   }
 
   /**
-   * @return The KMS client this Key Store uses to call AWS KMS.
+   * @return The KMS client this Key Store uses to call AWS KMS. If None is provided, a default KMS Client is created using the Region from the KMS ARN.
    */
   public KmsClient kmsClient() {
     return this.kmsClient;
@@ -124,22 +124,22 @@ public class KeyStoreConfig {
     String ddbTableName();
 
     /**
-     * @param kmsConfiguration The AWS KMS Key that protects this Key Store.
+     * @param kmsConfiguration Configures this Keystore's KMS Key ARN restrictions.
      */
     Builder kmsConfiguration(KMSConfiguration kmsConfiguration);
 
     /**
-     * @return The AWS KMS Key that protects this Key Store.
+     * @return Configures this Keystore's KMS Key ARN restrictions.
      */
     KMSConfiguration kmsConfiguration();
 
     /**
-     * @param logicalKeyStoreName The logical name for this Key Store, which is cryptographically bound to the keys it holds.
+     * @param logicalKeyStoreName The logical name for this Key Store, which is cryptographically bound to the keys it holds. This appears in the Encryption Context of KMS requests as `tablename`.
      */
     Builder logicalKeyStoreName(String logicalKeyStoreName);
 
     /**
-     * @return The logical name for this Key Store, which is cryptographically bound to the keys it holds.
+     * @return The logical name for this Key Store, which is cryptographically bound to the keys it holds. This appears in the Encryption Context of KMS requests as `tablename`.
      */
     String logicalKeyStoreName();
 
@@ -164,22 +164,22 @@ public class KeyStoreConfig {
     List<String> grantTokens();
 
     /**
-     * @param ddbClient The DynamoDB client this Key Store uses to call Amazon DynamoDB.
+     * @param ddbClient The DynamoDB client this Key Store uses to call Amazon DynamoDB. If None is provided, a default DynamoDB Client is created using the Region from the KMS ARN.
      */
     Builder ddbClient(DynamoDbClient ddbClient);
 
     /**
-     * @return The DynamoDB client this Key Store uses to call Amazon DynamoDB.
+     * @return The DynamoDB client this Key Store uses to call Amazon DynamoDB. If None is provided, a default DynamoDB Client is created using the Region from the KMS ARN.
      */
     DynamoDbClient ddbClient();
 
     /**
-     * @param kmsClient The KMS client this Key Store uses to call AWS KMS.
+     * @param kmsClient The KMS client this Key Store uses to call AWS KMS. If None is provided, a default KMS Client is created using the Region from the KMS ARN.
      */
     Builder kmsClient(KmsClient kmsClient);
 
     /**
-     * @return The KMS client this Key Store uses to call AWS KMS.
+     * @return The KMS client this Key Store uses to call AWS KMS. If None is provided, a default KMS Client is created using the Region from the KMS ARN.
      */
     KmsClient kmsClient();
 

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KMSConfiguration.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KMSConfiguration.cs
@@ -8,7 +8,7 @@ namespace AWS.Cryptography.KeyStore
   public class KMSConfiguration
   {
     private string _kmsKeyArn;
-    private string _mrkKmsKeyArn;
+    private string _kmsMRKeyArn;
     public string KmsKeyArn
     {
       get { return this._kmsKeyArn; }
@@ -18,19 +18,19 @@ namespace AWS.Cryptography.KeyStore
     {
       return this._kmsKeyArn != null;
     }
-    public string MrkKmsKeyArn
+    public string KmsMRKeyArn
     {
-      get { return this._mrkKmsKeyArn; }
-      set { this._mrkKmsKeyArn = value; }
+      get { return this._kmsMRKeyArn; }
+      set { this._kmsMRKeyArn = value; }
     }
-    public bool IsSetMrkKmsKeyArn()
+    public bool IsSetKmsMRKeyArn()
     {
-      return this._mrkKmsKeyArn != null;
+      return this._kmsMRKeyArn != null;
     }
     public void Validate()
     {
       var numberOfPropertiesSet = Convert.ToUInt16(IsSetKmsKeyArn()) +
-      Convert.ToUInt16(IsSetMrkKmsKeyArn());
+      Convert.ToUInt16(IsSetKmsMRKeyArn());
       if (numberOfPropertiesSet == 0) throw new System.ArgumentException("No union value set");
 
       if (numberOfPropertiesSet > 1) throw new System.ArgumentException("Multiple union values set");

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -164,9 +164,9 @@ namespace AWS.Cryptography.KeyStore
         converted.KmsKeyArn = FromDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M9_kmsKeyArn(concrete.dtor_kmsKeyArn);
         return converted;
       }
-      if (value.is_mrkKmsKeyArn)
+      if (value.is_kmsMRKeyArn)
       {
-        converted.MrkKmsKeyArn = FromDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M12_mrkKmsKeyArn(concrete.dtor_mrkKmsKeyArn);
+        converted.KmsMRKeyArn = FromDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_kmsMRKeyArn(concrete.dtor_kmsMRKeyArn);
         return converted;
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStore.KMSConfiguration state");
@@ -177,9 +177,9 @@ namespace AWS.Cryptography.KeyStore
       {
         return software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration.create_kmsKeyArn(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M9_kmsKeyArn(value.KmsKeyArn));
       }
-      if (value.IsSetMrkKmsKeyArn())
+      if (value.IsSetKmsMRKeyArn())
       {
-        return software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration.create_mrkKmsKeyArn(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M12_mrkKmsKeyArn(value.MrkKmsKeyArn));
+        return software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration.create_kmsMRKeyArn(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_kmsMRKeyArn(value.KmsMRKeyArn));
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStore.KMSConfiguration state");
     }
@@ -403,11 +403,11 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N3_com__N9_amazonaws__N3_kms__S9_KeyIdType(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M12_mrkKmsKeyArn(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_kmsMRKeyArn(Dafny.ISequence<char> value)
     {
       return FromDafny_N3_com__N9_amazonaws__N3_kms__S9_KeyIdType(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M12_mrkKmsKeyArn(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_kmsMRKeyArn(string value)
     {
       return ToDafny_N3_com__N9_amazonaws__N3_kms__S9_KeyIdType(value);
     }


### PR DESCRIPTION
_Issue #, if available:_ 

_Description of changes:_
1. Replace  `mrkKmsKeyArn` with  `kmsMRKeyArn`, as MRK means Multi-Region Key, so "mrkKMSKey" is a little redundant 
2. JavaDocs to describe the behavioral difference of the two KMS Configurations

_Squash/merge commit message, if applicable:_
```
fix(KeyStore): JavaDocs for KMS Configuration
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
