### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.3.0-SNAPSHOT"
+version = "1.4.0"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.3.0</Version>
+      <Version>1.4.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+# [1.4.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.3.0...v1.4.0) (2024-05-20)
+
+### Features
+
+- **Keystore:** Introduce additional KMSConfiguration options ([#316](https://github.com/aws/aws-cryptographic-material-providers-library/issues/316)) ([f3a0a52](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f3a0a5269e611afd254425226d32eaaed1f3d99b))
+
+The Hierarchical Keyring's Keystore now supports four (4) `KMSConfigurations`:
+
+- kmsKeyArn
+- kmsMRKeyArn
+- discovery
+- mrDiscovery
+
+See our [JavaDocs](https://aws.github.io/aws-cryptographic-material-providers-library/index.html?software/amazon/cryptography/keystore/model/KMSConfiguration.html) for details
+on how these options effect the relationship between
+a Keystore and KMS.
+
+### Maintenance
+
+- .NET : Bump dependency [BouncyCastle.Cryptography](https://github.com/bcgit/bc-csharp) from 2.2.1 to 2.3.1. ([#329](https://github.com/aws/aws-cryptographic-material-providers-library/pull/329))
+- .NET : Bump dependency [AWSSDK.Core](https://github.com/aws/aws-sdk-net) from 3.7.300.2 to 3.7.304.2. ([#329](https://github.com/aws/aws-cryptographic-material-providers-library/pull/329))
+- Java : Move InternalResult into StandardLibrary(Internal) ([#325](https://github.com/aws/aws-cryptographic-material-providers-library/pull/325))
+
+
 # [1.3.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.2.0...v1.3.0) (2024-04-24)
 
 ### Bug Fixes

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.3.0")]
+[assembly: AssemblyVersion("1.4.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -66,7 +66,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.3.0-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.4.0")
     implementation(platform("software.amazon.awssdk:bom:2.19.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")


### PR DESCRIPTION
### Features

- **Keystore:** Introduce additional KMSConfiguration options ([#316](https://github.com/aws/aws-cryptographic-material-providers-library/issues/316)) ([f3a0a52](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f3a0a5269e611afd254425226d32eaaed1f3d99b))

The Hierarchical Keyring's Keystore now supports four (4) `KMSConfigurations`:

- kmsKeyArn
- kmsMRKeyArn
- discovery
- mrDiscovery

See our [JavaDocs](https://aws.github.io/aws-cryptographic-material-providers-library/index.html?software/amazon/cryptography/keystore/model/KMSConfiguration.html) for details on how these options effect the relationship between a Keystore and KMS.

### Maintenance

- .NET : Bump dependency [BouncyCastle.Cryptography](https://github.com/bcgit/bc-csharp) from 2.2.1 to 2.3.1. ([#329](https://github.com/aws/aws-cryptographic-material-providers-library/pull/329))
- .NET : Bump dependency [AWSSDK.Core](https://github.com/aws/aws-sdk-net) from 3.7.300.2 to 3.7.304.2. ([#329](https://github.com/aws/aws-cryptographic-material-providers-library/pull/329))
- Java : Move InternalResult into StandardLibrary(Internal) ([#325](https://github.com/aws/aws-cryptographic-material-providers-library/pull/325))

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
