### PR TITLE
chore: speed up ecdh test vectors to no call KMS on creation

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
@@ -17,11 +17,15 @@ module TestEcdhCalculation {
   import PrimitiveTypes = AwsCryptographyPrimitivesTypes
   import ComAmazonawsKmsTypes
   import UTF8
+  import Base64
 
   // ECC Curve P256 Keys
   const senderKmsKey    := "arn:aws:kms:us-west-2:370957321024:key/eabdf483-6be2-4d2d-8ee4-8c2583d416e9";
   const recipientKmsKey := "arn:aws:kms:us-west-2:370957321024:key/0265c8e9-5b6a-4055-8f70-63719e09fda5";
   const senderArns := [TestUtils.KMS_ECC_256_KEY_ARN_S, TestUtils.KMS_ECC_384_KEY_ARN_S, TestUtils.KMS_ECC_521_KEY_ARN_S];
+  const senderArnPublicKeys := [TestUtils.KMS_ECC_256_PUBLIC_KEY_S, TestUtils.KMS_ECC_384_PUBLIC_KEY_S, TestUtils.KMS_ECC_521_PUBLIC_KEY_S]; 
+  const privateKeyReceivers := [TestUtils.ECC_P256_PRIVATE, TestUtils.ECC_P384_PRIVATE, TestUtils.ECC_P521_PRIVATE];
+  const publicKeyReceivers := [TestUtils.ECC_P256_PUBLIC, TestUtils.ECC_P384_PUBLIC, TestUtils.ECC_P521_PUBLIC];
   const curveSpecs := [PrimitiveTypes.ECC_NIST_P256, PrimitiveTypes.ECC_NIST_P384, PrimitiveTypes.ECC_NIST_P521];
 
   method {:test} TestKmsDeriveSharedSecretOfflineCalculation() {
@@ -113,6 +117,48 @@ module TestEcdhCalculation {
 
       expect kmsSharedSecret.value.SharedSecret.value == offlineSharedSecret.sharedSecret;
 
+    }
+  }
+
+  method {:test} TestOfflineDeriveSharedSecretStaticKeys() 
+  {
+    var kmsClient :- expect Kms.KMSClient();
+    var primitives :- expect Primitives.AtomicPrimitives();
+    
+    for i := 0 to |curveSpecs|
+    {
+      var curve := curveSpecs[i];
+      var senderArn := senderArns[i];
+      var senderPublicKey :- expect Base64.Decode(senderArnPublicKeys[i]);
+      var recipientPrivateKey :- expect UTF8.Encode(privateKeyReceivers[i]);
+      var recipientPublicKey :- expect Base64.Decode(publicKeyReceivers[i]);
+
+      var kmsSharedSecret := kmsClient.DeriveSharedSecret(
+        input := Kms.Types.DeriveSharedSecretRequest(
+          KeyId := senderArn,
+          KeyAgreementAlgorithm := Kms.Types.KeyAgreementAlgorithmSpec.ECDH,
+          PublicKey := recipientPublicKey
+        )
+      );
+      expect kmsSharedSecret.Success?;
+      expect kmsSharedSecret.value.SharedSecret.Some?;
+
+      var offlineSharedSecret :- expect primitives.DeriveSharedSecret(
+        PrimitiveTypes.DeriveSharedSecretInput(
+          eccCurve := curveSpecs[i],
+          privateKey := PrimitiveTypes.ECCPrivateKey(pem := recipientPrivateKey),
+          publicKey := PrimitiveTypes.ECCPublicKey(der := senderPublicKey)
+        )
+      );
+
+      print "\n";
+      print "KMS Derived Shared Secret: ";
+      print kmsSharedSecret.value.SharedSecret.value; 
+      print "\n";
+      print "Local Derived Shared Secret: ";
+      print offlineSharedSecret.sharedSecret;
+
+      expect kmsSharedSecret.value.SharedSecret.value == offlineSharedSecret.sharedSecret;
     }
   }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
@@ -151,12 +151,6 @@ module TestEcdhCalculation {
         )
       );
 
-      print "\n";
-      print "KMS Derived Shared Secret: ";
-      print kmsSharedSecret.value.SharedSecret.value;
-      print "\n";
-      print "Local Derived Shared Secret: ";
-      print offlineSharedSecret.sharedSecret;
 
       expect kmsSharedSecret.value.SharedSecret.value == offlineSharedSecret.sharedSecret;
     }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/test/TestEcdhCalculation.dfy
@@ -23,7 +23,7 @@ module TestEcdhCalculation {
   const senderKmsKey    := "arn:aws:kms:us-west-2:370957321024:key/eabdf483-6be2-4d2d-8ee4-8c2583d416e9";
   const recipientKmsKey := "arn:aws:kms:us-west-2:370957321024:key/0265c8e9-5b6a-4055-8f70-63719e09fda5";
   const senderArns := [TestUtils.KMS_ECC_256_KEY_ARN_S, TestUtils.KMS_ECC_384_KEY_ARN_S, TestUtils.KMS_ECC_521_KEY_ARN_S];
-  const senderArnPublicKeys := [TestUtils.KMS_ECC_256_PUBLIC_KEY_S, TestUtils.KMS_ECC_384_PUBLIC_KEY_S, TestUtils.KMS_ECC_521_PUBLIC_KEY_S]; 
+  const senderArnPublicKeys := [TestUtils.KMS_ECC_256_PUBLIC_KEY_S, TestUtils.KMS_ECC_384_PUBLIC_KEY_S, TestUtils.KMS_ECC_521_PUBLIC_KEY_S];
   const privateKeyReceivers := [TestUtils.ECC_P256_PRIVATE, TestUtils.ECC_P384_PRIVATE, TestUtils.ECC_P521_PRIVATE];
   const publicKeyReceivers := [TestUtils.ECC_P256_PUBLIC, TestUtils.ECC_P384_PUBLIC, TestUtils.ECC_P521_PUBLIC];
   const curveSpecs := [PrimitiveTypes.ECC_NIST_P256, PrimitiveTypes.ECC_NIST_P384, PrimitiveTypes.ECC_NIST_P521];
@@ -120,11 +120,11 @@ module TestEcdhCalculation {
     }
   }
 
-  method {:test} TestOfflineDeriveSharedSecretStaticKeys() 
+  method {:test} TestOfflineDeriveSharedSecretStaticKeys()
   {
     var kmsClient :- expect Kms.KMSClient();
     var primitives :- expect Primitives.AtomicPrimitives();
-    
+
     for i := 0 to |curveSpecs|
     {
       var curve := curveSpecs[i];
@@ -153,7 +153,7 @@ module TestEcdhCalculation {
 
       print "\n";
       print "KMS Derived Shared Secret: ";
-      print kmsSharedSecret.value.SharedSecret.value; 
+      print kmsSharedSecret.value.SharedSecret.value;
       print "\n";
       print "Local Derived Shared Secret: ";
       print offlineSharedSecret.sharedSecret;

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/ECDH/DeriveSharedSecret.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/ECDH/DeriveSharedSecret.java
@@ -52,7 +52,6 @@ public class DeriveSharedSecret extends _ExternBase___default {
         );
         keyAgreement.doPhase(fromBytesPublicKey(publicKeyBytes), true);
         byte[] sharedSecret = keyAgreement.generateSecret();
-
         return CreateExternDerivesharedSecretSuccess(
           DafnySequence.fromBytes(sharedSecret)
         );

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/Model/AwsCryptographyMaterialProvidersTestVectorKeysTypes.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/Model/AwsCryptographyMaterialProvidersTestVectorKeysTypes.dfy
@@ -162,6 +162,8 @@ module {:extern "software.amazon.cryptography.materialproviderstestvectorkeys.in
   datatype KmsEcdhKeyring = | KmsEcdhKeyring (
     nameonly senderKeyId: string ,
     nameonly recipientKeyId: string ,
+    nameonly senderPublicKey: string ,
+    nameonly recipientPublicKey: string ,
     nameonly curveSpec: string ,
     nameonly keyAgreementScheme: string
   )
@@ -191,6 +193,8 @@ module {:extern "software.amazon.cryptography.materialproviderstestvectorkeys.in
   datatype RawEcdh = | RawEcdh (
     nameonly senderKeyId: string ,
     nameonly recipientKeyId: string ,
+    nameonly senderPublicKey: string ,
+    nameonly recipientPublicKey: string ,
     nameonly providerId: string ,
     nameonly curveSpec: string ,
     nameonly keyAgreementScheme: string

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/Model/key-vectors.smithy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/Model/key-vectors.smithy
@@ -148,6 +148,10 @@ structure RawEcdh {
   @required
   recipientKeyId: String,
   @required
+  senderPublicKey: String,
+  @required
+  recipientPublicKey: String,
+  @required
   providerId: String,
   @required
   curveSpec: String,
@@ -172,6 +176,10 @@ structure KmsEcdhKeyring {
   senderKeyId: String,
   @required
   recipientKeyId: String,
+  @required
+  senderPublicKey: String,
+  @required
+  recipientPublicKey: String,
   @required
   curveSpec: String,
   @required

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/KeyDescription.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/KeyDescription.dfy
@@ -135,11 +135,15 @@ module {:options "-functionSyntax:4"} KeyDescription {
     var schema :- GetString("schema", obj);
     var sender :- GetString("sender", obj);
     var recipient :- GetString("recipient", obj);
+    var senderPublicKey :- GetString("sender-public-key", obj);
+    var recipientPublicKey :- GetString("recipient-public-key", obj);
 
 
     Success(KmsECDH(KmsEcdhKeyring(
                       senderKeyId := sender,
                       recipientKeyId := recipient,
+                      senderPublicKey := senderPublicKey,
+                      recipientPublicKey := recipientPublicKey,
                       keyAgreementScheme := schema,
                       curveSpec := eccCurve
                     )))
@@ -180,9 +184,13 @@ module {:options "-functionSyntax:4"} KeyDescription {
     var sender :- GetString("sender", obj);
     var recipient :- GetString("recipient", obj);
     var schema :- GetString("schema", obj);
+    var senderPublicKey :- GetString("sender-public-key", obj);
+    var recipientPublicKey :- GetString("recipient-public-key", obj);
     Success(ECDH(RawEcdh(
                    senderKeyId := sender,
                    recipientKeyId := recipient,
+                   senderPublicKey := senderPublicKey,
+                   recipientPublicKey := recipientPublicKey,
                    providerId := providerId,
                    keyAgreementScheme := schema,
                    curveSpec := ecc_curve
@@ -342,6 +350,8 @@ module {:options "-functionSyntax:4"} KeyDescription {
                        ("type", String("raw-ecdh")),
                        ("sender", String(ECDH.senderKeyId)),
                        ("recipient", String(ECDH.recipientKeyId)),
+                       ("sender-public-key", String(ECDH.senderPublicKey)),
+                       ("recipient-public-key", String(ECDH.recipientPublicKey)),
                        ("provider-id", String(ECDH.providerId)),
                        ("ecc-curve", String(ECDH.curveSpec)),
                        ("schema", String(ECDH.keyAgreementScheme))
@@ -364,6 +374,8 @@ module {:options "-functionSyntax:4"} KeyDescription {
                        ("type", String("aws-kms-ecdh")),
                        ("sender", String(KmsECDH.senderKeyId)),
                        ("recipient", String(KmsECDH.recipientKeyId)),
+                       ("sender-public-key", String(KmsECDH.senderPublicKey)),
+                       ("recipient-public-key", String(KmsECDH.recipientPublicKey)),
                        ("ecc-curve", String(KmsECDH.curveSpec)),
                        ("schema", String(KmsECDH.keyAgreementScheme))
                      ]))

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/KeyMaterial.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/KeyMaterial.dfy
@@ -69,6 +69,9 @@ module {:options "-functionSyntax:4"} KeyMaterial {
         var algorithm :- GetString("algorithm", obj);
         var senderMaterial :- GetString("sender-material", obj);
         var recipientMaterial :- GetString("recipient-material", obj);
+        var encoding :- GetString("encoding", obj);
+        var senderPublicKey :- GetString("sender-material-public-key", obj);
+        var recipientPublicKey :- GetString("recipient-material-public-key", obj);
         Success(KeyMaterial.KMSEcdh(
                   name := name,
                   encrypt := encrypt,
@@ -76,7 +79,9 @@ module {:options "-functionSyntax:4"} KeyMaterial {
                   keyIdentifier := keyIdentifier,
                   algorithm := algorithm,
                   senderMaterial := senderMaterial,
-                  recipientMaterial := recipientMaterial
+                  recipientMaterial := recipientMaterial,
+                  senderPublicKey := senderPublicKey,
+                  recipientPublicKey := recipientPublicKey
                 ))
       case "ecc-private" =>
         var algorithm :- GetString("algorithm", obj);
@@ -84,6 +89,8 @@ module {:options "-functionSyntax:4"} KeyMaterial {
         var encoding :- GetString("encoding", obj);
         var senderMaterial :- GetString("sender-material", obj);
         var recipientMaterial :- GetString("recipient-material", obj);
+        var senderPublicKey :- GetString("sender-material-public-key", obj);
+        var recipientPublicKey :- GetString("recipient-material-public-key", obj);
         Success(PrivateECDH(
                   name := name,
                   encrypt := encrypt,
@@ -93,7 +100,9 @@ module {:options "-functionSyntax:4"} KeyMaterial {
                   bits := bits,
                   encoding := encoding,
                   senderMaterial := senderMaterial,
-                  recipientMaterial := recipientMaterial
+                  recipientMaterial := recipientMaterial,
+                  senderPublicKey := senderPublicKey,
+                  recipientPublicKey := recipientPublicKey
                 ))
       case _ =>
         var algorithm :- GetString("algorithm", obj);
@@ -304,6 +313,8 @@ module {:options "-functionSyntax:4"} KeyMaterial {
         encoding: string,
         senderMaterial: string,
         recipientMaterial: string,
+        senderPublicKey: string,
+        recipientPublicKey: string,
         keyIdentifier: string
       )
     | KMS(
@@ -326,7 +337,9 @@ module {:options "-functionSyntax:4"} KeyMaterial {
         keyIdentifier: string,
         algorithm: string,
         senderMaterial: string,
-        recipientMaterial: string
+        recipientMaterial: string,
+        senderPublicKey: string,
+        recipientPublicKey: string
       )
     | StaticMaterial(
         name: string,

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/src/VectorsComposition/AllKmsEcdh.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/src/VectorsComposition/AllKmsEcdh.dfy
@@ -19,7 +19,9 @@ module {:options "-functionSyntax:4"} AllKmsEcdh {
       ::
         KeyVectorsTypes.KmsECDH(KeyVectorsTypes.KmsEcdhKeyring(
                                   senderKeyId := key,
+                                  senderPublicKey := "sender-material-public-key",
                                   recipientKeyId := key,
+                                  recipientPublicKey := "recipient-material-public-key",
                                   curveSpec := key,
                                   keyAgreementScheme :=  "static"
                                 ))
@@ -29,7 +31,9 @@ module {:options "-functionSyntax:4"} AllKmsEcdh {
       ::
         KeyVectorsTypes.KmsECDH(KeyVectorsTypes.KmsEcdhKeyring(
                                   senderKeyId := "discovery",
+                                  senderPublicKey := "discovery",
                                   recipientKeyId := key,
+                                  recipientPublicKey := "recipient-material-public-key",
                                   curveSpec := key,
                                   keyAgreementScheme :=  "discovery"
                                 ))

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/src/VectorsComposition/AllRawECDH.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/src/VectorsComposition/AllRawECDH.dfy
@@ -19,7 +19,9 @@ module {:options "-functionSyntax:4"} AllRawECDH {
       ::
         KeyVectorsTypes.ECDH(KeyVectorsTypes.RawEcdh(
                                senderKeyId := "ephemeral",
+                               senderPublicKey := "ephemeral",
                                recipientKeyId := key + "-private",
+                               recipientPublicKey := "recipient-material-public-key",
                                providerId := "aws-raw-vectors-persistent-ephemeral " + key,
                                keyAgreementScheme := "ephemeral",
                                curveSpec := key
@@ -31,7 +33,9 @@ module {:options "-functionSyntax:4"} AllRawECDH {
       ::
         KeyVectorsTypes.ECDH(KeyVectorsTypes.RawEcdh(
                                senderKeyId := "discovery",
+                               senderPublicKey := "discovery",
                                recipientKeyId := key + "-private",
+                               recipientPublicKey := "recipient-material-public-key",
                                providerId := "aws-raw-vectors-persistent-discovery " + key,
                                keyAgreementScheme := "discovery",
                                curveSpec := key
@@ -43,7 +47,9 @@ module {:options "-functionSyntax:4"} AllRawECDH {
       ::
         KeyVectorsTypes.ECDH(KeyVectorsTypes.RawEcdh(
                                senderKeyId := key + "-private",
+                               senderPublicKey := "sender-material-public-key",
                                recipientKeyId := key + "-private",
+                               recipientPublicKey := "recipient-material-public-key",
                                providerId := "aws-raw-vectors-persistent-static " + key,
                                keyAgreementScheme := "static",
                                curveSpec := key
@@ -55,7 +61,9 @@ module {:options "-functionSyntax:4"} AllRawECDH {
       ::
         KeyVectorsTypes.ECDH(KeyVectorsTypes.RawEcdh(
                                senderKeyId := key + "-private",
+                               senderPublicKey := "sender-material-public-key",
                                recipientKeyId := key + "-private",
+                               recipientPublicKey := "recipient-material-public-key",
                                providerId := "aws-raw-vectors-persistent-static " + key,
                                keyAgreementScheme := "static",
                                curveSpec := key

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/test/keys.json
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/TestVectorsAwsCryptographicMaterialProviders/test/keys.json
@@ -113,6 +113,9 @@
       "encoding": "pem",
       "sender-material": "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgw+7YSKEOEAh8/DFZ\n22oSTm/D3jo4nH5tN48IUp0WjyuhRANCAASnUgx7SrlHhPIn3McZfc3cEIs8+XFf\n7JvhcuV1wWELGZ8AjuwnKjE0ielEwSY5HYzWCF773FvJaWGYGYGhSba8\n-----END PRIVATE KEY-----",
       "recipient-material": "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYvB/1CVSgfQDrE6A\nDz7pdgxcOb+AHnsaI4LQMY6s8JChRANCAARYxf/AeERu2Z3VtDokplDs/atuGIbW\n7IGhknbK2MP+NV/mbcaxl8Xki9FegBslxCbM66KaoOZR1bCxPpGub2aS\n-----END PRIVATE KEY-----",
+      "public-key-encoding": "base64-der",
+      "sender-material-public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEp1IMe0q5R4TyJ9zHGX3N3BCLPPlxX+yb4XLldcFhCxmfAI7sJyoxNInpRMEmOR2M1ghe+9xbyWlhmBmBoUm2vA==",
+      "recipient-material-public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWMX/wHhEbtmd1bQ6JKZQ7P2rbhiG1uyBoZJ2ytjD/jVf5m3GsZfF5IvRXoAbJcQmzOuimqDmUdWwsT6Rrm9mkg==",
       "key-id": "ecc-256"
     },
     "ecc-384-private":{
@@ -124,6 +127,9 @@
       "encoding": "pem",
       "sender-material": "-----BEGIN PRIVATE KEY-----\nMIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAx0jhFAVQX2zykSLO/\n3VvDDaQJspek3404TtDZupcxi2rThfnxh96u8CYD6XfHikehZANiAAR2W/Cc8slJ\ngYSGi3e+38UUW6dFi1mJBNEZEbJ4vljgEzBo7FecTsCOQH8Zu2nX3eQpuboD8Fb7\nARpqq7rug5jKBMQLUbvridjLBRLuFsfaLpZ07ih4/+VduqQom7D31ik=\n-----END PRIVATE KEY-----", 
       "recipient-material": "-----BEGIN PRIVATE KEY-----\nMIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDALwMcT5K2IOUK5Ww5o\nqYrYLzKHuAvFs0VLuKvJOCmWa3NK2WXtUIJ2fPYzp2Y9oTShZANiAATXUn2WMiLB\nbf665ikArOEAOFgruhqAwlxy58BP42nodBZFFf4L7cy7vPLpasp3fFroN57tYfjy\nXL5Wc0vb+xJaTZLBTU/tRGvtjHH0hQgMib2ch6akUJAT6zuMgNNdd7A=\n-----END PRIVATE KEY-----", 
+      "public-key-encoding": "base64-der",
+      "sender-material-public-key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEdlvwnPLJSYGEhot3vt/FFFunRYtZiQTRGRGyeL5Y4BMwaOxXnE7AjkB/Gbtp193kKbm6A/BW+wEaaqu67oOYygTEC1G764nYywUS7hbH2i6WdO4oeP/lXbqkKJuw99Yp", 
+      "recipient-material-public-key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE11J9ljIiwW3+uuYpAKzhADhYK7oagMJccufAT+Np6HQWRRX+C+3Mu7zy6WrKd3xa6Dee7WH48ly+VnNL2/sSWk2SwU1P7URr7Yxx9IUIDIm9nIempFCQE+s7jIDTXXew",
       "key-id": "ecc-384"
     },
     "ecc-521-private":{
@@ -135,6 +141,9 @@
       "encoding": "pem",
       "sender-material": "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIANn8j3pIu1wiwkz7z\niPKuqj2MEVWKe/UW/8NEtvD9tKQmMlAzwY/QN93k+0TNlXpvJTUvjI2NZDKNoQ2b\n0B44YfyhgYkDgYYABAHfgnF9LoYBRWwXKKEFQa+Xfg+ztDRdTVTqNZ8roUYmNvLL\nLz2F8oEOhDbMJZ5r1B1C9w5uJqeF6tE8a3yzm47R/wAs0k6dY3wfDKD013Wnn+6e\nNw1mtrvTi6+Pej/ukYOuCjCwm8B0AvxBzdHk8Q/nCcspO9pIsRl/I4qNz4tPaGjJ\nTA==\n-----END PRIVATE KEY-----", 
       "recipient-material": "-----BEGIN PRIVATE KEY-----\nMIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIBjhdIxb49QXi4OsOH\n5PNWnp/KePiuICqC+fxJJ6ceUgPr5SMlLxhHcfHSVZBCkGLP0Rjd1D9gi7Va1oxe\nIHmWRu2hgYkDgYYABAAmg0dilFc6FiO9OE8t1el92KdPo9WYu1hXYnjGYT7OuGj3\nbD9lr0KMNCm3wTPCiLjPb4Iqnk+g0SgrsQ4NvU7nygFBlgz8xXLzIXPqVICthcHX\nRWRB8HnXmyzeF0iCs12F/6vYn/uZfxp3IV/KCR4LwSzbiFzxsV9GYoCoUE30LDVb\nXg==\n-----END PRIVATE KEY-----", 
+      "public-key-encoding": "base64-der",
+      "sender-material-public-key": "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB34JxfS6GAUVsFyihBUGvl34Ps7Q0XU1U6jWfK6FGJjbyyy89hfKBDoQ2zCWea9QdQvcObianherRPGt8s5uO0f8ALNJOnWN8Hwyg9Nd1p5/unjcNZra704uvj3o/7pGDrgowsJvAdAL8Qc3R5PEP5wnLKTvaSLEZfyOKjc+LT2hoyUw=",
+      "recipient-material-public-key": "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAJoNHYpRXOhYjvThPLdXpfdinT6PVmLtYV2J4xmE+zrho92w/Za9CjDQpt8Ezwoi4z2+CKp5PoNEoK7EODb1O58oBQZYM/MVy8yFz6lSArYXB10VkQfB515ss3hdIgrNdhf+r2J/7mX8adyFfygkeC8Es24hc8bFfRmKAqFBN9Cw1W14=",
       "key-id": "ecc-521"
     },
     "us-west-2-decryptable": {
@@ -178,6 +187,9 @@
       "type": "aws-kms-ecdh",
       "sender-material": "arn:aws:kms:us-west-2:370957321024:key/eabdf483-6be2-4d2d-8ee4-8c2583d416e9",
       "recipient-material": "arn:aws:kms:us-west-2:370957321024:key/0265c8e9-5b6a-4055-8f70-63719e09fda5",
+      "encoding": "base64-der",
+      "sender-material-public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE18m54QsLUnhWU7gT8hkAceNbZ/WBGNUUSPCeIKqOyX5psiqyC1TXPOJXqKKaVv5Mg91WV9UjpboblOhNU35nRw==",
+      "recipient-material-public-key": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9istdPCuX9nF8EmA4tioe/k0TCa2M9VeBW1N9n0sxPA6uPVOfLtE4+KuYxAGT0dYoK6CY93nowUy1yS+R7A+wA==",
       "key-id": "ecc-256"
     },
     "us-west-2-384-ecc": {
@@ -187,6 +199,9 @@
       "type": "aws-kms-ecdh",
       "sender-material": "arn:aws:kms:us-west-2:370957321024:key/7f35a704-f4fb-469d-98b1-62a1fa2cc44e",
       "recipient-material": "arn:aws:kms:us-west-2:370957321024:key/29f0bef9-1677-4e74-b67e-acefab1295ff",
+      "encoding": "base64-der",
+      "sender-material-public-key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfQ0OHFvwskFVjQwfqV7jpo62I6uyGY+5SPRZb6CuJ96bVreLZXh485BcPv09O/DWnpTBm8LL+YcfsqM3ECvi2ee3bDGpH6xIdr28uvyG75t5wqBjYYtZQFDf/ydfG9mm",
+      "recipient-material-public-key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWgGNWQ+vEwlMxyMQkSsOAYGfT6IlgEkcanEOSjbeEpEnh8JHEiBHQ6QaROxJ7c3nEkbjbi0m+7ejBEGtkiqaY5Dsv5u1iV4fc/2v1RzPba1ZtudEmM16Eyy9LHswdJ7v",
       "key-id": "ecc-384"
     },
     "us-west-2-521-ecc": {
@@ -196,6 +211,9 @@
       "type": "aws-kms-ecdh",
       "sender-material": "arn:aws:kms:us-west-2:370957321024:key/41b502e3-cc9d-442f-bd7b-d67faed0f22e",
       "recipient-material": "arn:aws:kms:us-west-2:370957321024:key/c45f1043-53bb-4f37-adc5-4d25d4a84f9d",
+      "encoding": "base64-der",
+      "sender-material-public-key": "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAz86qnfp3s0cl+73PQhlUstfdg9EZDA/jtLjBTWYp/1EB7RHNm8q5hMg5kBfjRDUFhbRBMlUV1xBOTgqzoSWj4oAABnQKiXXGGyu6PMN4D9nVMDsOpJ1pWU7rQexWDahBrK+5hx3beFXUpvvFRQrGAt2icUXm18VO6Qwbp0da9jyGDSY=", 
+      "recipient-material-public-key": "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAxLxcjtYfqc4+4oJZY0gGv2Ehu++CnVFea6uwXgEgLifq4eDSSVmQYvU8majsufpBXQwVjnDlQ7pGRw1j6K4FaLAAgYuMrmrwKtx/ZZtkbXzCwrqJY+sfCk8U5m89DX331cdBAhR2uVSPL2d5hp8up5v+EBpNArtdC5lZMx2ZrwKKYuQ=",
       "key-id": "ecc-521"
     }
   }

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/ToDafny.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/ToDafny.java
@@ -129,6 +129,16 @@ public class ToDafny {
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
         nativeValue.recipientKeyId()
       );
+    DafnySequence<? extends Character> senderPublicKey;
+    senderPublicKey =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.senderPublicKey()
+      );
+    DafnySequence<? extends Character> recipientPublicKey;
+    recipientPublicKey =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.recipientPublicKey()
+      );
     DafnySequence<? extends Character> curveSpec;
     curveSpec =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
@@ -142,6 +152,8 @@ public class ToDafny {
     return new KmsEcdhKeyring(
       senderKeyId,
       recipientKeyId,
+      senderPublicKey,
+      recipientPublicKey,
       curveSpec,
       keyAgreementScheme
     );
@@ -256,6 +268,16 @@ public class ToDafny {
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
         nativeValue.recipientKeyId()
       );
+    DafnySequence<? extends Character> senderPublicKey;
+    senderPublicKey =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.senderPublicKey()
+      );
+    DafnySequence<? extends Character> recipientPublicKey;
+    recipientPublicKey =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.recipientPublicKey()
+      );
     DafnySequence<? extends Character> providerId;
     providerId =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
@@ -274,6 +296,8 @@ public class ToDafny {
     return new RawEcdh(
       senderKeyId,
       recipientKeyId,
+      senderPublicKey,
+      recipientPublicKey,
       providerId,
       curveSpec,
       keyAgreementScheme

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/ToNative.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/ToNative.java
@@ -148,6 +148,16 @@ public class ToNative {
         dafnyValue.dtor_recipientKeyId()
       )
     );
+    nativeBuilder.senderPublicKey(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_senderPublicKey()
+      )
+    );
+    nativeBuilder.recipientPublicKey(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_recipientPublicKey()
+      )
+    );
     nativeBuilder.curveSpec(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
         dafnyValue.dtor_curveSpec()
@@ -270,6 +280,16 @@ public class ToNative {
     nativeBuilder.recipientKeyId(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
         dafnyValue.dtor_recipientKeyId()
+      )
+    );
+    nativeBuilder.senderPublicKey(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_senderPublicKey()
+      )
+    );
+    nativeBuilder.recipientPublicKey(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_recipientPublicKey()
       )
     );
     nativeBuilder.providerId(

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/KmsEcdhKeyring.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/KmsEcdhKeyring.java
@@ -11,6 +11,10 @@ public class KmsEcdhKeyring {
 
   private final String recipientKeyId;
 
+  private final String senderPublicKey;
+
+  private final String recipientPublicKey;
+
   private final String curveSpec;
 
   private final String keyAgreementScheme;
@@ -18,6 +22,8 @@ public class KmsEcdhKeyring {
   protected KmsEcdhKeyring(BuilderImpl builder) {
     this.senderKeyId = builder.senderKeyId();
     this.recipientKeyId = builder.recipientKeyId();
+    this.senderPublicKey = builder.senderPublicKey();
+    this.recipientPublicKey = builder.recipientPublicKey();
     this.curveSpec = builder.curveSpec();
     this.keyAgreementScheme = builder.keyAgreementScheme();
   }
@@ -28,6 +34,14 @@ public class KmsEcdhKeyring {
 
   public String recipientKeyId() {
     return this.recipientKeyId;
+  }
+
+  public String senderPublicKey() {
+    return this.senderPublicKey;
+  }
+
+  public String recipientPublicKey() {
+    return this.recipientPublicKey;
   }
 
   public String curveSpec() {
@@ -55,6 +69,14 @@ public class KmsEcdhKeyring {
 
     String recipientKeyId();
 
+    Builder senderPublicKey(String senderPublicKey);
+
+    String senderPublicKey();
+
+    Builder recipientPublicKey(String recipientPublicKey);
+
+    String recipientPublicKey();
+
     Builder curveSpec(String curveSpec);
 
     String curveSpec();
@@ -72,6 +94,10 @@ public class KmsEcdhKeyring {
 
     protected String recipientKeyId;
 
+    protected String senderPublicKey;
+
+    protected String recipientPublicKey;
+
     protected String curveSpec;
 
     protected String keyAgreementScheme;
@@ -81,6 +107,8 @@ public class KmsEcdhKeyring {
     protected BuilderImpl(KmsEcdhKeyring model) {
       this.senderKeyId = model.senderKeyId();
       this.recipientKeyId = model.recipientKeyId();
+      this.senderPublicKey = model.senderPublicKey();
+      this.recipientPublicKey = model.recipientPublicKey();
       this.curveSpec = model.curveSpec();
       this.keyAgreementScheme = model.keyAgreementScheme();
     }
@@ -101,6 +129,24 @@ public class KmsEcdhKeyring {
 
     public String recipientKeyId() {
       return this.recipientKeyId;
+    }
+
+    public Builder senderPublicKey(String senderPublicKey) {
+      this.senderPublicKey = senderPublicKey;
+      return this;
+    }
+
+    public String senderPublicKey() {
+      return this.senderPublicKey;
+    }
+
+    public Builder recipientPublicKey(String recipientPublicKey) {
+      this.recipientPublicKey = recipientPublicKey;
+      return this;
+    }
+
+    public String recipientPublicKey() {
+      return this.recipientPublicKey;
     }
 
     public Builder curveSpec(String curveSpec) {
@@ -130,6 +176,16 @@ public class KmsEcdhKeyring {
       if (Objects.isNull(this.recipientKeyId())) {
         throw new IllegalArgumentException(
           "Missing value for required field `recipientKeyId`"
+        );
+      }
+      if (Objects.isNull(this.senderPublicKey())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `senderPublicKey`"
+        );
+      }
+      if (Objects.isNull(this.recipientPublicKey())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `recipientPublicKey`"
         );
       }
       if (Objects.isNull(this.curveSpec())) {

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/RawEcdh.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/RawEcdh.java
@@ -11,6 +11,10 @@ public class RawEcdh {
 
   private final String recipientKeyId;
 
+  private final String senderPublicKey;
+
+  private final String recipientPublicKey;
+
   private final String providerId;
 
   private final String curveSpec;
@@ -20,6 +24,8 @@ public class RawEcdh {
   protected RawEcdh(BuilderImpl builder) {
     this.senderKeyId = builder.senderKeyId();
     this.recipientKeyId = builder.recipientKeyId();
+    this.senderPublicKey = builder.senderPublicKey();
+    this.recipientPublicKey = builder.recipientPublicKey();
     this.providerId = builder.providerId();
     this.curveSpec = builder.curveSpec();
     this.keyAgreementScheme = builder.keyAgreementScheme();
@@ -31,6 +37,14 @@ public class RawEcdh {
 
   public String recipientKeyId() {
     return this.recipientKeyId;
+  }
+
+  public String senderPublicKey() {
+    return this.senderPublicKey;
+  }
+
+  public String recipientPublicKey() {
+    return this.recipientPublicKey;
   }
 
   public String providerId() {
@@ -62,6 +76,14 @@ public class RawEcdh {
 
     String recipientKeyId();
 
+    Builder senderPublicKey(String senderPublicKey);
+
+    String senderPublicKey();
+
+    Builder recipientPublicKey(String recipientPublicKey);
+
+    String recipientPublicKey();
+
     Builder providerId(String providerId);
 
     String providerId();
@@ -83,6 +105,10 @@ public class RawEcdh {
 
     protected String recipientKeyId;
 
+    protected String senderPublicKey;
+
+    protected String recipientPublicKey;
+
     protected String providerId;
 
     protected String curveSpec;
@@ -94,6 +120,8 @@ public class RawEcdh {
     protected BuilderImpl(RawEcdh model) {
       this.senderKeyId = model.senderKeyId();
       this.recipientKeyId = model.recipientKeyId();
+      this.senderPublicKey = model.senderPublicKey();
+      this.recipientPublicKey = model.recipientPublicKey();
       this.providerId = model.providerId();
       this.curveSpec = model.curveSpec();
       this.keyAgreementScheme = model.keyAgreementScheme();
@@ -115,6 +143,24 @@ public class RawEcdh {
 
     public String recipientKeyId() {
       return this.recipientKeyId;
+    }
+
+    public Builder senderPublicKey(String senderPublicKey) {
+      this.senderPublicKey = senderPublicKey;
+      return this;
+    }
+
+    public String senderPublicKey() {
+      return this.senderPublicKey;
+    }
+
+    public Builder recipientPublicKey(String recipientPublicKey) {
+      this.recipientPublicKey = recipientPublicKey;
+      return this;
+    }
+
+    public String recipientPublicKey() {
+      return this.recipientPublicKey;
     }
 
     public Builder providerId(String providerId) {
@@ -153,6 +199,16 @@ public class RawEcdh {
       if (Objects.isNull(this.recipientKeyId())) {
         throw new IllegalArgumentException(
           "Missing value for required field `recipientKeyId`"
+        );
+      }
+      if (Objects.isNull(this.senderPublicKey())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `senderPublicKey`"
+        );
+      }
+      if (Objects.isNull(this.recipientPublicKey())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `recipientPublicKey`"
         );
       }
       if (Objects.isNull(this.providerId())) {

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/KmsEcdhKeyring.cs
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/KmsEcdhKeyring.cs
@@ -9,6 +9,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
   {
     private string _senderKeyId;
     private string _recipientKeyId;
+    private string _senderPublicKey;
+    private string _recipientPublicKey;
     private string _curveSpec;
     private string _keyAgreementScheme;
     public string SenderKeyId
@@ -28,6 +30,24 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     public bool IsSetRecipientKeyId()
     {
       return this._recipientKeyId != null;
+    }
+    public string SenderPublicKey
+    {
+      get { return this._senderPublicKey; }
+      set { this._senderPublicKey = value; }
+    }
+    public bool IsSetSenderPublicKey()
+    {
+      return this._senderPublicKey != null;
+    }
+    public string RecipientPublicKey
+    {
+      get { return this._recipientPublicKey; }
+      set { this._recipientPublicKey = value; }
+    }
+    public bool IsSetRecipientPublicKey()
+    {
+      return this._recipientPublicKey != null;
     }
     public string CurveSpec
     {
@@ -51,6 +71,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       if (!IsSetSenderKeyId()) throw new System.ArgumentException("Missing value for required property 'SenderKeyId'");
       if (!IsSetRecipientKeyId()) throw new System.ArgumentException("Missing value for required property 'RecipientKeyId'");
+      if (!IsSetSenderPublicKey()) throw new System.ArgumentException("Missing value for required property 'SenderPublicKey'");
+      if (!IsSetRecipientPublicKey()) throw new System.ArgumentException("Missing value for required property 'RecipientPublicKey'");
       if (!IsSetCurveSpec()) throw new System.ArgumentException("Missing value for required property 'CurveSpec'");
       if (!IsSetKeyAgreementScheme()) throw new System.ArgumentException("Missing value for required property 'KeyAgreementScheme'");
 

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/RawEcdh.cs
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/RawEcdh.cs
@@ -9,6 +9,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
   {
     private string _senderKeyId;
     private string _recipientKeyId;
+    private string _senderPublicKey;
+    private string _recipientPublicKey;
     private string _providerId;
     private string _curveSpec;
     private string _keyAgreementScheme;
@@ -29,6 +31,24 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     public bool IsSetRecipientKeyId()
     {
       return this._recipientKeyId != null;
+    }
+    public string SenderPublicKey
+    {
+      get { return this._senderPublicKey; }
+      set { this._senderPublicKey = value; }
+    }
+    public bool IsSetSenderPublicKey()
+    {
+      return this._senderPublicKey != null;
+    }
+    public string RecipientPublicKey
+    {
+      get { return this._recipientPublicKey; }
+      set { this._recipientPublicKey = value; }
+    }
+    public bool IsSetRecipientPublicKey()
+    {
+      return this._recipientPublicKey != null;
     }
     public string ProviderId
     {
@@ -61,6 +81,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       if (!IsSetSenderKeyId()) throw new System.ArgumentException("Missing value for required property 'SenderKeyId'");
       if (!IsSetRecipientKeyId()) throw new System.ArgumentException("Missing value for required property 'RecipientKeyId'");
+      if (!IsSetSenderPublicKey()) throw new System.ArgumentException("Missing value for required property 'SenderPublicKey'");
+      if (!IsSetRecipientPublicKey()) throw new System.ArgumentException("Missing value for required property 'RecipientPublicKey'");
       if (!IsSetProviderId()) throw new System.ArgumentException("Missing value for required property 'ProviderId'");
       if (!IsSetCurveSpec()) throw new System.ArgumentException("Missing value for required property 'CurveSpec'");
       if (!IsSetKeyAgreementScheme()) throw new System.ArgumentException("Missing value for required property 'KeyAgreementScheme'");

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/TypeConversion.cs
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/KeyVectors/TypeConversion.cs
@@ -516,6 +516,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.RawEcdh concrete = (software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.RawEcdh)value; AWS.Cryptography.MaterialProvidersTestVectorKeys.RawEcdh converted = new AWS.Cryptography.MaterialProvidersTestVectorKeys.RawEcdh(); converted.SenderKeyId = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M11_senderKeyId(concrete._senderKeyId);
       converted.RecipientKeyId = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M14_recipientKeyId(concrete._recipientKeyId);
+      converted.SenderPublicKey = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M15_senderPublicKey(concrete._senderPublicKey);
+      converted.RecipientPublicKey = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_recipientPublicKey(concrete._recipientPublicKey);
       converted.ProviderId = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M10_providerId(concrete._providerId);
       converted.CurveSpec = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M9_curveSpec(concrete._curveSpec);
       converted.KeyAgreementScheme = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_keyAgreementScheme(concrete._keyAgreementScheme); return converted;
@@ -524,7 +526,7 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       value.Validate();
 
-      return new software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.RawEcdh(ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M11_senderKeyId(value.SenderKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M14_recipientKeyId(value.RecipientKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M10_providerId(value.ProviderId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M9_curveSpec(value.CurveSpec), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_keyAgreementScheme(value.KeyAgreementScheme));
+      return new software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.RawEcdh(ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M11_senderKeyId(value.SenderKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M14_recipientKeyId(value.RecipientKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M15_senderPublicKey(value.SenderPublicKey), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_recipientPublicKey(value.RecipientPublicKey), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M10_providerId(value.ProviderId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M9_curveSpec(value.CurveSpec), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_keyAgreementScheme(value.KeyAgreementScheme));
     }
     public static AWS.Cryptography.MaterialProvidersTestVectorKeys.StaticKeyring FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S13_StaticKeyring(software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types._IStaticKeyring value)
     {
@@ -551,6 +553,8 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.KmsEcdhKeyring concrete = (software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.KmsEcdhKeyring)value; AWS.Cryptography.MaterialProvidersTestVectorKeys.KmsEcdhKeyring converted = new AWS.Cryptography.MaterialProvidersTestVectorKeys.KmsEcdhKeyring(); converted.SenderKeyId = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M11_senderKeyId(concrete._senderKeyId);
       converted.RecipientKeyId = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M14_recipientKeyId(concrete._recipientKeyId);
+      converted.SenderPublicKey = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M15_senderPublicKey(concrete._senderPublicKey);
+      converted.RecipientPublicKey = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_recipientPublicKey(concrete._recipientPublicKey);
       converted.CurveSpec = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M9_curveSpec(concrete._curveSpec);
       converted.KeyAgreementScheme = (string)FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_keyAgreementScheme(concrete._keyAgreementScheme); return converted;
     }
@@ -558,7 +562,7 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       value.Validate();
 
-      return new software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.KmsEcdhKeyring(ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M11_senderKeyId(value.SenderKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M14_recipientKeyId(value.RecipientKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M9_curveSpec(value.CurveSpec), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_keyAgreementScheme(value.KeyAgreementScheme));
+      return new software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types.KmsEcdhKeyring(ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M11_senderKeyId(value.SenderKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M14_recipientKeyId(value.RecipientKeyId), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M15_senderPublicKey(value.SenderPublicKey), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_recipientPublicKey(value.RecipientPublicKey), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M9_curveSpec(value.CurveSpec), ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_keyAgreementScheme(value.KeyAgreementScheme));
     }
     public static AWS.Cryptography.MaterialProvidersTestVectorKeys.HierarchyKeyring FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S16_HierarchyKeyring(software.amazon.cryptography.materialproviderstestvectorkeys.internaldafny.types._IHierarchyKeyring value)
     {
@@ -696,6 +700,22 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M15_senderPublicKey(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M15_senderPublicKey(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_recipientPublicKey(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M18_recipientPublicKey(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
     public static string FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S7_RawEcdh__M10_providerId(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
@@ -757,6 +777,22 @@ namespace AWS.Cryptography.MaterialProvidersTestVectorKeys
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M14_recipientKeyId(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M15_senderPublicKey(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M15_senderPublicKey(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_recipientPublicKey(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N31_materialProvidersTestVectorKeys__S14_KmsEcdhKeyring__M18_recipientPublicKey(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Adds comments to ecdh extern regarding signed/unsigned representation.
Updates test vectors to include raw base64 der encoded public keys, to facilitate java/net interop testing of der public keys.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
