### PR TITLE
fix(DDB-Model): DDB Supports 100 actions per Transaction

### DIFF
--- a/ComAmazonawsDynamodb/Model/dynamodb/model.json
+++ b/ComAmazonawsDynamodb/Model/dynamodb/model.json
@@ -1208,7 +1208,7 @@
       "traits": {
         "smithy.api#length": {
           "min": 1,
-          "max": 25
+          "max": 100
         }
       }
     },
@@ -5147,7 +5147,7 @@
       "traits": {
         "smithy.api#length": {
           "min": 1,
-          "max": 25
+          "max": 100
         }
       }
     },
@@ -6179,7 +6179,7 @@
       "traits": {
         "smithy.api#length": {
           "min": 1,
-          "max": 25
+          "max": 100
         }
       }
     },
@@ -9008,7 +9008,7 @@
       "traits": {
         "smithy.api#length": {
           "min": 1,
-          "max": 25
+          "max": 100
         }
       }
     },
@@ -9122,7 +9122,7 @@
       "traits": {
         "smithy.api#length": {
           "min": 1,
-          "max": 25
+          "max": 100
         }
       }
     },

--- a/ComAmazonawsDynamodb/codegen-patches/dafny/dafny-4.2.0.patch
+++ b/ComAmazonawsDynamodb/codegen-patches/dafny/dafny-4.2.0.patch
@@ -1,0 +1,49 @@
+diff --git b/ComAmazonawsDynamodb/Model/ComAmazonawsDynamodbTypes.dfy a/ComAmazonawsDynamodb/Model/ComAmazonawsDynamodbTypes.dfy
+index 95fbec3f..16030b6c 100644
+--- b/ComAmazonawsDynamodb/Model/ComAmazonawsDynamodbTypes.dfy
++++ a/ComAmazonawsDynamodb/Model/ComAmazonawsDynamodbTypes.dfy
+@@ -237,7 +237,7 @@ module {:extern "software.amazon.cryptography.services.dynamodb.internaldafny.ty
+   )
+   type CancellationReasonList = x: seq<CancellationReason> | IsValid_CancellationReasonList(x) witness *
+   predicate method IsValid_CancellationReasonList(x: seq<CancellationReason>) {
+-    ( 1 <= |x| <= 100 )
++    ( 1 <= |x| <= 25 )
+   }
+   datatype Capacity = | Capacity (
+     nameonly ReadCapacityUnits: Option<ConsumedCapacityUnits> := Option.None ,
+@@ -1781,7 +1781,7 @@ module {:extern "software.amazon.cryptography.services.dynamodb.internaldafny.ty
+   )
+   type ItemResponseList = x: seq<ItemResponse> | IsValid_ItemResponseList(x) witness *
+   predicate method IsValid_ItemResponseList(x: seq<ItemResponse>) {
+-    ( 1 <= |x| <= 100 )
++    ( 1 <= |x| <= 25 )
+   }
+   type Key = map<AttributeName, AttributeValue>
+   type KeyConditions = map<AttributeName, Condition>
+@@ -1955,7 +1955,7 @@ module {:extern "software.amazon.cryptography.services.dynamodb.internaldafny.ty
+   )
+   type ParameterizedStatements = x: seq<ParameterizedStatement> | IsValid_ParameterizedStatements(x) witness *
+   predicate method IsValid_ParameterizedStatements(x: seq<ParameterizedStatement>) {
+-    ( 1 <= |x| <= 100 )
++    ( 1 <= |x| <= 25 )
+   }
+   type PartiQLBatchRequest = x: seq<BatchStatementRequest> | IsValid_PartiQLBatchRequest(x) witness *
+   predicate method IsValid_PartiQLBatchRequest(x: seq<BatchStatementRequest>) {
+@@ -2474,7 +2474,7 @@ module {:extern "software.amazon.cryptography.services.dynamodb.internaldafny.ty
+   )
+   type TransactGetItemList = x: seq<TransactGetItem> | IsValid_TransactGetItemList(x) witness *
+   predicate method IsValid_TransactGetItemList(x: seq<TransactGetItem>) {
+-    ( 1 <= |x| <= 100 )
++    ( 1 <= |x| <= 25 )
+   }
+   datatype TransactGetItemsInput = | TransactGetItemsInput (
+     nameonly TransactItems: TransactGetItemList ,
+@@ -2492,7 +2492,7 @@ module {:extern "software.amazon.cryptography.services.dynamodb.internaldafny.ty
+   )
+   type TransactWriteItemList = x: seq<TransactWriteItem> | IsValid_TransactWriteItemList(x) witness *
+   predicate method IsValid_TransactWriteItemList(x: seq<TransactWriteItem>) {
+-    ( 1 <= |x| <= 100 )
++    ( 1 <= |x| <= 25 )
+   }
+   datatype TransactWriteItemsInput = | TransactWriteItemsInput (
+     nameonly TransactItems: TransactWriteItemList ,

--- a/ComAmazonawsDynamodb/codegen-patches/java/dafny-4.2.0.patch
+++ b/ComAmazonawsDynamodb/codegen-patches/java/dafny-4.2.0.patch
@@ -1,7 +1,7 @@
-diff --git a/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java b/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
+diff --git b/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java a/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
 index c30e7cdf..3964b7cb 100644
---- a/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
-+++ b/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
+--- b/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
++++ a/ComAmazonawsDynamodb/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/services/dynamodb/internaldafny/ToNative.java
 @@ -8040,6 +8040,126 @@ public class ToNative {
      return builder.build();
    }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

See:
https://aws.amazon.com/about-aws/whats-new/2022/09/amazon-dynamodb-supports-100-actions-per-transaction/

Note: We cannot use the latest DDB Model due to
https://github.com/smithy-lang/smithy-dafny/issues/105

Thus, I manually bumped the relevant values from 25 to 100.

_Squash/merge commit message, if applicable:_
`fix(DDB-Model): DDB Supports 100 actions per Transaction`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
