### PR TITLE
chore: add Java TestVectors to Semantic Release script

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -23,9 +23,10 @@ const Runtimes = {
     "AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts": {
       dependencies: [],
     },
-    "TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts": {
-      dependencies: [],
-    }
+    "TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts":
+      {
+        dependencies: [],
+      },
   },
   net: {
     "AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj": {

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -23,6 +23,9 @@ const Runtimes = {
     "AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts": {
       dependencies: [],
     },
+    "TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts": {
+      dependencies: [],
+    }
   },
   net: {
     "AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj": {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

During last MPL release, 
Semantic Release failed to bump the TestVectors in Java,
and I did it manually.

This should fix that.

_Squash/merge commit message, if applicable:_
`chore: add Java TestVectors to Semantic Release script`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
