### PR TITLE
fix: Remove uses of `:|`

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/DefaultCMM.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/DefaultCMM.dfy
@@ -373,7 +373,6 @@ module DefaultCMM {
       //# the values MUST be equal or the operation MUST fail.
       ensures
         && (output.Success? ==> CMM.ReproducedEncryptionContext?(input))
-      ensures
         && (!CMM.ReproducedEncryptionContext?(input) ==> output.Failure?)
       //= aws-encryption-sdk-specification/framework/cmm-interface.md#decrypt-materials
       //= type=implication
@@ -490,10 +489,10 @@ module DefaultCMM {
           invariant |keysSet'| == |keysSeq| - i
           invariant forall key
                       |
-                      && key in input.reproducedEncryptionContext.value.Keys
+                      && key in input.reproducedEncryptionContext.value
                       && key in input.encryptionContext
                       && key !in keysSet'
-                      :: input.encryptionContext[key] == input.reproducedEncryptionContext.value[key]
+                      :: input.reproducedEncryptionContext.value[key] == input.encryptionContext[key]
           invariant forall key <- requiredEncryptionContextKeys
                       :: key !in input.encryptionContext
         {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
@@ -16,6 +16,7 @@ module RequiredEncryptionContextCMM {
   import UTF8
   import Types = AwsCryptographyMaterialProvidersTypes
   import Seq
+  import SortedSets
 
   class RequiredEncryptionContextCMM
     extends CMM.VerifiableInterface
@@ -52,16 +53,7 @@ module RequiredEncryptionContextCMM {
       ensures Modifies == { History } + underlyingCMM.Modifies
     {
       var keySet := inputKeys;
-      var keySeq := [];
-      while keySet != {}
-        invariant |keySeq| + |keySet| == |inputKeys|
-        invariant forall k <- keySeq
-                    :: k in inputKeys
-      {
-        var key :| key in keySet;
-        keySeq := keySeq + [key];
-        keySet := keySet - {key};
-      }
+      var keySeq := SortedSets.ComputeSetToSequence(keySet);
 
       underlyingCMM := inputCMM;
       requiredEncryptionContextKeys := keySeq;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
@@ -54,7 +54,9 @@ module RequiredEncryptionContextCMM {
     {
       var keySet := inputKeys;
       var keySeq := SortedSets.ComputeSetToSequence(keySet);
-
+      assert |keySeq| == |keySet| == |inputKeys|;
+      assert forall k <- keySeq
+               :: k in inputKeys;
       underlyingCMM := inputCMM;
       requiredEncryptionContextKeys := keySeq;
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CMMs/RequiredEncryptionContextCMM.dfy
@@ -56,7 +56,7 @@ module RequiredEncryptionContextCMM {
       var keySeq := SortedSets.ComputeSetToSequence(keySet);
       assert |keySeq| == |keySet| == |inputKeys|;
       assert forall k <- keySeq
-               :: k in inputKeys;
+          :: k in inputKeys;
       underlyingCMM := inputCMM;
       requiredEncryptionContextKeys := keySeq;
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
@@ -9,6 +9,7 @@ module CanonicalEncryptionContext {
   import Types = AwsCryptographyMaterialProvidersTypes
   import opened Wrappers
   import Seq
+  import SortedSets
 
   //= aws-encryption-sdk-specification/framework/raw-aes-keyring.md#onencrypt
   //# The keyring MUST attempt to serialize the [encryption materials']
@@ -25,7 +26,7 @@ module CanonicalEncryptionContext {
   {
     :- Need(|encryptionContext| < UINT16_LIMIT,
             Types.AwsCryptographicMaterialProvidersException( message := "Encryption Context is too large" ));
-    var keys := SetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
+    var keys := SortedSets.ComputeSetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
 
     if |keys| == 0 then
       Success([])

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
@@ -26,7 +26,7 @@ module CanonicalEncryptionContext {
   {
     :- Need(|encryptionContext| < UINT16_LIMIT,
             Types.AwsCryptographicMaterialProvidersException( message := "Encryption Context is too large" ));
-    var keys := SortedSets.ComputeSetToOrderedSequence(encryptionContext.Keys, UInt.UInt8Less);
+    var keys := SortedSets.ComputeSetToOrderedSequence2(encryptionContext.Keys, UInt.UInt8Less);
 
     if |keys| == 0 then
       Success([])

--- a/AwsCryptographyPrimitives/test/TestRSA.dfy
+++ b/AwsCryptographyPrimitives/test/TestRSA.dfy
@@ -9,6 +9,7 @@ module {:options "-functionSyntax:4"} TestAwsCryptographyPrimitivesRSA {
   import opened Wrappers
   import opened StandardLibrary.UInt
   import UTF8
+  import SortedSets
 
   const RSA_PUBLIC_2048 := "-----BEGIN PUBLIC KEY-----\n"
                            + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqBvECLsPdF1J5DOkaA1n\n"
@@ -130,10 +131,11 @@ module {:options "-functionSyntax:4"} TestAwsCryptographyPrimitivesRSA {
         lengthBits := 2048,
         pem := PrivateKeyFromGenerateRSAKeyPairPemBytes
       ));
-
-    while allPadding != {}
+    var paddingSeq := SortedSets.ComputeSetToSequence(allPadding);
+    for paddingIdx := 0 to |paddingSeq|
     {
-      var padding :| padding in allPadding;
+      var padding := paddingSeq[paddingIdx];
+
       BasicRSAEncryptTest(
         Primitives.Types.RSAEncryptInput(
           padding := padding,
@@ -144,7 +146,6 @@ module {:options "-functionSyntax:4"} TestAwsCryptographyPrimitivesRSA {
         KeyFromGenerateRSAKeyPair
       );
 
-      allPadding := allPadding - {padding};
     }
   }
 
@@ -164,9 +165,10 @@ module {:options "-functionSyntax:4"} TestAwsCryptographyPrimitivesRSA {
         pem := PrivateKeyFromTestVectorsPemBytes
       ));
 
-    while allPadding != {}
+    var paddingSeq := SortedSets.ComputeSetToSequence(allPadding);
+    for paddingIdx := 0 to |paddingSeq|
     {
-      var padding :| padding in allPadding;
+      var padding := paddingSeq[paddingIdx];
 
       BasicRSAEncryptTest(
         Primitives.Types.RSAEncryptInput(
@@ -178,7 +180,6 @@ module {:options "-functionSyntax:4"} TestAwsCryptographyPrimitivesRSA {
         KeyFromTestVectorsPair
       );
 
-      allPadding := allPadding - {padding};
     }
   }
 

--- a/StandardLibrary/src/StandardLibrary.dfy
+++ b/StandardLibrary/src/StandardLibrary.dfy
@@ -335,7 +335,7 @@ module StandardLibrary {
    * The function is compilable, but will not exhibit enviable performance.
    */
 
-  function SetToOrderedSequence<T(!new,==)>(s: set<seq<T>>, less: (T, T) -> bool): (q: seq<seq<T>>)
+  function method {:tailrecursion} SetToOrderedSequence<T(!new,==)>(s: set<seq<T>>, less: (T, T) -> bool): (q: seq<seq<T>>)
     requires Trichotomous(less) && Transitive(less)
     ensures |s| == |q|
     ensures forall i :: 0 <= i < |q| ==> q[i] in s

--- a/StandardLibrary/src/StandardLibrary.dfy
+++ b/StandardLibrary/src/StandardLibrary.dfy
@@ -335,7 +335,7 @@ module StandardLibrary {
    * The function is compilable, but will not exhibit enviable performance.
    */
 
-  function method {:tailrecursion} SetToOrderedSequence<T(!new,==)>(s: set<seq<T>>, less: (T, T) -> bool): (q: seq<seq<T>>)
+  function SetToOrderedSequence<T(!new,==)>(s: set<seq<T>>, less: (T, T) -> bool): (q: seq<seq<T>>)
     requires Trichotomous(less) && Transitive(less)
     ensures |s| == |q|
     ensures forall i :: 0 <= i < |q| ==> q[i] in s


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Removes uses of `:|` in Dafny code, and updates the libraries submodule to a version that does not use it, either. This will eliminate failures when compiling with Dafny 4.8.0 and `-definiteAssignment:3`.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
