### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -20,9 +20,6 @@
 // We model all the files and the runtimes here in this structure
 const Runtimes = {
   java: {
-    "project.properties": {
-      dependencies: [],
-    },
     "AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts": {
       dependencies: [],
     },
@@ -84,13 +81,6 @@ module.exports = {
         replacements: [
           // Update the version for all Gradle Java projects
           // Does not update the dependencies
-          {
-            files: Object.keys(Runtimes.java),
-            from: 'mplVersion=".*"',
-            to: 'mplVersion="${nextRelease.version}"',
-            results: Object.keys(Runtimes.java).map(CheckResults),
-            countMatches: true,
-          },
           {
             files: Object.keys(Runtimes.java),
             from: 'version = ".*"',

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.5.1-SNAPSHOT"
+version = "1.6.0"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.5.1</Version>
+      <Version>1.6.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@
 - Remove 4.4 DDB and KMS patches, abstract test to work on later Dafny versions ([#611](https://github.com/aws/aws-cryptographic-material-providers-library/issues/611)) ([d51d648](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d51d6482e3d8ca668111a4695d1adc0c67c3f0a3))
 - Remove uses of `:|` ([#618](https://github.com/aws/aws-cryptographic-material-providers-library/issues/618)) ([f12fe5b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f12fe5b4a96a9873eb1b73cee8ae74737f3d2375))
 - test vector help text ([#657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/657)) ([0fedaf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0fedaf1466d1e0915faa6b6a533b88a40fb0ee91))
+- **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))
 
 ### Features
 
 - bump dafny verification and code gen to dafny 4.8.0 ([#520](https://github.com/aws/aws-cryptographic-material-providers-library/issues/520)) ([e16539e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e16539e98d4b0f60098693fdbaec12dc49c34c9b))
-- **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))
 
 ## [1.5.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.0...v1.5.1) (2024-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,20 @@
 
 # [1.6.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.1...v1.6.0) (2024-09-10)
 
-
 ### Bug Fixes
 
-* add ECDH error message for Rust ([#574](https://github.com/aws/aws-cryptographic-material-providers-library/issues/574)) ([473a34a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/473a34abe688629e1a5b8abe8bc859e1128ea40b))
-* **DDB-Model:** DDB Supports 100 actions per Transaction ([#692](https://github.com/aws/aws-cryptographic-material-providers-library/issues/692)) ([8a67843](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a6784372ff635828aa15b9edd7a1c7a37a95286))
-* GetCurrentTimeStamp returns ISO8601 format ([#575](https://github.com/aws/aws-cryptographic-material-providers-library/issues/575)) ([c07a51f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c07a51fc29ff70411f7573bca96d2a091db8c1ed))
-* maintain order in test vectors for languages with parallel tests ([#641](https://github.com/aws/aws-cryptographic-material-providers-library/issues/641)) ([8c8a38f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8c8a38ff3534b8e4f0dca020e65effc454ef330a))
-* Remove 4.4 DDB and KMS patches, abstract test to work on later Dafny versions ([#611](https://github.com/aws/aws-cryptographic-material-providers-library/issues/611)) ([d51d648](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d51d6482e3d8ca668111a4695d1adc0c67c3f0a3))
-* Remove uses of `:|` ([#618](https://github.com/aws/aws-cryptographic-material-providers-library/issues/618)) ([f12fe5b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f12fe5b4a96a9873eb1b73cee8ae74737f3d2375))
-* test vector help text ([#657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/657)) ([0fedaf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0fedaf1466d1e0915faa6b6a533b88a40fb0ee91))
-
+- add ECDH error message for Rust ([#574](https://github.com/aws/aws-cryptographic-material-providers-library/issues/574)) ([473a34a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/473a34abe688629e1a5b8abe8bc859e1128ea40b))
+- **DDB-Model:** DDB Supports 100 actions per Transaction ([#692](https://github.com/aws/aws-cryptographic-material-providers-library/issues/692)) ([8a67843](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a6784372ff635828aa15b9edd7a1c7a37a95286))
+- GetCurrentTimeStamp returns ISO8601 format ([#575](https://github.com/aws/aws-cryptographic-material-providers-library/issues/575)) ([c07a51f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c07a51fc29ff70411f7573bca96d2a091db8c1ed))
+- maintain order in test vectors for languages with parallel tests ([#641](https://github.com/aws/aws-cryptographic-material-providers-library/issues/641)) ([8c8a38f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8c8a38ff3534b8e4f0dca020e65effc454ef330a))
+- Remove 4.4 DDB and KMS patches, abstract test to work on later Dafny versions ([#611](https://github.com/aws/aws-cryptographic-material-providers-library/issues/611)) ([d51d648](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d51d6482e3d8ca668111a4695d1adc0c67c3f0a3))
+- Remove uses of `:|` ([#618](https://github.com/aws/aws-cryptographic-material-providers-library/issues/618)) ([f12fe5b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f12fe5b4a96a9873eb1b73cee8ae74737f3d2375))
+- test vector help text ([#657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/657)) ([0fedaf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0fedaf1466d1e0915faa6b6a533b88a40fb0ee91))
 
 ### Features
 
-* bump dafny verification and code gen to dafny 4.8.0 ([#520](https://github.com/aws/aws-cryptographic-material-providers-library/issues/520)) ([e16539e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e16539e98d4b0f60098693fdbaec12dc49c34c9b))
-* **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))
+- bump dafny verification and code gen to dafny 4.8.0 ([#520](https://github.com/aws/aws-cryptographic-material-providers-library/issues/520)) ([e16539e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e16539e98d4b0f60098693fdbaec12dc49c34c9b))
+- **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))
 
 ## [1.5.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.0...v1.5.1) (2024-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+# [1.6.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.1...v1.6.0) (2024-09-10)
+
+
+### Bug Fixes
+
+* add ECDH error message for Rust ([#574](https://github.com/aws/aws-cryptographic-material-providers-library/issues/574)) ([473a34a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/473a34abe688629e1a5b8abe8bc859e1128ea40b))
+* **DDB-Model:** DDB Supports 100 actions per Transaction ([#692](https://github.com/aws/aws-cryptographic-material-providers-library/issues/692)) ([8a67843](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a6784372ff635828aa15b9edd7a1c7a37a95286))
+* GetCurrentTimeStamp returns ISO8601 format ([#575](https://github.com/aws/aws-cryptographic-material-providers-library/issues/575)) ([c07a51f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c07a51fc29ff70411f7573bca96d2a091db8c1ed))
+* maintain order in test vectors for languages with parallel tests ([#641](https://github.com/aws/aws-cryptographic-material-providers-library/issues/641)) ([8c8a38f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8c8a38ff3534b8e4f0dca020e65effc454ef330a))
+* Remove 4.4 DDB and KMS patches, abstract test to work on later Dafny versions ([#611](https://github.com/aws/aws-cryptographic-material-providers-library/issues/611)) ([d51d648](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d51d6482e3d8ca668111a4695d1adc0c67c3f0a3))
+* Remove uses of `:|` ([#618](https://github.com/aws/aws-cryptographic-material-providers-library/issues/618)) ([f12fe5b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f12fe5b4a96a9873eb1b73cee8ae74737f3d2375))
+* test vector help text ([#657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/657)) ([0fedaf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0fedaf1466d1e0915faa6b6a533b88a40fb0ee91))
+
+
+### Features
+
+* bump dafny verification and code gen to dafny 4.8.0 ([#520](https://github.com/aws/aws-cryptographic-material-providers-library/issues/520)) ([e16539e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e16539e98d4b0f60098693fdbaec12dc49c34c9b))
+* **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))
+
 ## [1.5.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.0...v1.5.1) (2024-07-08)
 
 ### Fixes

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyVersion("1.6.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.5.1</Version>
+    <Version>1.6.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.5.1-SNAPSHOT"
+version = "1.6.0"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -68,7 +68,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.5.1-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.6.0")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.8.0
 dafnyVerifyVersion=4.8.0
-mplVersion=1.5.1-SNAPSHOT
+mplVersion=1.6.0


### PR DESCRIPTION
* add ECDH error message for Rust ([#574](https://github.com/aws/aws-cryptographic-material-providers-library/issues/574)) ([473a34a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/473a34abe688629e1a5b8abe8bc859e1128ea40b))
* **DDB-Model:** DDB Supports 100 actions per Transaction ([#692](https://github.com/aws/aws-cryptographic-material-providers-library/issues/692)) ([8a67843](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a6784372ff635828aa15b9edd7a1c7a37a95286))
* GetCurrentTimeStamp returns ISO8601 format ([#575](https://github.com/aws/aws-cryptographic-material-providers-library/issues/575)) ([c07a51f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c07a51fc29ff70411f7573bca96d2a091db8c1ed))
* maintain order in test vectors for languages with parallel tests ([#641](https://github.com/aws/aws-cryptographic-material-providers-library/issues/641)) ([8c8a38f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8c8a38ff3534b8e4f0dca020e65effc454ef330a))
* Remove 4.4 DDB and KMS patches, abstract test to work on later Dafny versions ([#611](https://github.com/aws/aws-cryptographic-material-providers-library/issues/611)) ([d51d648](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d51d6482e3d8ca668111a4695d1adc0c67c3f0a3))
* Remove uses of `:|` ([#618](https://github.com/aws/aws-cryptographic-material-providers-library/issues/618)) ([f12fe5b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f12fe5b4a96a9873eb1b73cee8ae74737f3d2375))
* test vector help text ([#657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/657)) ([0fedaf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0fedaf1466d1e0915faa6b6a533b88a40fb0ee91))

* bump dafny verification and code gen to dafny 4.8.0 ([#520](https://github.com/aws/aws-cryptographic-material-providers-library/issues/520)) ([e16539e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e16539e98d4b0f60098693fdbaec12dc49c34c9b))
* **post-release:** Change back to 1.5.1-SNAPSHOT ([09cd9a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/09cd9a432aeeb7e88da5932f335cd82f95d264b3))

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
