### PR TITLE
chore: Move InternalResult into StandardLibrary(Internal)

### DIFF
--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Digest_Compile/ExternDigest.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Digest_Compile/ExternDigest.java
@@ -1,7 +1,7 @@
 package Digest_Compile;
 
-import StandardLibraryInternal.InternalResult;
 import ExternDigest._ExternBase___default;
+import StandardLibraryInternal.InternalResult;
 import Wrappers_Compile.Result;
 import dafny.Array;
 import dafny.DafnySequence;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Digest_Compile/ExternDigest.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Digest_Compile/ExternDigest.java
@@ -1,6 +1,6 @@
 package Digest_Compile;
 
-import Dafny.Aws.Cryptography.Primitives.Types.InternalResult;
+import StandardLibraryInternal.InternalResult;
 import ExternDigest._ExternBase___default;
 import Wrappers_Compile.Result;
 import dafny.Array;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/ECDSA.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/ECDSA.java
@@ -2,9 +2,9 @@ package Signature;
 
 import static Signature.SignatureAlgorithm.signatureAlgorithm;
 
-import StandardLibraryInternal.InternalResult;
 import Digest_Compile.ExternDigest;
 import Random_Compile.ExternRandom;
+import StandardLibraryInternal.InternalResult;
 import Wrappers_Compile.Result;
 import dafny.Array;
 import dafny.DafnySequence;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/ECDSA.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/ECDSA.java
@@ -2,7 +2,7 @@ package Signature;
 
 import static Signature.SignatureAlgorithm.signatureAlgorithm;
 
-import Dafny.Aws.Cryptography.Primitives.Types.InternalResult;
+import StandardLibraryInternal.InternalResult;
 import Digest_Compile.ExternDigest;
 import Random_Compile.ExternRandom;
 import Wrappers_Compile.Result;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/PrivateKeyUtils.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/PrivateKeyUtils.java
@@ -1,6 +1,6 @@
 package Signature;
 
-import Dafny.Aws.Cryptography.Primitives.Types.InternalResult;
+import StandardLibraryInternal.InternalResult;
 import Wrappers_Compile.Result;
 import dafny.Array;
 import dafny.DafnySequence;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/PublicKeyUtils.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/PublicKeyUtils.java
@@ -6,7 +6,7 @@ import static Signature.ECDSA.TWO;
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
-import Dafny.Aws.Cryptography.Primitives.Types.InternalResult;
+import StandardLibraryInternal.InternalResult;
 import Wrappers_Compile.Result;
 import dafny.Array;
 import dafny.DafnySequence;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/SignatureAlgorithm.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/Signature/SignatureAlgorithm.java
@@ -4,7 +4,7 @@ import static Signature.ECDSA.SEC_P256;
 import static Signature.ECDSA.SEC_P384;
 import static Signature.ECDSA.SEC_PRIME_FIELD_PREFIX;
 
-import Dafny.Aws.Cryptography.Primitives.Types.InternalResult;
+import StandardLibraryInternal.InternalResult;
 import Wrappers_Compile.Result;
 import java.security.AlgorithmParameters;
 import java.security.NoSuchAlgorithmException;

--- a/StandardLibrary/runtimes/java/src/main/java/StandardLibraryInternal/InternalResult.java
+++ b/StandardLibrary/runtimes/java/src/main/java/StandardLibraryInternal/InternalResult.java
@@ -1,4 +1,4 @@
-package Dafny.Aws.Cryptography.Primitives.Types;
+package StandardLibraryInternal;
 
 /**
  * Similar to the translation of Dafny's Wrappers.Result type,


### PR DESCRIPTION
_Description of changes:_

This internal helper class was defined in the wrong place, which makes it look strange to use it outside of the MPL.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
