### PR TITLE
chore(Java): Sonatype requires User Token

### DIFF
--- a/.github/workflows/todo-java-release.yml
+++ b/.github/workflows/todo-java-release.yml
@@ -1,5 +1,5 @@
-# This workflow performs MPL Java release
-name: MPL-Release-Java
+# This workflow WOULD perform MPL Java release
+name: TODO-MPL-Release-Java
 
 on:
   workflow_call:

--- a/.github/workflows/todo-release.yml
+++ b/.github/workflows/todo-release.yml
@@ -1,5 +1,5 @@
 # This workflow is triggered manually
-name: MPL-Release
+name: TODO-MPL-Release
 
 on:
   workflow_dispatch:
@@ -15,6 +15,6 @@ jobs:
   java-release:
     if: contains('["seebees","texastony","ShubhamChaturvedi7","lucasmcdonald3","josecorella","imabhichow","rishav-karanjit","antonf-amzn","justplaz","ajewellamz"]', github.actor)
     needs: getVersion
-    uses: ./.github/workflows/java-release.yml
+    uses: ./.github/workflows/todo-java-release.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}

--- a/cfn/CB.yml
+++ b/cfn/CB.yml
@@ -234,6 +234,7 @@ Resources:
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-CI-Credentials-eBrSNB",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-haLIjZ",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-Credentials-WgJanS",
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Team-Account-0tWvZm",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-User-Token-zK61bM",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Github/aws-crypto-tools-ci-bot-AGUB3U"
               ],

--- a/cfn/CB.yml
+++ b/cfn/CB.yml
@@ -234,7 +234,7 @@ Resources:
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-CI-Credentials-eBrSNB",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-haLIjZ",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-Credentials-WgJanS",
-                "arn:aws:secretsmanager:us-west-2:587316601012:secret:Sonatype-User-Token-zK61bM",
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-User-Token-zK61bM",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Github/aws-crypto-tools-ci-bot-AGUB3U"
               ],
               "Action": "secretsmanager:GetSecretValue"

--- a/cfn/CB.yml
+++ b/cfn/CB.yml
@@ -234,7 +234,7 @@ Resources:
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-CI-Credentials-eBrSNB",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-haLIjZ",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-Credentials-WgJanS",
-                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Team-Account-0tWvZm",
+                "arn:aws:secretsmanager:us-west-2:587316601012:secret:Sonatype-User-Token-zK61bM",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Github/aws-crypto-tools-ci-bot-AGUB3U"
               ],
               "Action": "secretsmanager:GetSecretValue"

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -11,8 +11,8 @@ env:
   secrets-manager:
     GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
     GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
-    SONA_USERNAME: Sonatype-Team-Account:Username
-    SONA_PASSWORD: Sonatype-Team-Account:Password
+    SONA_USERNAME: Sonatype-User-Token:username
+    SONA_PASSWORD: Sonatype-User-Token:password
 
 phases:
   install:


### PR DESCRIPTION
_Issue #, if available:_ Sonatype requires User Token

As of Friday 6/21, Sonatype requires maven releases to use token-based authentication, instead of username and password authentication.

_Description of changes:_
- Use Sonatype token-based authentication to publish to Maven
- Rename WIP GitHub Workflows to release, to make it clear they are not used to release, but ideally would be used in the future.

_Squash/merge commit message, if applicable:_
```
chore(Java): Sonatype requires User Token
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
