### PR TITLE
test(Mutations): additional testing for Mutations

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -31,12 +31,18 @@ sourceSets {
         runtimeClasspath += sourceSets.test.get().output + sourceSets["examples"].output + sourceSets.main.get().output
     }
 }
-val examplesImplementation by configurations.getting{
+val examplesImplementation: Configuration by configurations.getting{
     extendsFrom(configurations.testImplementation.get())
 }
-val testExamplesImplementation by configurations.getting{
-    extendsFrom(configurations.testImplementation.get())
+configurations.add(examplesImplementation)
+val examplesAnnotationProcessor: Configuration by configurations.getting{
+    extendsFrom(configurations.testAnnotationProcessor.get())
 }
+configurations.add(examplesAnnotationProcessor)
+val testExamplesImplementation: Configuration by configurations.getting{
+    extendsFrom(configurations["examplesImplementation"])
+}
+configurations.add(testExamplesImplementation)
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -107,13 +113,14 @@ dependencies {
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")
 
-    // Example Dependencies are marked as testImplementation
-    testImplementation("software.amazon.awssdk:arns")
-    testImplementation("software.amazon.awssdk:auth")
-    testImplementation("software.amazon.awssdk:sts")
-    testImplementation("software.amazon.awssdk:apache-client:2.19.0")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
-    testImplementation("com.google.code.findbugs:jsr305:3.0.2")
+    // Example Dependencies
+    examplesImplementation("software.amazon.awssdk:arns")
+    examplesImplementation("software.amazon.awssdk:auth")
+    examplesImplementation("software.amazon.awssdk:sts")
+    examplesImplementation("software.amazon.awssdk:utils")
+    examplesImplementation("software.amazon.awssdk:apache-client:2.19.0")
+    examplesAnnotationProcessor("org.projectlombok:lombok:1.18.30")
+    examplesImplementation("com.google.code.findbugs:jsr305:3.0.2")
 
 }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -3,7 +3,6 @@
 package software.amazon.cryptography.example;
 
 import javax.annotation.Nonnull;
-
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.regions.Region;

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -1,0 +1,50 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example;
+
+import javax.annotation.Nonnull;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+public class CredentialUtils {
+
+  public static StsAssumeRoleCredentialsProvider credsForRole(
+    @Nonnull String roleArn,
+    @Nonnull String roleSessionName,
+    @Nonnull Region region,
+    @Nonnull SdkHttpClient httpClient,
+    @Nonnull AwsCredentialsProvider creds
+  ) {
+    StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider
+      .builder()
+      .stsClient(
+        StsClient
+          .builder()
+          .httpClient(httpClient)
+          .region(region)
+          .credentialsProvider(creds)
+          .build()
+      )
+      .refreshRequest(
+        AssumeRoleRequest
+          .builder()
+          .roleArn(roleArn)
+          .roleSessionName(roleSessionName)
+          .durationSeconds(900) // 15 minutes by 60 seconds
+          .build()
+      )
+      .build();
+    // Force credential resolution.
+    // If the host does not have permission to use these credentials,
+    // we want to fail early.
+    // This may not be appropriate in a production environment,
+    // as it is "greedy initialization".
+    provider.resolveCredentials();
+    return provider;
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
@@ -71,6 +71,6 @@ public class AdminProvider {
       .stream()
       .map(item -> String.format("%s : %s", item.itemType(), item.description())
       )
-      .collect(Collectors.joining(",\n "));
+      .collect(Collectors.joining(",\n"));
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
@@ -4,8 +4,10 @@ package software.amazon.cryptography.example.hierarchy;
 
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
 import software.amazon.cryptography.keystoreadmin.model.CreateKeyInput;
 import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
@@ -25,9 +27,10 @@ import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
 public class CreateKeyExample {
 
   public static String CreateKey(
-    String keyStoreTableName,
-    String logicalKeyStoreName,
-    String kmsKeyArn,
+    @Nonnull String keyStoreTableName,
+    @Nonnull String logicalKeyStoreName,
+    @Nonnull String kmsKeyArn,
+    @Nullable String branchKeyId,
     @Nullable DynamoDbClient dynamoDbClient
   ) {
     // 1. Configure your Key Store Admin resource.
@@ -42,8 +45,10 @@ public class CreateKeyExample {
     // If an Identifier is not provided, a v4 UUID will be generated and used.
     // This example provides a combination of a fixed string and a v4 UUID;
     // this makes it easy for Crypto Tools to clean up these Example Branch Keys.
-    final String branchKeyId =
-      "mpl-java-example-" + java.util.UUID.randomUUID().toString();
+    branchKeyId =
+      StringUtils.isBlank(branchKeyId)
+        ? "mpl-java-example-" + java.util.UUID.randomUUID().toString()
+        : branchKeyId;
 
     // 3. Create a custom encryption context for the Branch Key.
     // Most encrypted data should have an associated encryption context
@@ -90,6 +95,6 @@ public class CreateKeyExample {
     final String keyStoreTableName = args[0];
     final String logicalKeyStoreName = args[1];
     final String kmsKeyArn = args[2];
-    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null);
+    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null, null);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
@@ -10,11 +10,16 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class Fixtures {
 
@@ -25,6 +30,17 @@ public class Fixtures {
     "arn:aws:kms:us-west-2:370957321024:key/bc127593-f7da-452c-a1f3-cd34c46f81f8";
   public static final String KEYSTORE_KMS_ARN =
     "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126";
+  public static final String MRK_ARN_EAST =
+    "arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String MRK_ARN_WEST =
+    "arn:aws:kms:us-west-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  // Key MUST NOT exist in ap-south-2
+  public static final String MRK_ARN_AP =
+    "arn:aws:kms:ap-south-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String LIMITED_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-Limited-KMS-us-west-2";
+  public static final String NO_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-No-KMS-us-west-2";
 
   public static final AwsCredentialsProvider defaultCreds =
     DefaultCredentialsProvider.create();
@@ -32,15 +48,23 @@ public class Fixtures {
     .builder()
     .connectionTimeToLive(Duration.ofSeconds(5))
     .build();
-  public static final DynamoDbClient dynamoDbClient = DynamoDbClient
+  public static final DynamoDbClient ddbClientWest2 = DynamoDbClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
     .build();
-  public static final KmsClient kmsClient = KmsClient
+  public static final KmsClient kmsClientWest2 = KmsClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
+    .build();
+  public static final KmsClient kmsClientEast1 = KmsClient
+    .builder()
+    .httpClient(httpClient)
+    .credentialsProvider(defaultCreds)
+    .region(Region.US_EAST_1)
     .build();
 
   public static void deleteKeyStoreDdbItem(
@@ -76,6 +100,45 @@ public class Fixtures {
     dynamoDbClient = AdminProvider.dynamoDB(dynamoDbClient);
     return dynamoDbClient.getItem(builder ->
       builder.tableName(physicalName).key(ddbKey)
+    );
+  }
+
+  public static void cleanUpBranchKeyId(
+    KeyStorageInterface storage,
+    String branchKeyId
+  ) {
+    QueryForVersionsOutput versions = storage.QueryForVersions(
+      QueryForVersionsInput
+        .builder()
+        .Identifier(branchKeyId)
+        .pageSize(99)
+        .build()
+    );
+    String physicalName = storage
+      .GetKeyStorageInfo(GetKeyStorageInfoInput.builder().build())
+      .Name();
+    versions
+      .items()
+      .forEach(item ->
+        deleteKeyStoreDdbItem(
+          item.Identifier(),
+          item.EncryptionContext().get("type"),
+          physicalName,
+          ddbClientWest2
+        )
+      );
+
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "branch:ACTIVE",
+      physicalName,
+      ddbClientWest2
+    );
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "beacon:ACTIVE",
+      physicalName,
+      ddbClientWest2
     );
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
@@ -5,8 +5,6 @@ package software.amazon.cryptography.example.hierarchy;
 import org.testng.annotations.Test;
 import software.amazon.cryptography.example.Fixtures;
 import software.amazon.cryptography.keystore.KeyStorageInterface;
-import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
-import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class ExampleTests {
 
@@ -16,7 +14,8 @@ public class ExampleTests {
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
       Fixtures.KEYSTORE_KMS_ARN,
-      Fixtures.dynamoDbClient
+      null,
+      Fixtures.ddbClientWest2
     );
     branchKeyId =
       MutationExample.End2End(
@@ -24,8 +23,8 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient,
-        Fixtures.kmsClient
+        Fixtures.ddbClientWest2,
+        Fixtures.kmsClientWest2
       );
     branchKeyId =
       VersionKeyExample.VersionKey(
@@ -33,42 +32,13 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient
+        Fixtures.ddbClientWest2
       );
     KeyStorageInterface storage = StorageCheater.create(
-      Fixtures.dynamoDbClient,
+      Fixtures.ddbClientWest2,
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME
     );
-    QueryForVersionsOutput versions = storage.QueryForVersions(
-      QueryForVersionsInput
-        .builder()
-        .Identifier(branchKeyId)
-        .pageSize(10)
-        .build()
-    );
-    versions
-      .items()
-      .forEach(item ->
-        Fixtures.deleteKeyStoreDdbItem(
-          item.Identifier(),
-          item.Type().HierarchicalSymmetricVersion().Version(),
-          Fixtures.TEST_KEYSTORE_NAME,
-          Fixtures.dynamoDbClient
-        )
-      );
-
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "branch:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "beacon:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -1,0 +1,160 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.cryptography.example.CredentialUtils;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
+import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationResult;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.KeyManagementStrategy;
+import software.amazon.cryptography.keystoreadmin.model.MutationToken;
+import software.amazon.cryptography.keystoreadmin.model.Mutations;
+import software.amazon.cryptography.example.Fixtures;
+
+import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;
+import static software.amazon.cryptography.example.Fixtures.POSTAL_HORN_KEY_ARN;
+
+public class MutationKmsAccessInFlightTest {
+  static final String testPrefix = "mutation-kms-access-in-flight-test-";
+  @Test
+  public void test() {
+    KeyStorageInterface storage = StorageCheater.create(
+      Fixtures.ddbClientWest2,
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME
+    );
+    final String branchKeyId = testPrefix + java.util.UUID.randomUUID().toString();
+    CreateKeyExample.CreateKey(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      POSTAL_HORN_KEY_ARN,
+      branchKeyId,
+      Fixtures.ddbClientWest2
+    );
+    KeyManagementStrategy strategyWest2 = AdminProvider.strategy(Fixtures.kmsClientWest2);
+    KmsClient denyMrk = KmsClient.builder()
+        .credentialsProvider(
+          CredentialUtils.credsForRole(
+            Fixtures.LIMITED_KMS_ACCESS_IAM_ROLE,
+            "java-mpl-examples",
+            Region.US_WEST_2,
+            Fixtures.httpClient,
+            Fixtures.defaultCreds))
+      .region(Region.US_WEST_2)
+      .httpClient(Fixtures.httpClient)
+      .build();
+
+    KeyManagementStrategy strategyDenyMrk = AdminProvider.strategy(denyMrk);
+    KeyStoreAdmin admin = AdminProvider.admin(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      Fixtures.ddbClientWest2
+    );
+
+    System.out.println("BranchKey ID to mutate: " + branchKeyId);
+    HashMap<String, String> terminalEC = new HashMap<>();
+    terminalEC.put("Robbie", "is a dog.");
+
+    Mutations mutations = Mutations
+      .builder()
+      .terminalEncryptionContext(terminalEC)
+      .terminalKmsArn(MRK_ARN_WEST)
+      .build();
+
+    InitializeMutationInput initInput = InitializeMutationInput
+      .builder()
+      .mutations(mutations)
+      .branchKeyIdentifier(branchKeyId)
+      .strategy(strategyWest2)
+      .build();
+
+    InitializeMutationOutput initOutput = admin.InitializeMutation(initInput);
+    MutationToken token = initOutput.mutationToken();
+    System.out.println(
+      "InitLogs: " +
+      branchKeyId +
+      " items: \n" +
+      AdminProvider.mutatedItemsToString(initOutput.mutatedBranchKeyItems())
+    );
+    boolean done = false;
+    List<KmsException> kmsExceptions = new ArrayList<>();
+    boolean isFromThrown = false;
+    boolean isToThrown = false;
+    int limitLoop = 5;
+
+    while (!done) {
+      try {
+        limitLoop--;
+        if (limitLoop == 0) done = true;
+        ApplyMutationInput applyInput = ApplyMutationInput
+          .builder()
+          .mutationToken(token)
+          .pageSize(1)
+          .strategy(strategyDenyMrk)
+          .build();
+        ApplyMutationOutput applyOutput = admin.ApplyMutation(applyInput);
+        ApplyMutationResult result = applyOutput.result();
+        System.out.println(
+          "ApplyLogs: " +
+          branchKeyId +
+          " items: \n" +
+          AdminProvider.mutatedItemsToString(applyOutput.mutatedBranchKeyItems())
+        );
+
+        if (result.continueMutation() != null) token = result.continueMutation();
+        if (result.completeMutation() != null) done = true;
+
+      } catch (KmsException accessDenied) {
+        boolean isFrom = accessDenied.getMessage().contains("ReEncryptFrom");
+        isFromThrown = isFromThrown || isFrom;
+        boolean isTo = accessDenied.getMessage().contains("ReEncryptTo");
+        isToThrown = isToThrown || isTo;
+        Assert.assertTrue((isTo || isFrom),
+          "KMS Exception does not meet expectations. testId: " + branchKeyId + ". KMS Exception: " + accessDenied);
+        kmsExceptions.add(accessDenied);
+        // An exception was thrown, let's delete the item
+        QueryForVersionsOutput versions = storage.QueryForVersions(
+          QueryForVersionsInput
+            .builder()
+            .Identifier(branchKeyId)
+            .pageSize(1)
+            .build()
+        );
+        versions
+          .items()
+          .forEach(item ->
+            Fixtures.deleteKeyStoreDdbItem(
+              item.Identifier(),
+              item.EncryptionContext().get("type"),
+              Fixtures.TEST_KEYSTORE_NAME,
+              Fixtures.ddbClientWest2
+            )
+          );
+      }
+    }
+
+    // Clean Up
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
+    Assert.assertTrue((kmsExceptions.size() == 2),
+      "More KMS Exceptions thrown than expected. kmsExceptions: " + kmsExceptions);
+    Assert.assertTrue(isFromThrown, "Apply never verified the new decrypt.");
+    Assert.assertTrue(isToThrown, "Apply never mutated the old decrypt.");
+  }
+
+}


### PR DESCRIPTION
I will merge this after I give @josecorella  a chance to see if #751 addresses other concerns.

Verification failure is due to:
1. Key Store Admin's Index.dfy not proving Fresh, which has been a long standing issue with the Admin
2. In `AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy`, the test assumes `type` is in the Encryption Context. It is, but Structure.dfy does not prove that, so it must be proven else where.

A Dotnet DDB Test failed due to throttling from Nuget.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
