### PR TITLE
ci: Cut Dafny issues on nightly failures

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -17,23 +17,36 @@ on:
         type: boolean
 
 jobs:
-  manual-ci-format:
-    uses: ./.github/workflows/library_format.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-      regenerate-code: ${{ inputs.regenerate-code }}
-  manual-ci-verification:
-    uses: ./.github/workflows/library_dafny_verification.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-      regenerate-code: ${{ inputs.regenerate-code }}
-  manual-ci-java:
-    uses: ./.github/workflows/library_java_tests.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-      regenerate-code: ${{ inputs.regenerate-code }}
-  manual-ci-net:
-    uses: ./.github/workflows/library_net_tests.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-      regenerate-code: ${{ inputs.regenerate-code }}
+  # manual-ci-format:
+  #   uses: ./.github/workflows/library_format.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  #     regenerate-code: ${{ inputs.regenerate-code }}
+  # manual-ci-verification:
+  #   uses: ./.github/workflows/library_dafny_verification.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  #     regenerate-code: ${{ inputs.regenerate-code }}
+  # manual-ci-java:
+  #   uses: ./.github/workflows/library_java_tests.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  #     regenerate-code: ${{ inputs.regenerate-code }}
+  # manual-ci-net:
+  #   uses: ./.github/workflows/library_net_tests.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  #     regenerate-code: ${{ inputs.regenerate-code }}
+
+  cut-issue-on-failure:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.DAFNY_ISSUE_CUTTING_TOKEN }}
+    steps:
+      - name: Create release blocker on dafny-lang/dafny
+        run: |
+          gh issue create \
+            --repo "dafny-lang/dafny" \
+            --title "TEST ISSUE PLEASE IGNORE" \
+            --body "Failure in ${{ github.workflow_ref }}. \
+            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -40,6 +40,9 @@ jobs:
 
   cut-issue-on-failure:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -40,10 +40,25 @@ jobs:
 
   cut-issue-on-failure:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.DAFNY_ISSUE_CUTTING_TOKEN }}
     steps:
+      # We need access to the role that is able to get CI Bot Creds
+      - name: Configure AWS Credentials for Release
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+          role-session-name: CI_Bot_Release
+
+      # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
+      - name: Get CI Bot Creds Secret
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: Github/aws-crypto-tools-ci-bot
+          parse-json-secrets: true
+
       - name: Create release blocker on dafny-lang/dafny
+        env:
+          GH_TOKEN: ${{ env.GITHUB_AWS_CRYPTO_TOOLS_CI_BOT_ESDK_RELEASE_TOKEN }}
         run: |
           gh issue create \
             --repo "dafny-lang/dafny" \

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -17,54 +17,23 @@ on:
         type: boolean
 
 jobs:
-  # manual-ci-format:
-  #   uses: ./.github/workflows/library_format.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  #     regenerate-code: ${{ inputs.regenerate-code }}
-  # manual-ci-verification:
-  #   uses: ./.github/workflows/library_dafny_verification.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  #     regenerate-code: ${{ inputs.regenerate-code }}
-  # manual-ci-java:
-  #   uses: ./.github/workflows/library_java_tests.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  #     regenerate-code: ${{ inputs.regenerate-code }}
-  # manual-ci-net:
-  #   uses: ./.github/workflows/library_net_tests.yml
-  #   with:
-  #     dafny: ${{ inputs.dafny }}
-  #     regenerate-code: ${{ inputs.regenerate-code }}
-
-  cut-issue-on-failure:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      # We need access to the role that is able to get CI Bot Creds
-      - name: Configure AWS Credentials for Release
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-          role-session-name: CI_Bot_Release
-
-      # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
-      - name: Get CI Bot Creds Secret
-        uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          secret-ids: Github/aws-crypto-tools-ci-bot
-          parse-json-secrets: true
-
-      - name: Create release blocker on dafny-lang/dafny
-        env:
-          GH_TOKEN: ${{ env.GITHUB_AWS_CRYPTO_TOOLS_CI_BOT_ESDK_RELEASE_TOKEN }}
-        run: |
-          gh issue create \
-            --repo "dafny-lang/dafny" \
-            --title "TEST ISSUE PLEASE IGNORE" \
-            --body "Failure in ${{ github.workflow_ref }}. \
-            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+  manual-ci-format:
+    uses: ./.github/workflows/library_format.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+      regenerate-code: ${{ inputs.regenerate-code }}
+  manual-ci-verification:
+    uses: ./.github/workflows/library_dafny_verification.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+      regenerate-code: ${{ inputs.regenerate-code }}
+  manual-ci-java:
+    uses: ./.github/workflows/library_java_tests.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+      regenerate-code: ${{ inputs.regenerate-code }}
+  manual-ci-net:
+    uses: ./.github/workflows/library_net_tests.yml
+    with:
+      dafny: ${{ inputs.dafny }}
+      regenerate-code: ${{ inputs.regenerate-code }}

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -40,6 +40,9 @@ jobs:
 
   cut-issue-on-failure:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     needs:
       [
         dafny-nightly-format,
@@ -48,10 +51,25 @@ jobs:
         dafny-nightly-net
       ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
-    env:
-      GH_TOKEN: ${{ secrets.DAFNY_ISSUE_CUTTING_TOKEN }}
     steps:
+      # We need access to the role that is able to get CI Bot Creds
+      - name: Configure AWS Credentials for Release
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+          role-session-name: CI_Bot_Release
+
+      # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
+      - name: Get CI Bot Creds Secret
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: Github/aws-crypto-tools-ci-bot
+          parse-json-secrets: true
+
       - name: Create release blocker on dafny-lang/dafny
+        env:
+          GH_TOKEN: ${{ env.GITHUB_AWS_CRYPTO_TOOLS_CI_BOT_ESDK_RELEASE_TOKEN }}
         run: |
           gh issue create \
             --repo "dafny-lang/dafny" \

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -37,3 +37,25 @@ jobs:
     with:
       dafny: "nightly-latest"
       regenerate-code: true
+
+  cut-issue-on-failure:
+    runs-on: ubuntu-latest
+    needs:
+      [
+        dafny-nightly-format,
+        dafny-nightly-verification,
+        dafny-nightly-java,
+        dafny-nightly-net
+      ]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    env:
+      GH_TOKEN: ${{ secrets.DAFNY_ISSUE_CUTTING_TOKEN }}
+    steps:
+      - name: Create release blocker on dafny-lang/dafny
+        run: |
+          gh issue create \
+            --repo "dafny-lang/dafny" \
+            --title "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" \
+            --body "Failure in ${{ github.workflow_ref }}. \
+            See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -48,7 +48,7 @@ jobs:
         dafny-nightly-format,
         dafny-nightly-verification,
         dafny-nightly-java,
-        dafny-nightly-net
+        dafny-nightly-net,
       ]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
@@ -58,7 +58,7 @@ jobs:
         with:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-          role-session-name: CI_Bot_Release
+          role-session-name: Dafny_Issue_Blocker
 
       # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
       - name: Get CI Bot Creds Secret
@@ -76,4 +76,3 @@ jobs:
             --title "[PRERELEASE REGRESSION] Dafny prerelease regression from ${{ github.repository }}" \
             --body "Failure in ${{ github.workflow_ref }}. \
             See ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-    


### PR DESCRIPTION
_Description of changes:_

Automates cutting an issue to `dafny-lang/dafny` if the nightly build against the latest Dafny prerelease fails.

Reuses the same GH token as the semantic release workflows, since that already has more than enough permissions (only `public_repo` is needed for this action).

Tested this by putting the same steps in the manual CI workflow, which created this issue: https://github.com/dafny-lang/dafny/issues/5391

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
