### PR TITLE
feat(KS+): More modeled errors

### DIFF
--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
-index 0b153802..56aef9ec 100644
+index 0b153802b..56aef9ec6 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
 @@ -3903,7 +3903,9 @@ namespace AWS.Cryptography.MaterialProviders

--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/dotnet/dafny-4.8.0.patch
@@ -1,8 +1,8 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
-index cc3dc4cd..63100b40 100644
+index 2804c8f21..868d600b3 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
-@@ -1727,7 +1727,7 @@ namespace AWS.Cryptography.KeyStore
+@@ -1875,7 +1875,7 @@ namespace AWS.Cryptography.KeyStore
              dafnyVal._ComAmazonawsDynamodb
            );
          case software.amazon.cryptography.keystore.internaldafny.types.Error_ComAmazonawsKms dafnyVal:
@@ -10,8 +10,8 @@ index cc3dc4cd..63100b40 100644
 +          return Com.Amazonaws.Kms.TypeConversion.FromDafny_CommonError( // Manual edit KMS. -> Kms.
              dafnyVal._ComAmazonawsKms
            );
-         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException dafnyVal:
-@@ -1754,7 +1754,7 @@ namespace AWS.Cryptography.KeyStore
+         case software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed dafnyVal:
+@@ -1910,7 +1910,7 @@ namespace AWS.Cryptography.KeyStore
        {
          case "Com.Amazonaws.KMS":
            return software.amazon.cryptography.keystore.internaldafny.types.Error.create_ComAmazonawsKms(
@@ -20,16 +20,3 @@ index cc3dc4cd..63100b40 100644
            );
          case "Com.Amazonaws.Dynamodb":
            return software.amazon.cryptography.keystore.internaldafny.types.Error.create_ComAmazonawsDynamodb(
-diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-index 16da0962..9607f4a4 100644
---- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-+++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-@@ -11,7 +11,7 @@ namespace AWS.Cryptography.KeyStore
-     private string _identifier;
-     private System.IO.MemoryStream _original;
-     private System.IO.MemoryStream _terminal;
--    private bool? _completeMutation;
-+    private bool? _completeMutation = false; // Manual edit to default false
-     public System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> Items
-     {
-       get { return this._items; }

--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStoreAdmin/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStoreAdmin/dotnet/dafny-4.8.0.patch
@@ -1,8 +1,8 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
-index b8ad30a5..4904d73b 100644
+index fa79a35cd..97802ad43 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
-@@ -1056,7 +1056,8 @@ namespace AWS.Cryptography.KeyStoreAdmin
+@@ -963,7 +963,8 @@ namespace AWS.Cryptography.KeyStoreAdmin
              dafnyVal._ComAmazonawsDynamodb
            );
          case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_ComAmazonawsKms dafnyVal:

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -38,6 +38,12 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly encryptionContext: EncryptionContext ,
     nameonly branchKey: Secret
   )
+  datatype ClobberMutationLockInput = | ClobberMutationLockInput (
+    nameonly mutationLock: MutationLock
+  )
+  datatype ClobberMutationLockOutput = | ClobberMutationLockOutput (
+
+                                       )
   datatype CreateKeyInput = | CreateKeyInput (
     nameonly branchKeyIdentifier: Option<string> := Option.None ,
     nameonly encryptionContext: Option<EncryptionContext> := Option.None
@@ -129,6 +135,12 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly grantTokens: GrantTokenList ,
     nameonly kmsConfiguration: KMSConfiguration
   )
+  datatype GetMutationLockInput = | GetMutationLockInput (
+    nameonly Identifier: string
+  )
+  datatype GetMutationLockOutput = | GetMutationLockOutput (
+    nameonly mutationLock: Option<MutationLock> := Option.None
+  )
   type GrantTokenList = seq<string>
   datatype HierarchicalKeyType =
     | ActiveHierarchicalSymmetricVersion(ActiveHierarchicalSymmetricVersion: ActiveHierarchicalSymmetric)
@@ -147,8 +159,10 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       WriteNewEncryptedBranchKey := [];
       WriteInitializeMutation := [];
       GetItemsForInitializeMutation := [];
+      GetMutationLock := [];
       WriteNewEncryptedBranchKeyVersion := [];
       QueryForVersions := [];
+      ClobberMutationLock := [];
       GetKeyStorageInfo := [];
       GetEncryptedBranchKeyVersion := [];
       GetEncryptedBeaconKey := [];
@@ -158,8 +172,10 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     ghost var WriteNewEncryptedBranchKey: seq<DafnyCallEvent<WriteNewEncryptedBranchKeyInput, Result<WriteNewEncryptedBranchKeyOutput, Error>>>
     ghost var WriteInitializeMutation: seq<DafnyCallEvent<WriteInitializeMutationInput, Result<WriteInitializeMutationOutput, Error>>>
     ghost var GetItemsForInitializeMutation: seq<DafnyCallEvent<GetItemsForInitializeMutationInput, Result<GetItemsForInitializeMutationOutput, Error>>>
+    ghost var GetMutationLock: seq<DafnyCallEvent<GetMutationLockInput, Result<GetMutationLockOutput, Error>>>
     ghost var WriteNewEncryptedBranchKeyVersion: seq<DafnyCallEvent<WriteNewEncryptedBranchKeyVersionInput, Result<WriteNewEncryptedBranchKeyVersionOutput, Error>>>
     ghost var QueryForVersions: seq<DafnyCallEvent<QueryForVersionsInput, Result<QueryForVersionsOutput, Error>>>
+    ghost var ClobberMutationLock: seq<DafnyCallEvent<ClobberMutationLockInput, Result<ClobberMutationLockOutput, Error>>>
     ghost var GetKeyStorageInfo: seq<DafnyCallEvent<GetKeyStorageInfoInput, Result<GetKeyStorageInfoOutput, Error>>>
     ghost var GetEncryptedBranchKeyVersion: seq<DafnyCallEvent<GetEncryptedBranchKeyVersionInput, Result<GetEncryptedBranchKeyVersionOutput, Error>>>
     ghost var GetEncryptedBeaconKey: seq<DafnyCallEvent<GetEncryptedBeaconKeyInput, Result<GetEncryptedBeaconKeyOutput, Error>>>
@@ -346,6 +362,37 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       ensures GetItemsForInitializeMutationEnsuresPublicly(input, output)
       ensures unchanged(History)
 
+    predicate GetMutationLockEnsuresPublicly(input: GetMutationLockInput , output: Result<GetMutationLockOutput, Error>)
+    // The public method to be called by library consumers
+    method GetMutationLock ( input: GetMutationLockInput )
+      returns (output: Result<GetMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetMutationLock
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetMutationLockEnsuresPublicly(input, output)
+      ensures History.GetMutationLock == old(History.GetMutationLock) + [DafnyCallEvent(input, output)]
+    {
+      output := GetMutationLock' (input);
+      History.GetMutationLock := History.GetMutationLock + [DafnyCallEvent(input, output)];
+    }
+    // The method to implement in the concrete class.
+    method GetMutationLock' ( input: GetMutationLockInput )
+      returns (output: Result<GetMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History}
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetMutationLockEnsuresPublicly(input, output)
+      ensures unchanged(History)
+
     predicate WriteNewEncryptedBranchKeyVersionEnsuresPublicly(input: WriteNewEncryptedBranchKeyVersionInput , output: Result<WriteNewEncryptedBranchKeyVersionOutput, Error>)
     // The public method to be called by library consumers
     method WriteNewEncryptedBranchKeyVersion ( input: WriteNewEncryptedBranchKeyVersionInput )
@@ -406,6 +453,37 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       ensures
         && ValidState()
       ensures QueryForVersionsEnsuresPublicly(input, output)
+      ensures unchanged(History)
+
+    predicate ClobberMutationLockEnsuresPublicly(input: ClobberMutationLockInput , output: Result<ClobberMutationLockOutput, Error>)
+    // The public method to be called by library consumers
+    method ClobberMutationLock ( input: ClobberMutationLockInput )
+      returns (output: Result<ClobberMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`ClobberMutationLock
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures ClobberMutationLockEnsuresPublicly(input, output)
+      ensures History.ClobberMutationLock == old(History.ClobberMutationLock) + [DafnyCallEvent(input, output)]
+    {
+      output := ClobberMutationLock' (input);
+      History.ClobberMutationLock := History.ClobberMutationLock + [DafnyCallEvent(input, output)];
+    }
+    // The method to implement in the concrete class.
+    method ClobberMutationLock' ( input: ClobberMutationLockInput )
+      returns (output: Result<ClobberMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History}
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures ClobberMutationLockEnsuresPublicly(input, output)
       ensures unchanged(History)
 
     predicate GetKeyStorageInfoEnsuresPublicly(input: GetKeyStorageInfoInput , output: Result<GetKeyStorageInfoOutput, Error>)
@@ -737,10 +815,22 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
                                                      )
   datatype Error =
       // Local Error structures are listed here
+    | AlreadyExistsConditionFailed (
+        nameonly message: string
+      )
     | KeyStorageException (
         nameonly message: string
       )
     | KeyStoreException (
+        nameonly message: string
+      )
+    | MutationLockConditionFailed (
+        nameonly message: string
+      )
+    | NoLongerExistsConditionFailed (
+        nameonly message: string
+      )
+    | OldEncConditionFailed (
         nameonly message: string
       )
     | VersionRaceException (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -39,7 +39,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly branchKey: Secret
   )
   datatype ClobberMutationLockInput = | ClobberMutationLockInput (
-    nameonly mutationLock: MutationLock
+    nameonly MutationLock: MutationLock
   )
   datatype ClobberMutationLockOutput = | ClobberMutationLockOutput (
 
@@ -117,9 +117,9 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly Identifier: string
   )
   datatype GetItemsForInitializeMutationOutput = | GetItemsForInitializeMutationOutput (
-    nameonly activeItem: EncryptedHierarchicalKey ,
-    nameonly beaconItem: EncryptedHierarchicalKey ,
-    nameonly mutationLock: Option<MutationLock> := Option.None
+    nameonly ActiveItem: EncryptedHierarchicalKey ,
+    nameonly BeaconItem: EncryptedHierarchicalKey ,
+    nameonly MutationLock: Option<MutationLock> := Option.None
   )
   datatype GetKeyStorageInfoInput = | GetKeyStorageInfoInput (
 
@@ -139,7 +139,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly Identifier: string
   )
   datatype GetMutationLockOutput = | GetMutationLockOutput (
-    nameonly mutationLock: Option<MutationLock> := Option.None
+    nameonly MutationLock: Option<MutationLock> := Option.None
   )
   type GrantTokenList = seq<string>
   datatype HierarchicalKeyType =
@@ -758,13 +758,13 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly Terminal: seq<uint8>
   )
   datatype QueryForVersionsInput = | QueryForVersionsInput (
-    nameonly exclusiveStartKey: Option<seq<uint8>> := Option.None ,
+    nameonly ExclusiveStartKey: Option<seq<uint8>> := Option.None ,
     nameonly Identifier: string ,
-    nameonly pageSize: int32
+    nameonly PageSize: int32
   )
   datatype QueryForVersionsOutput = | QueryForVersionsOutput (
-    nameonly exclusiveStartKey: seq<uint8> ,
-    nameonly items: EncryptedHierarchicalKeys
+    nameonly ExclusiveStartKey: seq<uint8> ,
+    nameonly Items: EncryptedHierarchicalKeys
   )
   type Secret = seq<uint8>
   datatype Storage =
@@ -778,17 +778,17 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
 
                               )
   datatype WriteInitializeMutationInput = | WriteInitializeMutationInput (
-    nameonly active: EncryptedHierarchicalKey ,
-    nameonly oldActive: EncryptedHierarchicalKey ,
-    nameonly version: EncryptedHierarchicalKey ,
-    nameonly beacon: EncryptedHierarchicalKey ,
-    nameonly mutationLock: MutationLock
+    nameonly Active: EncryptedHierarchicalKey ,
+    nameonly OldActive: EncryptedHierarchicalKey ,
+    nameonly Version: EncryptedHierarchicalKey ,
+    nameonly Beacon: EncryptedHierarchicalKey ,
+    nameonly MutationLock: MutationLock
   )
   datatype WriteInitializeMutationOutput = | WriteInitializeMutationOutput (
 
                                            )
   datatype WriteMutatedVersionsInput = | WriteMutatedVersionsInput (
-    nameonly items: EncryptedHierarchicalKeys ,
+    nameonly Items: EncryptedHierarchicalKeys ,
     nameonly Identifier: string ,
     nameonly Original: seq<uint8> ,
     nameonly Terminal: seq<uint8> ,
@@ -808,7 +808,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
   datatype WriteNewEncryptedBranchKeyVersionInput = | WriteNewEncryptedBranchKeyVersionInput (
     nameonly Active: EncryptedHierarchicalKey ,
     nameonly Version: EncryptedHierarchicalKey ,
-    nameonly oldActive: EncryptedHierarchicalKey
+    nameonly OldActive: EncryptedHierarchicalKey
   )
   datatype WriteNewEncryptedBranchKeyVersionOutput = | WriteNewEncryptedBranchKeyVersionOutput (
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/Storage.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/Storage.smithy
@@ -313,7 +313,7 @@ structure WriteNewEncryptedBranchKeyVersionInput {
   This means that when updating the current active record
   the existing active record should be equal to this value.
   ")
-  oldActive: EncryptedHierarchicalKey
+  OldActive: EncryptedHierarchicalKey
 }
 @documentation("The output of writing a new version for an existing branch key. There is currently no additional information returned.")
 structure WriteNewEncryptedBranchKeyVersionOutput {}
@@ -406,12 +406,12 @@ structure GetItemsForInitializeMutationInput {
 structure GetItemsForInitializeMutationOutput {
   @required
   @documentation("The materials for the Branch Key.")
-  activeItem: EncryptedHierarchicalKey
+  ActiveItem: EncryptedHierarchicalKey
   @documentation("The materials for the Beacon Key.")
   @required
-  beaconItem: EncryptedHierarchicalKey
+  BeaconItem: EncryptedHierarchicalKey
   @documentation("The Mutation Lock, if it exists.")
-  mutationLock: MutationLock
+  MutationLock: MutationLock
 }
 
 structure WriteInitializeMutationInput {
@@ -420,28 +420,28 @@ structure WriteInitializeMutationInput {
   The active representation of this branch key,
   generated with the Mutation's terminal properities.  
   The plain-text cryptographic material of the Active must be the same as the Version.")
-  active: EncryptedHierarchicalKey,
+  Active: EncryptedHierarchicalKey,
   @required
   @documentation("
   The previous active version.
   This key should be used as an optimistic lock on the new version.
   This means that when updating the current active record
   the existing active record should be equal to this value.")
-  oldActive: EncryptedHierarchicalKey,
+  OldActive: EncryptedHierarchicalKey,
   @required
   @documentation("
   The decrypt representation of this branch key version,
   generated with the Mutation's terminal properities.  
   The plain-text cryptographic material of the `Version` must be the same as the `Active`.")
-  version: EncryptedHierarchicalKey,
+  Version: EncryptedHierarchicalKey,
   @required
   @documentation("
   The mutated HMAC key used to support searchable encryption.
   The cryptographic material is identical to the existing beacon,
   but is now authorized with the Mutation's terminal properities.")
-  beacon: EncryptedHierarchicalKey,
+  Beacon: EncryptedHierarchicalKey,
   @required // Smithy will copy documentation traits from existing shapes
-  mutationLock: MutationLock
+  MutationLock: MutationLock
 }
 structure WriteInitializeMutationOutput {}
 
@@ -458,13 +458,13 @@ structure QueryForVersionsInput {
   see Amazon DynamoDB's defination of exclusiveStartKey for details.
   Note: While the Default Storage is DDB,
   the Key Store transforms the exclusiveStartKey into an opaque representation.")
-  exclusiveStartKey: Blob
+  ExclusiveStartKey: Blob
   @required
   @documentation("The Identifier of the Branch Key.")
   Identifier: String
   @required // @range(min: 1) Smithy-Dafny may not respect range
   @documentation("The maximum read items.")
-  pageSize: Integer
+  PageSize: Integer
 }
 
 structure QueryForVersionsOutput {
@@ -476,16 +476,16 @@ structure QueryForVersionsOutput {
   Note: While the Default Storage is DDB,
   the Key Store transforms the exclusiveStartKey into an opaque representation.")
   @required
-  exclusiveStartKey: Blob
+  ExclusiveStartKey: Blob
   @documentation("Up to pageSize list of version (decrypt only) items of a Branch Key.")
   @required
-  items: EncryptedHierarchicalKeys
+  Items: EncryptedHierarchicalKeys
 }
 
 structure WriteMutatedVersionsInput {
   @documentation("List of version (decrypt only) items of a Branch Key to overwrite conditionally.")
   @required
-  items: EncryptedHierarchicalKeys
+  Items: EncryptedHierarchicalKeys
   @documentation("The Identifier of the Branch Key.")  
   @required
   Identifier: String
@@ -517,7 +517,7 @@ structure GetMutationLockInput {
 }
 structure GetMutationLockOutput {
   @documentation("If not present, there is no Mutation Lock.")
-  mutationLock: MutationLock
+  MutationLock: MutationLock
 }
 
 @documentation("Overwrite an existing Mutation Lock.")
@@ -531,7 +531,7 @@ operation ClobberMutationLock {
 }
 structure ClobberMutationLockInput {
   @required
-  mutationLock: MutationLock
+  MutationLock: MutationLock
 }
 structure ClobberMutationLockOutput {}
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
@@ -546,7 +546,7 @@ module {:options "/functionSyntax:4" } CreateKeys {
           decryptOnlyEncryptionContext,
           wrappedDecryptOnlyBranchKey.CiphertextBlob.value
         ),
-        oldActive := oldActiveItem
+        OldActive := oldActiveItem
       )
     );
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -171,9 +171,11 @@ module DefaultKeyStorageInterface {
             && output.value.activeItem.Identifier == input.Identifier
             && Structure.ActiveHierarchicalSymmetricKey?(output.value.activeItem)
             && output.value.activeItem.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+            && KmsArn.ValidKmsArn?(output.value.activeItem.KmsArn)
             && output.value.beaconItem.Identifier == input.Identifier
             && Structure.ActiveHierarchicalSymmetricBeaconKey?(output.value.beaconItem)
             && output.value.beaconItem.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+            && KmsArn.ValidKmsArn?(output.value.beaconItem.KmsArn)
       )
     }
 
@@ -194,6 +196,7 @@ module DefaultKeyStorageInterface {
               && Structure.DecryptOnlyHierarchicalSymmetricKey?(item)
               && item.Type.HierarchicalSymmetricVersion?
               && item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+              && KmsArn.ValidKmsArn?(item.KmsArn)
       )
     }
 
@@ -963,6 +966,7 @@ module DefaultKeyStorageInterface {
                 && Structure.EncryptedHierarchicalKey?(output.value)
                 && output.value.Identifier == identifier
                 && output.value.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+                && KmsArn.ValidKmsArn?(output.value.KmsArn)
     {
       :- Need(
            Structure.BranchKeyItem?(item),
@@ -970,17 +974,18 @@ module DefaultKeyStorageInterface {
              message:="Malformed Branch Key Store Item encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      var item := ToEncryptedHierarchicalKey(item, logicalKeyStoreName);
+      var branchKey := ToEncryptedHierarchicalKey(branchKey, logicalKeyStoreName);
 
-      assert item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
+      assert branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
       :- Need(
-           && item.Identifier == identifier
-           && item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName,
+           && branchKey.Identifier == identifier
+           && branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+           && KmsArn.ValidKmsArn?(branchKey.KmsArn),
            Types.KeyStorageException(
-             message:="Malformed Branch Key Store Item encountered. TableName: "
+             message:="Malformed Branch Key Store BranchKey encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      Success(item)
+      Success(branchKey)
     }
 
     /** A transaction write for 4 items, conditioned on No Mutation Lock exsisting for Identifier.*/

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -974,7 +974,7 @@ module DefaultKeyStorageInterface {
              message:="Malformed Branch Key Store Item encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      var branchKey := ToEncryptedHierarchicalKey(branchKey, logicalKeyStoreName);
+      var branchKey := ToEncryptedHierarchicalKey(item, logicalKeyStoreName);
 
       assert branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
       :- Need(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
@@ -363,8 +363,8 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
       GrantTokens := Some(grantTokens)
     );
 
-    var maybeReEncryptResponse := kmsClient.ReEncrypt(reEncryptRequest);
-    var reEncryptResponse :- maybeReEncryptResponse
+    var reEncryptResponse? := kmsClient.ReEncrypt(reEncryptRequest);
+    var reEncryptResponse :- reEncryptResponse?
     .MapFailure(e => Types.ComAmazonawsKms(ComAmazonawsKms := e));
 
     :- Need(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/Structure.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/Structure.dfy
@@ -23,7 +23,8 @@ module {:options "/functionSyntax:4" } Structure {
   const M_LOCK_TERMINAL := "terminal" // The DDB Attribute name for the terminal state, which is AttributeValue.B
   const M_LOCK_UUID := "uuid" // The DDB Attribute name for the uuid, which is AttributeValue.S
 
-  const ENCRYPTION_CONTEXT_PREFIX := "aws-crypto-ec:"
+  const AWS_CRYPTO_EC := "aws-crypto-ec"
+  const ENCRYPTION_CONTEXT_PREFIX := AWS_CRYPTO_EC + ":"
 
   const BRANCH_KEY_RESTRICTED_FIELD_NAMES := {
     BRANCH_KEY_IDENTIFIER_FIELD,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
@@ -28,19 +28,19 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := Fixtures.branchKeyId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
-    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+    expect Structure.TYPE_FIELD in output.ActiveItem.EncryptionContext,
                                    "`type` missing from activeItem!";
     expect
-      output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
-      "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
-    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+      output.ActiveItem.Type.ActiveHierarchicalSymmetricVersion?,
+      "activeItem was not Active? 'type': " + output.ActiveItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.BeaconItem.EncryptionContext,
                                    "`type` missing from beaconItem!";
     expect
-      output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
-      "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];
+      output.BeaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
+      "beaconItem was not Beacon? 'type': " + output.BeaconItem.EncryptionContext[Structure.TYPE_FIELD];
     expect
-      output.mutationLock.None?,
-      "MutationLock was not None. 'UUID': " + output.mutationLock.value.UUID;
+      output.MutationLock.None?,
+      "MutationLock was not None. 'UUID': " + output.MutationLock.value.UUID;
   }
 
   method {:test} TestHappyCaseMLocked()
@@ -50,18 +50,18 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := mLockedId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
-    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+    expect Structure.TYPE_FIELD in output.ActiveItem.EncryptionContext,
                                    "`type` missing from activeItem!";
     expect
-      output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
-      "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
-    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+      output.ActiveItem.Type.ActiveHierarchicalSymmetricVersion?,
+      "activeItem was not Active? 'type': " + output.ActiveItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.BeaconItem.EncryptionContext,
                                    "`type` missing from beaconItem!";
     expect
-      output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
-      "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];
+      output.BeaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
+      "beaconItem was not Beacon? 'type': " + output.BeaconItem.EncryptionContext[Structure.TYPE_FIELD];
     expect
-      output.mutationLock.Some?,
+      output.MutationLock.Some?,
       "MutationLock was not Some.";
   }
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
@@ -23,18 +23,7 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
 
   method {:test} TestHappyCase()
   {
-    // var underTest :- expect Fixtures.DefaultStorage();
-    var ddbClient :- expect DDB.DynamoDBClient();
-    // The next two assumes are tragic
-    assume {:axiom} UTF8.Encode(physicalName).Success? && UTF8.EncodeAscii(physicalName) == UTF8.Encode(physicalName).value;
-    assume {:axiom} UTF8.Encode(logicalName).Success? && UTF8.EncodeAscii(logicalName) == UTF8.Encode(logicalName).value;
-    var underTest := new DefaultKeyStorageInterface.DynamoDBKeyStorageInterface(
-      ddbTableName := physicalName,
-      ddbClient := ddbClient,
-      logicalKeyStoreName := logicalName,
-      ddbTableNameUtf8 := UTF8.EncodeAscii(physicalName),
-      logicalKeyStoreNameUtf8 := UTF8.EncodeAscii(logicalName)
-    );
+    var underTest :- expect Fixtures.DefaultStorage();
     var input := Types.GetItemsForInitializeMutationInput(
       Identifier := Fixtures.branchKeyId
     );
@@ -52,18 +41,7 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
 
   method {:test} TestHappyCaseMLocked()
   {
-    // var underTest :- expect Fixtures.DefaultStorage();
-    // The next two assumes are tragic
-    assume {:axiom} UTF8.Encode(physicalName).Success? && UTF8.EncodeAscii(physicalName) == UTF8.Encode(physicalName).value;
-    assume {:axiom} UTF8.Encode(logicalName).Success? && UTF8.EncodeAscii(logicalName) == UTF8.Encode(logicalName).value;
-    var ddbClient :- expect DDB.DynamoDBClient();
-    var underTest := new DefaultKeyStorageInterface.DynamoDBKeyStorageInterface(
-      ddbTableName := physicalName,
-      ddbClient := ddbClient,
-      logicalKeyStoreName := logicalName,
-      ddbTableNameUtf8 := UTF8.EncodeAscii(physicalName),
-      logicalKeyStoreNameUtf8 := UTF8.EncodeAscii(logicalName)
-    );
+    var underTest :- expect Fixtures.DefaultStorage();
     var input := Types.GetItemsForInitializeMutationInput(
       Identifier := mLockedId
     );

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
@@ -28,9 +28,13 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := Fixtures.branchKeyId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
+    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+                                   "`type` missing from activeItem!";
     expect
       output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
       "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+                                   "`type` missing from beaconItem!";
     expect
       output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
       "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];
@@ -46,10 +50,13 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := mLockedId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
-
+    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+                                   "`type` missing from activeItem!";
     expect
       output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
       "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+                                   "`type` missing from beaconItem!";
     expect
       output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
       "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestQueryForVersions.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestQueryForVersions.dfy
@@ -34,7 +34,7 @@ module {:options "/functionSyntax:4"} TestQueryForVersions {
 
     inputQuery := Types.QueryForVersionsInput(
       Identifier := happyCaseId,
-      pageSize := 2
+      PageSize := 2
     );
 
     var pageLimit := 3;
@@ -46,13 +46,13 @@ module {:options "/functionSyntax:4"} TestQueryForVersions {
       print "\nTestQueryForVersions :: TestHappyCase :: pre-Query "
             + String.Base10Int2String(queryCount+1)  +
             " :: Input Start Key is None? :: " +
-            (if inputQuery.exclusiveStartKey.None? then "True" else "False")
+            (if inputQuery.ExclusiveStartKey.None? then "True" else "False")
             + "\n";
       assume {:axiom} underTest.Modifies == {}; // Turns off verification
       queryOut :- expect underTest.QueryForVersions(inputQuery);
       queryCount := queryCount + 1;
-      items := queryOut.items;
-      startKey := queryOut.exclusiveStartKey;
+      items := queryOut.Items;
+      startKey := queryOut.ExclusiveStartKey;
       strStartKey := "";
 
       if (|items| > 0) {
@@ -78,8 +78,8 @@ module {:options "/functionSyntax:4"} TestQueryForVersions {
 
       inputQuery := Types.QueryForVersionsInput(
         Identifier := inputQuery.Identifier,
-        pageSize := inputQuery.pageSize,
-        exclusiveStartKey := if |startKey| > 0 then Some(startKey) else None()
+        PageSize := inputQuery.PageSize,
+        ExclusiveStartKey := if |startKey| > 0 then Some(startKey) else None()
       );
       pageIndex := pageIndex + 1;
     }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestWriteAndDeleteMutationLock.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestWriteAndDeleteMutationLock.dfy
@@ -71,11 +71,11 @@ module {:options "/functionSyntax:4"} TestWriteAndDeleteMutationLock {
     );
 
     var inputInit := Types.WriteInitializeMutationInput(
-      active := allThree.active,
-      oldActive := allThree.active,
-      version := allThree.decrypt,
-      beacon := allThree.beacon,
-      mutationLock := mLock
+      Active := allThree.active,
+      OldActive := allThree.active,
+      Version := allThree.decrypt,
+      Beacon := allThree.beacon,
+      MutationLock := mLock
     );
 
     var writeInit :- expect underTest.WriteInitializeMutation(inputInit);
@@ -94,7 +94,7 @@ module {:options "/functionSyntax:4"} TestWriteAndDeleteMutationLock {
     print "\nTestWriteAndDeleteMutationLock :: TestHappyCase :: WriteInit PASS\n";
 
     var writeCompl := Types.WriteMutatedVersionsInput(
-      items := [],
+      Items := [],
       Identifier := testId,
       Original := original,
       Terminal := terminal,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestWriteMutatedVersions.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestWriteMutatedVersions.dfy
@@ -39,11 +39,11 @@ module {:options "/functionSyntax:4"} TestWriteMutatedVersions {
           + testId  +  "\n";
     var inputQuery := Types.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
 
     var queryOut :- expect underTest.QueryForVersions(inputQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
     expect
       |items| == 4,
       "Test expects there to be 4 Decrypt Only items! Found: " + String.Base10Int2String(|items|);
@@ -67,7 +67,7 @@ module {:options "/functionSyntax:4"} TestWriteMutatedVersions {
     }
 
     var input := Types.WriteMutatedVersionsInput(
-      items := mutatedItems,
+      Items := mutatedItems,
       Identifier := testId,
       Original := original,
       Terminal := terminal,
@@ -79,7 +79,7 @@ module {:options "/functionSyntax:4"} TestWriteMutatedVersions {
           + testId  +  "\n";
 
     queryOut :- expect underTest.QueryForVersions(inputQuery);
-    items := queryOut.items;
+    items := queryOut.Items;
     print "\nTestWriteMutatedVersions :: TestHappyCase :: Read the \"mutated\" test items! testId: "
           + testId  +  "\n";
     itemIndex := 0;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestVersionKey.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestVersionKey.dfy
@@ -359,7 +359,7 @@ module TestVersionKey {
       Types.WriteNewEncryptedBranchKeyVersionInput(
         Version := Version,
         Active := Active,
-        oldActive := Active
+        OldActive := Active
       )
     );
 
@@ -404,7 +404,7 @@ module TestVersionKey {
       Types.WriteNewEncryptedBranchKeyVersionInput(
         Version := Version,
         Active := Active,
-        oldActive := Active
+        OldActive := Active
       )
     );
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
@@ -193,10 +193,19 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny.types"
     | MutationConflictException (
         nameonly message: string
       )
+    | MutationFromException (
+        nameonly message: string
+      )
     | MutationInvalidException (
         nameonly message: string
       )
     | MutationLockInvalidException (
+        nameonly message: string
+      )
+    | MutationToException (
+        nameonly message: string
+      )
+    | MutationVerificationException (
         nameonly message: string
       )
     | UnexpectedStateException (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
@@ -19,34 +19,34 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny.types"
   // Begin Generated Types
 
   datatype ApplyMutationInput = | ApplyMutationInput (
-    nameonly mutationToken: MutationToken ,
-    nameonly pageSize: Option<int32> := Option.None ,
-    nameonly strategy: Option<KeyManagementStrategy> := Option.None
+    nameonly MutationToken: MutationToken ,
+    nameonly PageSize: Option<int32> := Option.None ,
+    nameonly Strategy: Option<KeyManagementStrategy> := Option.None
   )
   datatype ApplyMutationOutput = | ApplyMutationOutput (
-    nameonly result: ApplyMutationResult ,
-    nameonly mutatedBranchKeyItems: MutatedBranchKeyItems
+    nameonly MutationResult: ApplyMutationResult ,
+    nameonly MutatedBranchKeyItems: MutatedBranchKeyItems
   )
   datatype ApplyMutationResult =
-    | continueMutation(continueMutation: MutationToken)
-    | completeMutation(completeMutation: MutationComplete)
+    | ContinueMutation(ContinueMutation: MutationToken)
+    | CompleteMutation(CompleteMutation: MutationComplete)
   datatype CreateKeyInput = | CreateKeyInput (
-    nameonly branchKeyIdentifier: Option<string> := Option.None ,
-    nameonly encryptionContext: Option<AwsCryptographyKeyStoreTypes.EncryptionContext> := Option.None ,
-    nameonly kmsArn: KMSIdentifier ,
-    nameonly strategy: Option<KeyManagementStrategy> := Option.None
+    nameonly Identifier: Option<string> := Option.None ,
+    nameonly EncryptionContext: Option<AwsCryptographyKeyStoreTypes.EncryptionContext> := Option.None ,
+    nameonly KmsArn: KMSIdentifier ,
+    nameonly Strategy: Option<KeyManagementStrategy> := Option.None
   )
   datatype CreateKeyOutput = | CreateKeyOutput (
-    nameonly branchKeyIdentifier: string
+    nameonly Identifier: string
   )
   datatype InitializeMutationInput = | InitializeMutationInput (
-    nameonly branchKeyIdentifier: string ,
-    nameonly mutations: Mutations ,
-    nameonly strategy: Option<KeyManagementStrategy> := Option.None
+    nameonly Identifier: string ,
+    nameonly Mutations: Mutations ,
+    nameonly Strategy: Option<KeyManagementStrategy> := Option.None
   )
   datatype InitializeMutationOutput = | InitializeMutationOutput (
-    nameonly mutationToken: MutationToken ,
-    nameonly mutatedBranchKeyItems: MutatedBranchKeyItems
+    nameonly MutationToken: MutationToken ,
+    nameonly MutatedBranchKeyItems: MutatedBranchKeyItems
   )
   datatype KeyManagementStrategy =
     | AwsKmsReEncrypt(AwsKmsReEncrypt: AwsCryptographyKeyStoreTypes.AwsKms)
@@ -155,19 +155,19 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny.types"
     nameonly storage: AwsCryptographyKeyStoreTypes.Storage
   )
   datatype KMSIdentifier =
-    | kmsKeyArn(kmsKeyArn: string)
-    | kmsMRKeyArn(kmsMRKeyArn: string)
+    | KmsKeyArn(KmsKeyArn: string)
+    | KmsMRKeyArn(KmsMRKeyArn: string)
   datatype MutatedBranchKeyItem = | MutatedBranchKeyItem (
-    nameonly itemType: string ,
-    nameonly description: string
+    nameonly ItemType: string ,
+    nameonly Description: string
   )
   type MutatedBranchKeyItems = seq<MutatedBranchKeyItem>
   datatype MutationComplete = | MutationComplete (
 
                               )
   datatype Mutations = | Mutations (
-    nameonly terminalKmsArn: Option<string> := Option.None ,
-    nameonly terminalEncryptionContext: Option<AwsCryptographyKeyStoreTypes.EncryptionContextString> := Option.None
+    nameonly TerminalKmsArn: Option<string> := Option.None ,
+    nameonly TerminalEncryptionContext: Option<AwsCryptographyKeyStoreTypes.EncryptionContextString> := Option.None
   )
   datatype MutationToken = | MutationToken (
     nameonly Identifier: string ,
@@ -178,9 +178,9 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny.types"
     nameonly CreateTime: string
   )
   datatype VersionKeyInput = | VersionKeyInput (
-    nameonly branchKeyIdentifier: string ,
-    nameonly kmsArn: KMSIdentifier ,
-    nameonly strategy: Option<KeyManagementStrategy> := Option.None
+    nameonly Identifier: string ,
+    nameonly KmsArn: KMSIdentifier ,
+    nameonly Strategy: Option<KeyManagementStrategy> := Option.None
   )
   datatype VersionKeyOutput = | VersionKeyOutput (
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
@@ -453,23 +453,68 @@ structure MutationConflictException {
 }
 
 @error("client")
-@documentation("Key Management Authorization failed while Initializing the Mutation. No Mutation Lock was created; no items were changed.")
+@documentation(
+"Branch Key Authorization failed while Initializing the Mutation.
+No Mutation Lock was created; no items were changed.")
 structure MutationInvalidException {
   @required
   message: String,
 }
 
-// Mutation Lock's Digest is incorrect; TODO: If we trust the backing table, should we remove this error?
 @error("client")
-@documentation("Mutation Lock is failing authentication. Mutation Lock still exists but Mutation cannot proceed. No items were changed. Recommend identifying latest author of Mutation Lock and validating their access.")
+@documentation(
+"Mutation Lock disagrees with provided Mutation Token.
+Mutation Lock still exists but Mutation cannot proceed.
+No items were changed.
+Recommend identifying latest author of Mutation Lock
+and validating their access;
+or checking the integrity of Mutation Token.")
 structure MutationLockInvalidException {
   @required
   message: String,
 }
 
 @error("client")
-@documentation("An Item was encountered that is not in an expected state. Mutation Lock is still present; no items were changed by this request. Recommend audting backing table access; an Item of a Branch Key MUST only be in one of two states during a Mutation; this item is in a third state.")
+@documentation(
+"An Item was encountered that is not
+in an expected state.
+Mutation Lock is still present;
+no items were changed by this request.
+Recommend audting backing table access;
+an Item of a Branch Key MUST be in
+either the original or terminal states during a Mutation;
+encountered item(s) in other states.")
 structure UnexpectedStateException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while authenticating
+an item already in the terminal state.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationVerificationException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while mutating
+an item from original to terminal.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationToException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while mutating
+an item from original to terminal.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationFromException {
   @required
   message: String,
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
@@ -105,7 +105,8 @@ union KMSIdentifier {
   KmsMRKeyArn: String,
 }
 
-// For GA of Mutations, only ReEncrypt is allowd
+// TODO-Mutations-FF :
+// For GA of Mutations,  of Mutations, only ReEncrypt is allowd
 // structure AwsKmsDecryptEncrypt {
 //   @documentation("The KMS Client (and Grant Tokens) used to Decrypt Branch Key Store Items.")
 //   decrypt: aws.cryptography.keyStore#AwsKms
@@ -125,6 +126,7 @@ union KeyManagementStrategy {
   This is one request to Key Management, as compared to two.
   But only one set of credentials can be used.")
   AwsKmsReEncrypt: aws.cryptography.keyStore#AwsKms
+  // TODO-Mutations-FF :
   // For GA of Mutations, only ReEncrypt is allowd
   // @documentation(
   //   "Key Store Items are authenicated and re-wrapped via a Decrypt and then Encrypt request.
@@ -208,7 +210,6 @@ Establishes the Mutation Lock; Simultaneous conflicting Mutations are prevented 
 Mutations MUST be completed via subsequent invocations of the Apply Mutation Operation, first invoked with the Mutation Token returned in InitializeMutationOutput.
 Uses 1 read of 3 items and 1 write of 4 items.
 By default, Key Management will be called 5 times; 2 x GenerateDataKeyWithoutPlaintext, 3 x ReEncrypt.")
-//If verifyDecrypt is true, an additional Decrypt will be called.")
 operation InitializeMutation {
   input: InitializeMutationInput
   output: InitializeMutationOutput
@@ -321,9 +322,6 @@ operation ApplyMutation {
 }
 
 structure ApplyMutationInput {
-  // Technically, we could XOR on ApplyMutationResult & MutationToken
-  // that MAY be user friendly, as they do not have bother unwrapping structures.
-  // For now, let's treat this as a two way door.
   @required
   MutationToken: MutationToken
 
@@ -452,7 +450,7 @@ structure KeyStoreAdminException {
   message: String
 }
 
-// Rather than link, we could detail recovery steps in the documentation trait.
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation("A Mutation for this Branch Key ID is already inflight! Nothing was changed. See <link>.")
 structure MutationConflictException {
@@ -460,6 +458,7 @@ structure MutationConflictException {
   message: String,
 }
 
+// TODO-Mutations-FF : Document recovery
 @error("client")
 @documentation(
 "Branch Key Authorization failed while Initializing the Mutation.
@@ -469,6 +468,7 @@ structure MutationInvalidException {
   message: String,
 }
 
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation(
 "Mutation Lock disagrees with provided Mutation Token.
@@ -482,6 +482,7 @@ structure MutationLockInvalidException {
   message: String,
 }
 
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation(
 "An Item was encountered that is not
@@ -497,6 +498,7 @@ structure UnexpectedStateException {
   message: String,
 }
 
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation(
 "Key Management generic error encountered while authenticating
@@ -507,6 +509,7 @@ structure MutationVerificationException {
   message: String,
 }
 
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation(
 "Key Management generic error encountered while mutating
@@ -517,6 +520,7 @@ structure MutationToException {
   message: String,
 }
 
+// TODO-Mutations-GA : Document recovery
 @error("client")
 @documentation(
 "Key Management generic error encountered while mutating

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -30,6 +30,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   // This function is the lie we will tell ourselves
   // about what the mutation scope is.
   // You MUST NOT reveal this value.
+  // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
   function {:opaque} MutationLie(): set<object>
   {{}}
 
@@ -45,6 +46,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     // Because Dafny is not able to parse
     // the code that Smithy-Dafny produces for reference types inside a union,
     // the requires kms.ValidState() and modifies kmsClient are commented out.
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     // requires kms.kmsClient.Some? ==> kms.kmsClient.value.ValidState()
     // modifies (if kms.kmsClient.Some? then kms.kmsClient.value.Modifies else {})
     ensures output.Success?
@@ -59,6 +61,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     } else {
       kmsClient := kmsClient?.value;
     }
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} kmsClient.Modifies < MutationLie();
     // If the customer gave us the KMS Client, it is fresh
     // If we create the KMS Client, it is fresh
@@ -74,6 +77,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     // Because Dafny is not able to parse
     // the code that Smithy-Dafny produces for reference types inside a union,
     // the requires kms.ValidState() and modifies kmsClient are commented out.
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     // requires
     //   kmsStratgey?.Some? ==> match kmsStratgey?.value {
     //       case AwsKmsReEncrypt(kms) => kms.kmsClient.Some? ==> kms.kmsClient.value.ValidState()
@@ -113,6 +117,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
       case AwsKmsReEncrypt(kms) =>
         var tuple :- ResolveKmsInput(kms, config);
         return Success(Mutations.keyManagerStrat.reEncrypt(tuple));
+        // TODO-Mutations-FF :
         // case AwsKmsDecryptEncrypt(kmsDecryptEncrypt) =>
         //   // var decrypt :- ResolveKmsInput(kmsDecryptEncrypt.decrypt, config);
         //   // var encrypt :- ResolveKmsInput(kmsDecryptEncrypt.encrypt, config);
@@ -129,6 +134,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     // Because Dafny is not able to parse
     // the code that Smithy-Dafny produces for reference types inside a union,
     // the requires kms.ValidState() and modifies kmsClient are commented out.
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     // requires kms.kmsClient.Some? ==> kms.kmsClient.value.ValidState()
     // modifies (if kms.kmsClient.Some? then kms.kmsClient.value.Modifies else {})
     requires ValidInternalConfig?(config)
@@ -148,7 +154,6 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
         message := "Grant Tokens passed to Key Store Admin are invalid.")
     );
     assume {:axiom} config.storage.Modifies !! kmsClient.Modifies;
-    // assume {:axiom} kms.kmsClient.value.ValidState();
     output := Success(Mutations.KMSTuple(kmsClient, grantTokens.value));
   }
 
@@ -157,7 +162,6 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     kmsArn: Types.KMSIdentifier,
     config: InternalConfig
   ): (output: Result<KeyStoreOperations.Config, Error>)
-    // returns (output: Result<KeyStoreOperations.Config, Error>)
     requires ValidInternalConfig?(config)
     requires
       && keyManagerStrat.reEncrypt?
@@ -190,11 +194,11 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     // These are required to use the existing logic.
     // This is required because Dafny is not able to parse
     // the code that Smithy-Dafny produces for reference types inside a union
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} legacyConfig.kmsClient.ValidState();
     // This is for the legacy client. Again, this should follow from the code that smithy-dafny produces.
     assume {:axiom} legacyConfig.storage.Modifies !! legacyConfig.kmsClient.Modifies;
 
-    // output := Success(legacyConfig)
     Success(legacyConfig)
   }
 
@@ -212,6 +216,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
 
     var legacyConfig :- LegacyConfig(keyManagerStrat, input.KmsArn, config);
 
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
     var output? := KeyStoreOperations.CreateKey(
@@ -245,6 +250,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
 
     var legacyConfig :- LegacyConfig(keyManagerStrat, input.KmsArn, config);
 
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
     var output? := KeyStoreOperations.VersionKey(
@@ -269,6 +275,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543  
     assume {:axiom} keyManagerStrat.reEncrypt.kmsClient.Modifies < MutationLie();
 
     var _ :- Mutations.ValidateInitializeMutationInput(input, config.logicalKeyStoreName);
@@ -287,6 +294,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543  
     assume {:axiom} keyManagerStrat.reEncrypt.kmsClient.Modifies < MutationLie();
 
     var _ :- Mutations.ValidateApplyMutationInput(input, config.logicalKeyStoreName, config.storage);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -169,16 +169,16 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     ensures output.Success? ==> KeyStoreOperations.ValidInternalConfig?(output.value)
   {
     var _ :- KmsArn.IsValidKeyArn(match kmsArn
-                                  case kmsKeyArn(kmsKeyArn) => kmsKeyArn
-                                  case kmsMRKeyArn(kmsMRKeyArn) => kmsMRKeyArn)
+                                  case KmsKeyArn(kmsKeyArn) => kmsKeyArn
+                                  case KmsMRKeyArn(kmsMRKeyArn) => kmsMRKeyArn)
              .MapFailure(e => Types.Error.AwsCryptographyKeyStore(e));
     var legacyConfig := KeyStoreOperations.Config(
                           id := "",
                           ddbTableName := None,
                           logicalKeyStoreName := config.logicalKeyStoreName,
                           kmsConfiguration := match kmsArn
-                          case kmsKeyArn(kmsKeyArn) => KeyStoreOperations.Types.kmsKeyArn(kmsKeyArn)
-                          case kmsMRKeyArn(kmsMRKeyArn) => KeyStoreOperations.Types.kmsMRKeyArn(kmsMRKeyArn),
+                          case KmsKeyArn(kmsKeyArn) => KeyStoreOperations.Types.kmsKeyArn(kmsKeyArn)
+                          case KmsMRKeyArn(kmsMRKeyArn) => KeyStoreOperations.Types.kmsMRKeyArn(kmsMRKeyArn),
                           grantTokens := keyManagerStrat.reEncrypt.grantTokens,
                           kmsClient := keyManagerStrat.reEncrypt.kmsClient,
                           ddbClient := None,
@@ -204,21 +204,21 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   method CreateKey ( config: InternalConfig , input: CreateKeyInput )
     returns (output: Result<CreateKeyOutput, Error>)
   {
-    var keyManagerStrat :- ResolveStrategy(input.strategy, config);
+    var keyManagerStrat :- ResolveStrategy(input.Strategy, config);
     :- Need(
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
 
-    var legacyConfig :- LegacyConfig(keyManagerStrat, input.kmsArn, config);
+    var legacyConfig :- LegacyConfig(keyManagerStrat, input.KmsArn, config);
 
     assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
     var output? := KeyStoreOperations.CreateKey(
       config := legacyConfig,
       input := KeyStoreOperations.Types.CreateKeyInput(
-        branchKeyIdentifier := input.branchKeyIdentifier,
-        encryptionContext := input.encryptionContext
+        branchKeyIdentifier := input.Identifier,
+        encryptionContext := input.EncryptionContext
       )
     );
     var value :- output?
@@ -226,7 +226,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
 
     output := Success(
       Types.CreateKeyOutput(
-        branchKeyIdentifier := value.branchKeyIdentifier
+        Identifier := value.branchKeyIdentifier
       ));
   }
 
@@ -237,20 +237,20 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
     returns (output: Result<VersionKeyOutput, Error>)
   {
 
-    var keyManagerStrat :- ResolveStrategy(input.strategy, config);
+    var keyManagerStrat :- ResolveStrategy(input.Strategy, config);
     :- Need(
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
 
-    var legacyConfig :- LegacyConfig(keyManagerStrat, input.kmsArn, config);
+    var legacyConfig :- LegacyConfig(keyManagerStrat, input.KmsArn, config);
 
     assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
     var output? := KeyStoreOperations.VersionKey(
       config := legacyConfig,
       input := KeyStoreOperations.Types.VersionKeyInput(
-        branchKeyIdentifier := input.branchKeyIdentifier
+        branchKeyIdentifier := input.Identifier
       )
     );
     var value :- output?
@@ -264,7 +264,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   method InitializeMutation(config: InternalConfig, input: InitializeMutationInput )
     returns (output: Result<InitializeMutationOutput, Error>)
   {
-    var keyManagerStrat :- ResolveStrategy(input.strategy, config);
+    var keyManagerStrat :- ResolveStrategy(input.Strategy, config);
     :- Need(
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
@@ -282,7 +282,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   method ApplyMutation(config: InternalConfig, input: ApplyMutationInput)
     returns (output: Result<ApplyMutationOutput, Error>)
   {
-    var keyManagerStrat :- ResolveStrategy(input.strategy, config);
+    var keyManagerStrat :- ResolveStrategy(input.Strategy, config);
     :- Need(
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -275,7 +275,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
-    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543  
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} keyManagerStrat.reEncrypt.kmsClient.Modifies < MutationLie();
 
     var _ :- Mutations.ValidateInitializeMutationInput(input, config.logicalKeyStoreName);
@@ -294,7 +294,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
       keyManagerStrat.reEncrypt?,
       Types.KeyStoreAdminException(message :="Only ReEncrypt is supported at this time.")
     );
-    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543  
+    // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
     assume {:axiom} keyManagerStrat.reEncrypt.kmsClient.Modifies < MutationLie();
 
     var _ :- Mutations.ValidateApplyMutationInput(input, config.logicalKeyStoreName, config.storage);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Index.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Index.dfy
@@ -128,7 +128,6 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny"}
     } else {
       ddbClient := ddbClient?.value;
     }
-    // assume {:axiom} ddbClient.Modifies < FixturesLie(); // Tony thinks we don't need this
     // If the customer gave us the DDB Client, it is fresh
     // If we create the DDB Client, it is fresh
     assume {:axiom} fresh(ddbClient) && fresh(ddbClient.Modifies);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationStateStructures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationStateStructures.dfy
@@ -43,13 +43,13 @@ module {:options "/functionSyntax:4" } MutationStateStructures {
     input: Types.Mutations
   )
   {
-    && (input.terminalKmsArn.Some? ==> KmsArn.ValidKmsArn?(input.terminalKmsArn.value))
-    && (input.terminalEncryptionContext.Some? ==>
-          && |input.terminalEncryptionContext.value| > 0
-          &&  forall k <- input.terminalEncryptionContext.value ::
-               && |k| > 0 && |input.terminalEncryptionContext.value[k]| > 0
-               && input.terminalEncryptionContext.value.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES)
-    && !(input.terminalKmsArn.None? && input.terminalEncryptionContext.None?)
+    && (input.TerminalKmsArn.Some? ==> KmsArn.ValidKmsArn?(input.TerminalKmsArn.value))
+    && (input.TerminalEncryptionContext.Some? ==>
+          && |input.TerminalEncryptionContext.value| > 0
+          &&  forall k <- input.TerminalEncryptionContext.value ::
+               && |k| > 0 && |input.TerminalEncryptionContext.value[k]| > 0
+               && input.TerminalEncryptionContext.value.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES)
+    && !(input.TerminalKmsArn.None? && input.TerminalEncryptionContext.None?)
   }
 
   datatype MutableProperties = | MutableProperties (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Mutations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Mutations.dfy
@@ -228,6 +228,8 @@ module {:options "/functionSyntax:4" } Mutations {
         aMap := input.Mutations.TerminalEncryptionContext.value
       ) + unexpectedEC;
       // ValidateInitializeMutationInput SHOULD take care of this Need, but Dafny is struggling
+      // TODO-Mutations-FF : Replace runtime check with Lemma.
+      // See https://github.com/aws/aws-cryptographic-material-providers-library/pull/750#discussion_r1777654751
       :- Need(
         terminalEC.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES,
         Types.KeyStoreAdminException(message:="Terminal Encryption Context contains a reserved word!")
@@ -364,7 +366,7 @@ module {:options "/functionSyntax:4" } Mutations {
           Terminal := MutationToken.Terminal
         )
       ));
-    // TODO Mutations FastFollow? :: Ideally, we would diagnosis the Storage Failure.
+    // TODO-Mutations-FF :: Ideally, we would diagnosis the Storage Failure.
     // What Condition Check failed? Was the Key Versioned? Or did another M-Lock get written?
     var _ :- throwAway2?.MapFailure(e => Types.Error.AwsCryptographyKeyStore(e));
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
@@ -81,11 +81,13 @@ module {:options "/functionSyntax:4" } AdminFixtures {
     key: string := "Robbie",
     value: string := "Is a dog.")
 
+  /** Adds an "un-modeled Attribute" to the Active & Decrypt. */
+  /** If alsoViolateBeacion?, also add to Beacon.*/
   method AddAttributeWithoutLibrary(
     nameonly id: string,
     nameonly physicalName: string := Fixtures.branchKeyStoreName,
     nameonly logicalName: string := Fixtures.logicalKeyStoreName,
-    nameonly keyValue: KeyValue := KeyValue(key:="Robbie", value:="Is a dog."),
+    nameonly keyValue: KeyValue := KeyValue(),
     nameonly alsoViolateBeacon?: bool := false,
     nameonly ddbClient?: Option<DDB.Types.IDynamoDBClient> := None,
     nameonly kmsClient?: Option<KMS.Types.IKMSClient> := None
@@ -100,13 +102,10 @@ module {:options "/functionSyntax:4" } AdminFixtures {
              + (if kmsClient?.Some? then kmsClient?.value.Modifies else {})
   {
     var ddbClient :- expect Fixtures.ProvideDDBClient(ddbClient?);
-    assume {:axiom} fresh(ddbClient) && fresh(ddbClient.Modifies);
     var kmsClient :- expect Fixtures.ProvideKMSClient(None);
-    assume {:axiom} fresh(kmsClient) && fresh(kmsClient.Modifies);
-
     var storage :- expect Fixtures.DefaultStorage(
       physicalName := physicalName, logicalName := logicalName, ddbClient? := Some(ddbClient));
-    assume {:axiom} fresh(storage) && fresh(storage.Modifies);
+
     var allThree :- expect Fixtures.getItems(id:=id, underTest:=storage);
     var activeDDB :- expect ViolateItem(
       item := allThree.active, keyValue:=keyValue, kmsClient:=kmsClient, physicalName:=physicalName);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
@@ -87,7 +87,7 @@ module {:options "/functionSyntax:4" } AdminFixtures {
     nameonly id: string,
     nameonly physicalName: string := Fixtures.branchKeyStoreName,
     nameonly logicalName: string := Fixtures.logicalKeyStoreName,
-    nameonly keyValue: KeyValue := KeyValue(),
+    nameonly keyValue: KeyValue := KeyValue(key:="Robbie", value:="Is a dog."),
     nameonly alsoViolateBeacon?: bool := false,
     nameonly ddbClient?: Option<DDB.Types.IDynamoDBClient> := None,
     nameonly kmsClient?: Option<KMS.Types.IKMSClient> := None

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestEncryptionContextChanged.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestEncryptionContextChanged.dfy
@@ -66,34 +66,34 @@ module {:options "/functionSyntax:4" } TestEncryptionContextChanged {
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
     var newCustomEC: KeyStoreTypes.EncryptionContextString := map["Robbie" := timestamp];
-    var mutationsRequest := Types.Mutations(terminalEncryptionContext := Some(newCustomEC));
+    var mutationsRequest := Types.Mutations(TerminalEncryptionContext := Some(newCustomEC));
     var initInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput :- expect underTest.InitializeMutation(initInput);
-    var initializeToken := initializeOutput.mutationToken;
+    var initializeToken := initializeOutput.MutationToken;
 
     expect initializeToken.UUID.Some?, "Mutation Token from InitializeMutation does not have a UUID!";
 
     print testLogPrefix + " Initialized Mutation. M-Lock UUID " + initializeToken.UUID.value + "\n";
 
     var testInput := Types.ApplyMutationInput(
-      mutationToken := initializeToken,
-      pageSize := Some(24),
-      strategy := Some(strategy));
+      MutationToken := initializeToken,
+      PageSize := Some(24),
+      Strategy := Some(strategy));
     var applyOutput :- expect underTest.ApplyMutation(testInput);
 
     print testLogPrefix + " Applied Mutation w/ pageSize 1. testId: " + testId + "\n";
 
-    expect applyOutput.result.completeMutation?, "Apply Mutation output should not continue!";
+    expect applyOutput.MutationResult.CompleteMutation?, "Apply Mutation output should not continue!";
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
     expect
       |items| == 3,
       "Test expects there to be 3 Decrypt Only items! Found: " + String.Base10Int2String(|items|);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestInitMutActiveAndBeaconAreInSameState.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestInitMutActiveAndBeaconAreInSameState.dfy
@@ -61,11 +61,11 @@ module {:options "/functionSyntax:4" } TestInitMutActiveAndBeaconAreInSameState 
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
     var newCustomEC: KeyStoreTypes.EncryptionContextString := map["Koda" := timestamp];
-    var mutationsRequest := Types.Mutations(terminalEncryptionContext := Some(newCustomEC));
+    var mutationsRequest := Types.Mutations(TerminalEncryptionContext := Some(newCustomEC));
     var initInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput? := underTest.InitializeMutation(initInput);
 
     expect initializeOutput?.Failure?, "Initialize Mutation did not detect drifted Active & Beacon!";
@@ -80,10 +80,10 @@ module {:options "/functionSyntax:4" } TestInitMutActiveAndBeaconAreInSameState 
     var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BRANCH_KEY_ACTIVE_TYPE, ddbClient);
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
-      Identifier := testId, pageSize := 24
+      Identifier := testId, PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
     var itemIndex := 0;
     while itemIndex < |items|
     {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestKmsArnChanged.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestKmsArnChanged.dfy
@@ -59,32 +59,32 @@ module {:options "/functionSyntax:4" } TestKmsArnChanged {
     print testLogPrefix + " Created the test items with 2 versions! testId: " + testId + "\n";
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
-    var mutationsRequest := Types.Mutations(terminalKmsArn := Some(Fixtures.postalHornKeyArn));
+    var mutationsRequest := Types.Mutations(TerminalKmsArn := Some(Fixtures.postalHornKeyArn));
     var initInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput :- expect underTest.InitializeMutation(initInput);
-    var initializeToken := initializeOutput.mutationToken;
+    var initializeToken := initializeOutput.MutationToken;
 
     expect initializeToken.UUID.Some?, "Mutation Token from InitializeMutation does not have a UUID!";
     print testLogPrefix + " Initialized Mutation. M-Lock UUID " + initializeToken.UUID.value + "\n";
 
     var testInput := Types.ApplyMutationInput(
-      mutationToken := initializeToken,
-      pageSize := Some(24),
-      strategy := Some(strategy));
+      MutationToken := initializeToken,
+      PageSize := Some(24),
+      Strategy := Some(strategy));
     var applyOutput :- expect underTest.ApplyMutation(testInput);
 
     print testLogPrefix + " Applied Mutation w/ pageSize 24. testId: " + testId + "\n";
-    expect applyOutput.result.completeMutation?, "Apply Mutation output should not continue!";
+    expect applyOutput.MutationResult.CompleteMutation?, "Apply Mutation output should not continue!";
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
     expect
       |items| == 3,
       "Test expects there to be 3 Decrypt Only items! Found: " + String.Base10Int2String(|items|);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsEncryptionContextUnModeledAttribute.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsEncryptionContextUnModeledAttribute.dfy
@@ -8,11 +8,13 @@ include "../../../AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
 include "../AdminFixtures.dfy"
 
 // Tests that an Encryption Context only change:
-// - Completes if there is no paging
+// - Completes, without paging, since it is annoying to violate the items
 // - Changes the Custom Encryption Context for all items
 // - All items can be decrypted by KMS
+// - maintains un-modeled attributes in exsisting items
+// - projects un-modeled attributes to new items
 
-module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
+module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAttribute {
   import Types = AwsCryptographyKeyStoreAdminTypes
   import KeyStoreAdmin
   import KeyStore
@@ -36,14 +38,12 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
   const kmsId: string := Fixtures.keyArn
   const physicalName: string := Fixtures.branchKeyStoreName
   const logicalName: string := Fixtures.logicalKeyStoreName
-  const testLogPrefix := "\nTestMutationsEncryptionContextAddValue :: TestProofMutationsOverWritesUnModeldedAttributesCase :: "
+  const testLogPrefix := "\nTestMutationsEncryptionContextUnModeledAttribute :: TestHappyCase :: "
 
-  // This is evidence that the code behaves in the manner we DO NOT WANT
-  method {:test} {:vcs_split_on_every_assert} TestProofMutationsOverWritesUnModeldedAttributesCase()
+  method {:test} {:vcs_split_on_every_assert} TestHappyCase()
   {
     print " running";
 
-    // expect false; // disable test till other investigation is done
     var ddbClient :- expect DDB.DynamoDBClient();
     var kmsClient :- expect KMS.KMSClient();
 
@@ -55,15 +55,18 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var uuid :- expect UUID.GenerateUUID();
     var testId := happyCaseId + "-" + uuid;
 
-    // var robbieBytes :- expect UTF8.Encode("Robbie");
     var kodaBytes :- expect UTF8.Encode("Koda");
     var isADogBytes :- expect UTF8.Encode("is a dog.");
     var originalEC := map[kodaBytes := isADogBytes];
     Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0, customEC:=originalEC);
 
     print testLogPrefix + " Created the legit test items with 1 versions! testId: " + testId + "\n";
-
-    var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(id:=testId, alsoViolateBeacon? := true, ddbClient? := Some(ddbClient));
+    var unModeledAttri := AdminFixtures.KeyValue();
+    var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
+      id:=testId,
+      alsoViolateBeacon? := true,
+      ddbClient? := Some(ddbClient),
+      keyValue := unModeledAttri);
 
     print testLogPrefix + " Violated all three. testId: " + testId + "\n";
 
@@ -102,19 +105,9 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     {
       var item := items[itemIndex];
       expect
-        customEC in item.EncryptionContext,
-                    "Koda should be a Key in the Custom Encryption Context of all items for this test.";
-      expect
-        item.EncryptionContext[customEC] == timestamp,
-        "Koda's value should be the test timestamp for all decrypt items for this test.";
-      expect "type" in item.EncryptionContext, "Decrypt Only item is missing 'type' from EC!!";
-      expect
         item.Type.HierarchicalSymmetricVersion?,
         "Query for Decrypt Only returned a non-Decrypt Only!";
-
-      if ("Robbie" in item.EncryptionContext) {
-        print testLogPrefix + "Robbie in " + item.EncryptionContext["type"] + "\n";
-      }
+      var _ := itemExpectations(item, timestamp, unModeledAttri);
       var versionUUID := item.Type.HierarchicalSymmetricVersion.Version;
       inputV := KeyStoreTypes.GetBranchKeyVersionInput(
         branchKeyIdentifier := testId,
@@ -123,8 +116,10 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
       var _ :- expect keyStore.GetBranchKeyVersion(inputV);
 
       // This is a best effort
-      var _ := CleanupItems.DeleteTypeWithFailure(testId, item.EncryptionContext["type"], ddbClient);
-      print testLogPrefix + " Validated Decrypt Only and tried to clean it up: " + item.EncryptionContext["type"] + "\n";
+      var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BRANCH_KEY_TYPE_PREFIX + versionUUID, ddbClient);
+      print testLogPrefix
+            + " Validated Decrypt Only and tried to clean it up: "
+            + Structure.BRANCH_KEY_TYPE_PREFIX + versionUUID + "\n";
       itemIndex := 1 + itemIndex;
     }
 
@@ -132,12 +127,7 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var lastActive? :- expect storage.GetEncryptedActiveBranchKey(lastActiveInput);
     expect lastActive?.Item.Type.ActiveHierarchicalSymmetricVersion?;
     var lastActive := lastActive?.Item.Type.ActiveHierarchicalSymmetricVersion;
-    expect
-      customEC in lastActive?.Item.EncryptionContext,
-                  "Koda should be a Key in the Custom Encryption Context for the ACTIVE.";
-    expect
-      lastActive?.Item.EncryptionContext[customEC] == timestamp,
-      "Koda's value should be the test timestamp for the ACTIVE.";
+    var _ := itemExpectations(lastActive?.Item, timestamp, unModeledAttri);
     var _ :- expect keyStore.GetActiveBranchKey(KeyStoreTypes.GetActiveBranchKeyInput(branchKeyIdentifier := testId));
     print testLogPrefix + " Active Validated with KMS/KeyStore: " + testId + "\n";
     var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BRANCH_KEY_ACTIVE_TYPE, ddbClient);
@@ -145,15 +135,32 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var beaconInput := KeyStoreTypes.GetEncryptedBeaconKeyInput(Identifier:=testId);
     var beacon? :- expect storage.GetEncryptedBeaconKey(beaconInput);
     expect beacon?.Item.Type.ActiveHierarchicalSymmetricBeacon?;
-    expect
-      customEC in beacon?.Item.EncryptionContext,
-                  "Koda should be a Key in the Custom Encryption Context for the Beacon.";
-    expect
-      beacon?.Item.EncryptionContext[customEC] == timestamp,
-      "Koda's value should be the test timestamp for the Beacon.";
+    var _ := itemExpectations(beacon?.Item, timestamp, unModeledAttri);
     var _ :- expect keyStore.GetBeaconKey(KeyStoreTypes.GetBeaconKeyInput(branchKeyIdentifier := testId));
     print testLogPrefix + " Beacon Validated with KMS/KeyStore: " + testId + "\n";
     var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BEACON_KEY_TYPE_VALUE, ddbClient);
+  }
+
+  method itemExpectations(
+    item: KeyStoreTypes.EncryptedHierarchicalKey,
+    timestamp : string,
+    unModeledAttri : AdminFixtures.KeyValue
+  )
+    returns (output: bool)
+    ensures output ==> "type" in item.EncryptionContext
+  {
+    expect
+      customEC in item.EncryptionContext,
+                  "Koda should be a Key in the Custom Encryption Context of all items for this test.";
+    expect
+      item.EncryptionContext[customEC] == timestamp,
+      "Koda's value should be the test timestamp for all items for this test.";
+    expect "type" in item.EncryptionContext, "item is missing 'type' from EC!!";
+    expect unModeledAttri.key in item.EncryptionContext,
+                                 "un-modeled attribute was dropped!";
+    expect item.EncryptionContext[unModeledAttri.key] == unModeledAttri.value,
+      "un-modeled attribute value is incorrect";
+    return true;
   }
 }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
@@ -72,32 +72,32 @@ module {:options "/functionSyntax:4" } TestMutationsUnModeledAttribute {
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
     var newCustomEC: KeyStoreTypes.EncryptionContextString := map["Koda" := timestamp];
-    var mutationsRequest := Types.Mutations(terminalEncryptionContext := Some(newCustomEC));
+    var mutationsRequest := Types.Mutations(TerminalEncryptionContext := Some(newCustomEC));
     var initInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput :- expect underTest.InitializeMutation(initInput);
-    var initializeToken := initializeOutput.mutationToken;
+    var initializeToken := initializeOutput.MutationToken;
 
     print testLogPrefix + " Initialized Mutation. testId: " + testId + "\n";
 
     var testInput := Types.ApplyMutationInput(
-      mutationToken := initializeToken,
-      pageSize := Some(24),
-      strategy := Some(strategy));
+      MutationToken := initializeToken,
+      PageSize := Some(24),
+      Strategy := Some(strategy));
     var applyOutput :- expect underTest.ApplyMutation(testInput);
 
     print testLogPrefix + " Applied Mutation w/ pageSize 24. testId: " + testId + "\n";
 
-    expect applyOutput.result.completeMutation?, "Apply Mutation output should not continue!";
+    expect applyOutput.MutationResult.CompleteMutation?, "Apply Mutation output should not continue!";
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
 
     var itemIndex := 0;
     var inputV: KeyStoreTypes.GetBranchKeyVersionInput;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
@@ -14,7 +14,7 @@ include "../AdminFixtures.dfy"
 // - maintains un-modeled attributes in exsisting items
 // - projects un-modeled attributes to new items
 
-module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAttribute {
+module {:options "/functionSyntax:4" } TestMutationsUnModeledAttribute {
   import Types = AwsCryptographyKeyStoreAdminTypes
   import KeyStoreAdmin
   import KeyStore
@@ -38,9 +38,9 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAt
   const kmsId: string := Fixtures.keyArn
   const physicalName: string := Fixtures.branchKeyStoreName
   const logicalName: string := Fixtures.logicalKeyStoreName
-  const testLogPrefix := "\nTestMutationsEncryptionContextUnModeledAttribute :: TestHappyCase :: "
+  const testLogPrefix := "\nTestMutationsUnModeledAttribute :: TestHappyCase :: "
 
-  method {:test} {:vcs_split_on_every_assert} TestHappyCase()
+  method {:test} TestHappyCase()
   {
     print " running";
 
@@ -61,7 +61,7 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAt
     Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0, customEC:=originalEC);
 
     print testLogPrefix + " Created the legit test items with 1 versions! testId: " + testId + "\n";
-    var unModeledAttri := AdminFixtures.KeyValue();
+    var unModeledAttri := AdminFixtures.KeyValue(key:="Robbie", value:="Is a dog.");
     var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
       id:=testId,
       alsoViolateBeacon? := true,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestThreat27.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestThreat27.dfy
@@ -80,11 +80,11 @@ module {:options "/functionSyntax:4" } TestThreat27 {
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
     var newCustomEC: KeyStoreTypes.EncryptionContextString := map["Robbie" := timestamp];
-    var mutationsRequest := Types.Mutations(terminalEncryptionContext := Some(newCustomEC));
+    var mutationsRequest := Types.Mutations(TerminalEncryptionContext := Some(newCustomEC));
     var testInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput :- expect underTest.InitializeMutation(testInput);
 
     print "\nTestThreat27 :: TestHappyCase :: Initialized Mutation: " + activeOne + "\n";

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestThreat28.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestThreat28.dfy
@@ -78,22 +78,22 @@ module {:options "/functionSyntax:4" } TestThreat28 {
 
     var timestamp :- expect Time.GetCurrentTimeStamp();
     var newCustomEC: KeyStoreTypes.EncryptionContextString := map["Robbie" := timestamp];
-    var mutationsRequest := Types.Mutations(terminalEncryptionContext := Some(newCustomEC));
+    var mutationsRequest := Types.Mutations(TerminalEncryptionContext := Some(newCustomEC));
     var initInput := Types.InitializeMutationInput(
-      branchKeyIdentifier := testId,
-      mutations := mutationsRequest,
-      strategy := Some(strategy));
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy));
     var initializeOutput :- expect underTest.InitializeMutation(initInput);
-    var initializeToken := initializeOutput.mutationToken;
+    var initializeToken := initializeOutput.MutationToken;
 
     expect initializeToken.UUID.Some?, "Mutation Token from InitializeMutation does not have a UUID!";
 
     print testLogPrefix + " Initialized Mutation. M-Lock UUID " + initializeToken.UUID.value + "\n";
 
     var testInput := Types.ApplyMutationInput(
-      mutationToken := initializeToken,
-      pageSize := Some(1), //Some(24),
-      strategy := Some(strategy));
+      MutationToken := initializeToken,
+      PageSize := Some(1), //Some(24),
+      Strategy := Some(strategy));
     // var applyOutput :- expect underTest.ApplyMutation(testInput);
     var applyOutput? := underTest.ApplyMutation(testInput);
     if (applyOutput?.Failure?) {
@@ -102,8 +102,8 @@ module {:options "/functionSyntax:4" } TestThreat28 {
     expect applyOutput?.Success?, "Apply 1 FAILED";
     var applyOutput := applyOutput?.value;
     print testLogPrefix + " Applied Mutation w/ pageSize 1. testId: " + testId + "\n";
-    expect applyOutput.result.continueMutation?, "Apply Mutation output should continue!";
-    var applyToken: Types.MutationToken := applyOutput.result.continueMutation;
+    expect applyOutput.MutationResult.ContinueMutation?, "Apply Mutation output should continue!";
+    var applyToken: Types.MutationToken := applyOutput.MutationResult.ContinueMutation;
     expect applyToken.ExclusiveStartKey.Some?, "Apply Mutation output continues but pageIndex is None?";
     expect |applyToken.ExclusiveStartKey.value| > 0, "Apply Mutation output continues but pageIndex has length 0.";
 
@@ -112,9 +112,9 @@ module {:options "/functionSyntax:4" } TestThreat28 {
     // TODO: Assert log lines
 
     testInput := Types.ApplyMutationInput(
-      mutationToken := applyToken,
-      pageSize := Some(1),
-      strategy := Some(strategy));
+      MutationToken := applyToken,
+      PageSize := Some(1),
+      Strategy := Some(strategy));
     applyOutput? := underTest.ApplyMutation(testInput);
     if (applyOutput?.Failure?) {
       print applyOutput?;
@@ -123,30 +123,30 @@ module {:options "/functionSyntax:4" } TestThreat28 {
     applyOutput := applyOutput?.value;
 
     // print testLogPrefix + " Applied 2 Mutation w/ pageSize 1. testId: " + testId + "\n";
-    expect applyOutput.result.continueMutation?, "Apply Mutation output should continue, based on the DDB Limit";
-    applyToken := applyOutput.result.continueMutation;
+    expect applyOutput.MutationResult.ContinueMutation?, "Apply Mutation output should continue, based on the DDB Limit";
+    applyToken := applyOutput.MutationResult.ContinueMutation;
     expect applyToken.ExclusiveStartKey.Some?, "Apply Mutation output continues but pageIndex is None?";
     expect |applyToken.ExclusiveStartKey.value| > 0, "Apply Mutation output continues but pageIndex has length 0.";
     print testLogPrefix + " Apply 2 output met expectations. testId: " + testId + "\n";
 
     testInput := Types.ApplyMutationInput(
-      mutationToken := applyToken,
-      pageSize := Some(1),
-      strategy := Some(strategy));
+      MutationToken := applyToken,
+      PageSize := Some(1),
+      Strategy := Some(strategy));
     applyOutput? := underTest.ApplyMutation(testInput);
     if (applyOutput?.Failure?) {
       print applyOutput?;
     }
     expect applyOutput?.Success?, "Apply 3 FAILED";
     applyOutput := applyOutput?.value;
-    expect applyOutput.result.completeMutation?, "Apply Mutation output should not continue!";
+    expect applyOutput.MutationResult.CompleteMutation?, "Apply Mutation output should not continue!";
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
     expect
       |items| == 3,
       "Test expects there to be 3 Decrypt Only items! Found: " + String.Base10Int2String(|items|);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestUnModeledEncryptionContextIsUsable.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestUnModeledEncryptionContextIsUsable.dfy
@@ -65,10 +65,10 @@ module {:options "/functionSyntax:4" } TestUnModeledEncryptionContextIsUsable {
 
     var versionQuery := KeyStoreTypes.QueryForVersionsInput(
       Identifier := testId,
-      pageSize := 24
+      PageSize := 24
     );
     var queryOut :- expect storage.QueryForVersions(versionQuery);
-    var items := queryOut.items;
+    var items := queryOut.Items;
 
     var itemIndex := 0;
     var inputV: KeyStoreTypes.GetBranchKeyVersionInput;

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -31,12 +31,18 @@ sourceSets {
         runtimeClasspath += sourceSets.test.get().output + sourceSets["examples"].output + sourceSets.main.get().output
     }
 }
-val examplesImplementation by configurations.getting{
+val examplesImplementation: Configuration by configurations.getting{
     extendsFrom(configurations.testImplementation.get())
 }
-val testExamplesImplementation by configurations.getting{
-    extendsFrom(configurations.testImplementation.get())
+configurations.add(examplesImplementation)
+val examplesAnnotationProcessor: Configuration by configurations.getting{
+    extendsFrom(configurations.testAnnotationProcessor.get())
 }
+configurations.add(examplesAnnotationProcessor)
+val testExamplesImplementation: Configuration by configurations.getting{
+    extendsFrom(configurations["examplesImplementation"])
+}
+configurations.add(testExamplesImplementation)
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -107,13 +113,14 @@ dependencies {
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")
 
-    // Example Dependencies are marked as testImplementation
-    testImplementation("software.amazon.awssdk:arns")
-    testImplementation("software.amazon.awssdk:auth")
-    testImplementation("software.amazon.awssdk:sts")
-    testImplementation("software.amazon.awssdk:apache-client:2.19.0")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
-    testImplementation("com.google.code.findbugs:jsr305:3.0.2")
+    // Example Dependencies
+    examplesImplementation("software.amazon.awssdk:arns")
+    examplesImplementation("software.amazon.awssdk:auth")
+    examplesImplementation("software.amazon.awssdk:sts")
+    examplesImplementation("software.amazon.awssdk:utils")
+    examplesImplementation("software.amazon.awssdk:apache-client:2.19.0")
+    examplesAnnotationProcessor("org.projectlombok:lombok:1.18.30")
+    examplesImplementation("com.google.code.findbugs:jsr305:3.0.2")
 
 }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/README.md
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/README.md
@@ -8,5 +8,5 @@ AWS Cryptographic Material Providers Library (MPL) in Java.
 
 ```
 ├── ..
-└── Hierarchy: Examples for manging the Hierarchical Keyring's Key Store
+└── Hierarchy: Examples for managing the Hierarchical Keyring's Key Store
 ```

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -3,7 +3,6 @@
 package software.amazon.cryptography.example;
 
 import javax.annotation.Nonnull;
-
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.regions.Region;

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -1,0 +1,50 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example;
+
+import javax.annotation.Nonnull;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+public class CredentialUtils {
+
+  public static StsAssumeRoleCredentialsProvider credsForRole(
+    @Nonnull String roleArn,
+    @Nonnull String roleSessionName,
+    @Nonnull Region region,
+    @Nonnull SdkHttpClient httpClient,
+    @Nonnull AwsCredentialsProvider creds
+  ) {
+    StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider
+      .builder()
+      .stsClient(
+        StsClient
+          .builder()
+          .httpClient(httpClient)
+          .region(region)
+          .credentialsProvider(creds)
+          .build()
+      )
+      .refreshRequest(
+        AssumeRoleRequest
+          .builder()
+          .roleArn(roleArn)
+          .roleSessionName(roleSessionName)
+          .durationSeconds(900) // 15 minutes by 60 seconds
+          .build()
+      )
+      .build();
+    // Force credential resolution.
+    // If the host does not have permission to use these credentials,
+    // we want to fail early.
+    // This may not be appropriate in a production environment,
+    // as it is "greedy initialization".
+    provider.resolveCredentials();
+    return provider;
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
@@ -69,7 +69,7 @@ public class AdminProvider {
   ) {
     return mutatedItems
       .stream()
-      .map(item -> String.format("%s : %s", item.itemType(), item.description())
+      .map(item -> String.format("%s : %s", item.ItemType(), item.Description())
       )
       .collect(Collectors.joining(",\n"));
   }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
@@ -71,6 +71,6 @@ public class AdminProvider {
       .stream()
       .map(item -> String.format("%s : %s", item.itemType(), item.description())
       )
-      .collect(Collectors.joining(",\n "));
+      .collect(Collectors.joining(",\n"));
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
@@ -4,8 +4,10 @@ package software.amazon.cryptography.example.hierarchy;
 
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
 import software.amazon.cryptography.keystoreadmin.model.CreateKeyInput;
 import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
@@ -25,9 +27,10 @@ import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
 public class CreateKeyExample {
 
   public static String CreateKey(
-    String keyStoreTableName,
-    String logicalKeyStoreName,
-    String kmsKeyArn,
+    @Nonnull String keyStoreTableName,
+    @Nonnull String logicalKeyStoreName,
+    @Nonnull String kmsKeyArn,
+    @Nullable String branchKeyId,
     @Nullable DynamoDbClient dynamoDbClient
   ) {
     // 1. Configure your Key Store Admin resource.
@@ -42,8 +45,10 @@ public class CreateKeyExample {
     // If an Identifier is not provided, a v4 UUID will be generated and used.
     // This example provides a combination of a fixed string and a v4 UUID;
     // this makes it easy for Crypto Tools to clean up these Example Branch Keys.
-    final String branchKeyId =
-      "mpl-java-example-" + java.util.UUID.randomUUID().toString();
+    branchKeyId =
+      StringUtils.isBlank(branchKeyId)
+        ? "mpl-java-example-" + java.util.UUID.randomUUID().toString()
+        : branchKeyId;
 
     // 3. Create a custom encryption context for the Branch Key.
     // Most encrypted data should have an associated encryption context
@@ -90,6 +95,6 @@ public class CreateKeyExample {
     final String keyStoreTableName = args[0];
     final String logicalKeyStoreName = args[1];
     final String kmsKeyArn = args[2];
-    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null);
+    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null, null);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
@@ -71,16 +71,16 @@ public class CreateKeyExample {
           .builder()
           // This is the KMS ARN that will be used to protect the Branch Key.
           // It is a required argument.
-          .kmsArn(KMSIdentifier.builder().kmsKeyArn(kmsKeyArn).build())
+          .KmsArn(KMSIdentifier.builder().KmsKeyArn(kmsKeyArn).build())
           // If you need to specify the Identifier for a Branch Key, you may.
           // This is an optional argument.
-          .branchKeyIdentifier(branchKeyId)
+          .Identifier(branchKeyId)
           // If a branch key Identifier is provided,
           // custom encryption context MUST be provided as well.
-          .encryptionContext(encryptionContext)
+          .EncryptionContext(encryptionContext)
           .build()
       )
-      .branchKeyIdentifier();
+      .Identifier();
 
     assert actualBranchKeyId.equals(branchKeyId);
     return branchKeyId;

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/MutationExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/MutationExample.java
@@ -79,8 +79,12 @@ public class MutationExample {
         AdminProvider.mutatedItemsToString(applyOutput.MutatedBranchKeyItems())
       );
 
-      if (result.ContinueMutation() != null) {token = result.ContinueMutation();}
-      if (result.CompleteMutation() != null) {done = true;}
+      if (result.ContinueMutation() != null) {
+        token = result.ContinueMutation();
+      }
+      if (result.CompleteMutation() != null) {
+        done = true;
+      }
       if (limitLoop == 0) {
         done = true;
       }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/MutationExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/MutationExample.java
@@ -39,25 +39,25 @@ public class MutationExample {
     terminalEC.put("Robbie", "is a dog.");
     Mutations mutations = Mutations
       .builder()
-      .terminalEncryptionContext(terminalEC)
-      .terminalKmsArn(kmsKeyArnTerminal)
+      .TerminalEncryptionContext(terminalEC)
+      .TerminalKmsArn(kmsKeyArnTerminal)
       .build();
 
     InitializeMutationInput initInput = InitializeMutationInput
       .builder()
-      .mutations(mutations)
-      .branchKeyIdentifier(branchKeyId)
-      .strategy(strategy)
+      .Mutations(mutations)
+      .Identifier(branchKeyId)
+      .Strategy(strategy)
       .build();
 
     InitializeMutationOutput initOutput = admin.InitializeMutation(initInput);
 
-    MutationToken token = initOutput.mutationToken();
+    MutationToken token = initOutput.MutationToken();
     System.out.println(
       "InitLogs: " +
       branchKeyId +
       " items: \n" +
-      AdminProvider.mutatedItemsToString(initOutput.mutatedBranchKeyItems())
+      AdminProvider.mutatedItemsToString(initOutput.MutatedBranchKeyItems())
     );
     boolean done = false;
     int limitLoop = 10;
@@ -65,23 +65,25 @@ public class MutationExample {
     while (!done) {
       ApplyMutationInput applyInput = ApplyMutationInput
         .builder()
-        .mutationToken(token)
-        .pageSize(98)
-        .strategy(strategy)
+        .MutationToken(token)
+        .PageSize(98)
+        .Strategy(strategy)
         .build();
       ApplyMutationOutput applyOutput = admin.ApplyMutation(applyInput);
-      ApplyMutationResult result = applyOutput.result();
+      ApplyMutationResult result = applyOutput.MutationResult();
 
       System.out.println(
         "ApplyLogs: " +
         branchKeyId +
         " items: \n" +
-        AdminProvider.mutatedItemsToString(applyOutput.mutatedBranchKeyItems())
+        AdminProvider.mutatedItemsToString(applyOutput.MutatedBranchKeyItems())
       );
 
-      if (result.continueMutation() != null) token = result.continueMutation();
-      if (result.completeMutation() != null) done = true;
-      if (limitLoop == 0) done = true;
+      if (result.ContinueMutation() != null) {token = result.ContinueMutation();}
+      if (result.CompleteMutation() != null) {done = true;}
+      if (limitLoop == 0) {
+        done = true;
+      }
 
       limitLoop--;
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/VersionKeyExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/VersionKeyExample.java
@@ -63,9 +63,9 @@ public class VersionKeyExample {
         // This is the KMS ARN that will be used to protect the Branch Key.
         // It is a required argument.
         // This ARN MUST match the ARN that protects the Branch Key.
-        .kmsArn(KMSIdentifier.builder().kmsKeyArn(kmsKeyArn).build())
+        .KmsArn(KMSIdentifier.builder().KmsKeyArn(kmsKeyArn).build())
         // This the Identifier for the Branch Key that is being rotated/versioned.
-        .branchKeyIdentifier(branchKeyId)
+        .Identifier(branchKeyId)
         .build()
     );
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/IKeyStorageInterface.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/IKeyStorageInterface.java
@@ -3,6 +3,8 @@
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 package software.amazon.cryptography.keystore;
 
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedBeaconKeyInput;
@@ -13,6 +15,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutationOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 import software.amazon.cryptography.keystore.model.WriteInitializeMutationInput;
@@ -25,6 +29,12 @@ import software.amazon.cryptography.keystore.model.WriteNewEncryptedBranchKeyVer
 import software.amazon.cryptography.keystore.model.WriteNewEncryptedBranchKeyVersionOutput;
 
 public interface IKeyStorageInterface {
+  /**
+   * Overwrite an existing Mutation Lock.
+   *
+   */
+  ClobberMutationLockOutput ClobberMutationLock(ClobberMutationLockInput input);
+
   /**
    * Get the ACTIVE branch key for encryption for an existing branch key.
    *
@@ -72,6 +82,14 @@ public interface IKeyStorageInterface {
    * @return Output containing information about the underlying storage.
    */
   GetKeyStorageInfoOutput GetKeyStorageInfo(GetKeyStorageInfoInput input);
+
+  /**
+   * Check for Mutation Lock on a Branch Key ID.
+   * If one exists, returns the Mutation Lock.
+   * Otherwise, returns nothing.
+   *
+   */
+  GetMutationLockOutput GetMutationLock(GetMutationLockInput input);
 
   /**
    * Query Storage for a page of version (decrypt only) items

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStorageInterface.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStorageInterface.java
@@ -8,6 +8,8 @@ import java.lang.IllegalArgumentException;
 import java.lang.RuntimeException;
 import java.util.Objects;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedBeaconKeyInput;
@@ -18,6 +20,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutationOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 import software.amazon.cryptography.keystore.model.WriteInitializeMutationInput;
@@ -67,6 +71,25 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
 
   public software.amazon.cryptography.keystore.internaldafny.types.IKeyStorageInterface impl() {
     return this._impl;
+  }
+
+  /**
+   * Overwrite an existing Mutation Lock.
+   *
+   */
+  public ClobberMutationLockOutput ClobberMutationLock(
+    ClobberMutationLockInput input
+  ) {
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyValue =
+      ToDafny.ClobberMutationLockInput(input);
+    Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > result = this._impl.ClobberMutationLock(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.ClobberMutationLockOutput(result.dtor_value());
   }
 
   /**
@@ -172,6 +195,25 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
       throw ToNative.Error(result.dtor_error());
     }
     return ToNative.GetKeyStorageInfoOutput(result.dtor_value());
+  }
+
+  /**
+   * Check for Mutation Lock on a Branch Key ID.
+   * If one exists, returns the Mutation Lock.
+   * Otherwise, returns nothing.
+   *
+   */
+  public GetMutationLockOutput GetMutationLock(GetMutationLockInput input) {
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyValue =
+      ToDafny.GetMutationLockInput(input);
+    Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > result = this._impl.GetMutationLock(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.GetMutationLockOutput(result.dtor_value());
   }
 
   /**
@@ -305,6 +347,42 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
         );
       }
       this._impl = nativeImpl;
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > ClobberMutationLock(
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyInput
+    ) {
+      try {
+        ClobberMutationLockInput nativeInput =
+          ToNative.ClobberMutationLockInput(dafnyInput);
+        ClobberMutationLockOutput nativeOutput =
+          this._impl.ClobberMutationLock(nativeInput);
+        software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput dafnyOutput =
+          ToDafny.ClobberMutationLockOutput(nativeOutput);
+        return Result.create_Success(
+          software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          dafnyOutput
+        );
+      } catch (RuntimeException ex) {
+        return Result.create_Failure(
+          software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          ToDafny.Error(ex)
+        );
+      }
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > ClobberMutationLock_k(
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyInput
+    ) {
+      throw new RuntimeException("Not supported at this time.");
     }
 
     public Result<
@@ -484,6 +562,43 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
       Error
     > GetKeyStorageInfo_k(
       software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoInput dafnyInput
+    ) {
+      throw new RuntimeException("Not supported at this time.");
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > GetMutationLock(
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyInput
+    ) {
+      try {
+        GetMutationLockInput nativeInput = ToNative.GetMutationLockInput(
+          dafnyInput
+        );
+        GetMutationLockOutput nativeOutput =
+          this._impl.GetMutationLock(nativeInput);
+        software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput dafnyOutput =
+          ToDafny.GetMutationLockOutput(nativeOutput);
+        return Result.create_Success(
+          software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          dafnyOutput
+        );
+      } catch (RuntimeException ex) {
+        return Result.create_Failure(
+          software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          ToDafny.Error(ex)
+        );
+      }
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > GetMutationLock_k(
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyInput
     ) {
       throw new RuntimeException("Not supported at this time.");
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -23,6 +23,8 @@ import software.amazon.cryptography.keystore.internaldafny.types.ActiveHierarchi
 import software.amazon.cryptography.keystore.internaldafny.types.AwsKms;
 import software.amazon.cryptography.keystore.internaldafny.types.BeaconKeyMaterials;
 import software.amazon.cryptography.keystore.internaldafny.types.BranchKeyMaterials;
+import software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyStoreInput;
@@ -31,8 +33,12 @@ import software.amazon.cryptography.keystore.internaldafny.types.Discovery;
 import software.amazon.cryptography.keystore.internaldafny.types.DynamoDBTable;
 import software.amazon.cryptography.keystore.internaldafny.types.EncryptedHierarchicalKey;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException;
 import software.amazon.cryptography.keystore.internaldafny.types.GetActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetActiveBranchKeyOutput;
@@ -51,6 +57,8 @@ import software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInit
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType;
 import software.amazon.cryptography.keystore.internaldafny.types.HierarchicalSymmetric;
 import software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient;
@@ -72,9 +80,13 @@ import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncrypt
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput;
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionOutput;
+import software.amazon.cryptography.keystore.model.AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.model.CollectionOfErrors;
 import software.amazon.cryptography.keystore.model.KeyStorageException;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
+import software.amazon.cryptography.keystore.model.MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.model.NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.model.OldEncConditionFailed;
 import software.amazon.cryptography.keystore.model.OpaqueError;
 import software.amazon.cryptography.keystore.model.VersionRaceException;
 import software.amazon.cryptography.services.dynamodb.internaldafny.types.IDynamoDBClient;
@@ -83,11 +95,23 @@ import software.amazon.cryptography.services.kms.internaldafny.types.IKMSClient;
 public class ToDafny {
 
   public static Error Error(RuntimeException nativeValue) {
+    if (nativeValue instanceof AlreadyExistsConditionFailed) {
+      return ToDafny.Error((AlreadyExistsConditionFailed) nativeValue);
+    }
     if (nativeValue instanceof KeyStorageException) {
       return ToDafny.Error((KeyStorageException) nativeValue);
     }
     if (nativeValue instanceof KeyStoreException) {
       return ToDafny.Error((KeyStoreException) nativeValue);
+    }
+    if (nativeValue instanceof MutationLockConditionFailed) {
+      return ToDafny.Error((MutationLockConditionFailed) nativeValue);
+    }
+    if (nativeValue instanceof NoLongerExistsConditionFailed) {
+      return ToDafny.Error((NoLongerExistsConditionFailed) nativeValue);
+    }
+    if (nativeValue instanceof OldEncConditionFailed) {
+      return ToDafny.Error((OldEncConditionFailed) nativeValue);
     }
     if (nativeValue instanceof VersionRaceException) {
       return ToDafny.Error((VersionRaceException) nativeValue);
@@ -255,6 +279,20 @@ public class ToDafny {
       encryptionContext,
       branchKey
     );
+  }
+
+  public static ClobberMutationLockInput ClobberMutationLockInput(
+    software.amazon.cryptography.keystore.model.ClobberMutationLockInput nativeValue
+  ) {
+    MutationLock mutationLock;
+    mutationLock = ToDafny.MutationLock(nativeValue.mutationLock());
+    return new ClobberMutationLockInput(mutationLock);
+  }
+
+  public static ClobberMutationLockOutput ClobberMutationLockOutput(
+    software.amazon.cryptography.keystore.model.ClobberMutationLockOutput nativeValue
+  ) {
+    return new ClobberMutationLockOutput();
   }
 
   public static CreateKeyInput CreateKeyInput(
@@ -606,6 +644,31 @@ public class ToDafny {
     );
   }
 
+  public static GetMutationLockInput GetMutationLockInput(
+    software.amazon.cryptography.keystore.model.GetMutationLockInput nativeValue
+  ) {
+    DafnySequence<? extends Character> identifier;
+    identifier =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.Identifier()
+      );
+    return new GetMutationLockInput(identifier);
+  }
+
+  public static GetMutationLockOutput GetMutationLockOutput(
+    software.amazon.cryptography.keystore.model.GetMutationLockOutput nativeValue
+  ) {
+    Option<MutationLock> mutationLock;
+    mutationLock =
+      Objects.nonNull(nativeValue.mutationLock())
+        ? Option.create_Some(
+          MutationLock._typeDescriptor(),
+          ToDafny.MutationLock(nativeValue.mutationLock())
+        )
+        : Option.create_None(MutationLock._typeDescriptor());
+    return new GetMutationLockOutput(mutationLock);
+  }
+
   public static HierarchicalSymmetric HierarchicalSymmetric(
     software.amazon.cryptography.keystore.model.HierarchicalSymmetric nativeValue
   ) {
@@ -919,6 +982,15 @@ public class ToDafny {
     return new WriteNewEncryptedBranchKeyVersionOutput();
   }
 
+  public static Error Error(AlreadyExistsConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_AlreadyExistsConditionFailed(message);
+  }
+
   public static Error Error(KeyStorageException nativeValue) {
     DafnySequence<? extends Character> message;
     message =
@@ -935,6 +1007,33 @@ public class ToDafny {
         nativeValue.message()
       );
     return new Error_KeyStoreException(message);
+  }
+
+  public static Error Error(MutationLockConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationLockConditionFailed(message);
+  }
+
+  public static Error Error(NoLongerExistsConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_NoLongerExistsConditionFailed(message);
+  }
+
+  public static Error Error(OldEncConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_OldEncConditionFailed(message);
   }
 
   public static Error Error(VersionRaceException nativeValue) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -285,7 +285,7 @@ public class ToDafny {
     software.amazon.cryptography.keystore.model.ClobberMutationLockInput nativeValue
   ) {
     MutationLock mutationLock;
-    mutationLock = ToDafny.MutationLock(nativeValue.mutationLock());
+    mutationLock = ToDafny.MutationLock(nativeValue.MutationLock());
     return new ClobberMutationLockInput(mutationLock);
   }
 
@@ -573,15 +573,15 @@ public class ToDafny {
     software.amazon.cryptography.keystore.model.GetItemsForInitializeMutationOutput nativeValue
   ) {
     EncryptedHierarchicalKey activeItem;
-    activeItem = ToDafny.EncryptedHierarchicalKey(nativeValue.activeItem());
+    activeItem = ToDafny.EncryptedHierarchicalKey(nativeValue.ActiveItem());
     EncryptedHierarchicalKey beaconItem;
-    beaconItem = ToDafny.EncryptedHierarchicalKey(nativeValue.beaconItem());
+    beaconItem = ToDafny.EncryptedHierarchicalKey(nativeValue.BeaconItem());
     Option<MutationLock> mutationLock;
     mutationLock =
-      Objects.nonNull(nativeValue.mutationLock())
+      Objects.nonNull(nativeValue.MutationLock())
         ? Option.create_Some(
           MutationLock._typeDescriptor(),
-          ToDafny.MutationLock(nativeValue.mutationLock())
+          ToDafny.MutationLock(nativeValue.MutationLock())
         )
         : Option.create_None(MutationLock._typeDescriptor());
     return new GetItemsForInitializeMutationOutput(
@@ -660,10 +660,10 @@ public class ToDafny {
   ) {
     Option<MutationLock> mutationLock;
     mutationLock =
-      Objects.nonNull(nativeValue.mutationLock())
+      Objects.nonNull(nativeValue.MutationLock())
         ? Option.create_Some(
           MutationLock._typeDescriptor(),
-          ToDafny.MutationLock(nativeValue.mutationLock())
+          ToDafny.MutationLock(nativeValue.MutationLock())
         )
         : Option.create_None(MutationLock._typeDescriptor());
     return new GetMutationLockOutput(mutationLock);
@@ -827,11 +827,11 @@ public class ToDafny {
   ) {
     Option<DafnySequence<? extends Byte>> exclusiveStartKey;
     exclusiveStartKey =
-      Objects.nonNull(nativeValue.exclusiveStartKey())
+      Objects.nonNull(nativeValue.ExclusiveStartKey())
         ? Option.create_Some(
           DafnySequence._typeDescriptor(TypeDescriptor.BYTE),
           software.amazon.smithy.dafny.conversion.ToDafny.Simple.ByteSequence(
-            nativeValue.exclusiveStartKey()
+            nativeValue.ExclusiveStartKey()
           )
         )
         : Option.create_None(
@@ -843,7 +843,7 @@ public class ToDafny {
         nativeValue.Identifier()
       );
     Integer pageSize;
-    pageSize = (nativeValue.pageSize());
+    pageSize = (nativeValue.PageSize());
     return new QueryForVersionsInput(exclusiveStartKey, identifier, pageSize);
   }
 
@@ -853,10 +853,10 @@ public class ToDafny {
     DafnySequence<? extends Byte> exclusiveStartKey;
     exclusiveStartKey =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.ByteSequence(
-        nativeValue.exclusiveStartKey()
+        nativeValue.ExclusiveStartKey()
       );
     DafnySequence<? extends EncryptedHierarchicalKey> items;
-    items = ToDafny.EncryptedHierarchicalKeys(nativeValue.items());
+    items = ToDafny.EncryptedHierarchicalKeys(nativeValue.Items());
     return new QueryForVersionsOutput(exclusiveStartKey, items);
   }
 
@@ -881,15 +881,15 @@ public class ToDafny {
     software.amazon.cryptography.keystore.model.WriteInitializeMutationInput nativeValue
   ) {
     EncryptedHierarchicalKey active;
-    active = ToDafny.EncryptedHierarchicalKey(nativeValue.active());
+    active = ToDafny.EncryptedHierarchicalKey(nativeValue.Active());
     EncryptedHierarchicalKey oldActive;
-    oldActive = ToDafny.EncryptedHierarchicalKey(nativeValue.oldActive());
+    oldActive = ToDafny.EncryptedHierarchicalKey(nativeValue.OldActive());
     EncryptedHierarchicalKey version;
-    version = ToDafny.EncryptedHierarchicalKey(nativeValue.version());
+    version = ToDafny.EncryptedHierarchicalKey(nativeValue.Version());
     EncryptedHierarchicalKey beacon;
-    beacon = ToDafny.EncryptedHierarchicalKey(nativeValue.beacon());
+    beacon = ToDafny.EncryptedHierarchicalKey(nativeValue.Beacon());
     MutationLock mutationLock;
-    mutationLock = ToDafny.MutationLock(nativeValue.mutationLock());
+    mutationLock = ToDafny.MutationLock(nativeValue.MutationLock());
     return new WriteInitializeMutationInput(
       active,
       oldActive,
@@ -909,7 +909,7 @@ public class ToDafny {
     software.amazon.cryptography.keystore.model.WriteMutatedVersionsInput nativeValue
   ) {
     DafnySequence<? extends EncryptedHierarchicalKey> items;
-    items = ToDafny.EncryptedHierarchicalKeys(nativeValue.items());
+    items = ToDafny.EncryptedHierarchicalKeys(nativeValue.Items());
     DafnySequence<? extends Character> identifier;
     identifier =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
@@ -968,7 +968,7 @@ public class ToDafny {
     EncryptedHierarchicalKey version;
     version = ToDafny.EncryptedHierarchicalKey(nativeValue.Version());
     EncryptedHierarchicalKey oldActive;
-    oldActive = ToDafny.EncryptedHierarchicalKey(nativeValue.oldActive());
+    oldActive = ToDafny.EncryptedHierarchicalKey(nativeValue.OldActive());
     return new WriteNewEncryptedBranchKeyVersionInput(
       active,
       version,

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -336,8 +336,8 @@ public class ToNative {
   ) {
     ClobberMutationLockInput.Builder nativeBuilder =
       ClobberMutationLockInput.builder();
-    nativeBuilder.mutationLock(
-      ToNative.MutationLock(dafnyValue.dtor_mutationLock())
+    nativeBuilder.MutationLock(
+      ToNative.MutationLock(dafnyValue.dtor_MutationLock())
     );
     return nativeBuilder.build();
   }
@@ -630,15 +630,15 @@ public class ToNative {
   ) {
     GetItemsForInitializeMutationOutput.Builder nativeBuilder =
       GetItemsForInitializeMutationOutput.builder();
-    nativeBuilder.activeItem(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_activeItem())
+    nativeBuilder.ActiveItem(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_ActiveItem())
     );
-    nativeBuilder.beaconItem(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_beaconItem())
+    nativeBuilder.BeaconItem(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_BeaconItem())
     );
-    if (dafnyValue.dtor_mutationLock().is_Some()) {
-      nativeBuilder.mutationLock(
-        ToNative.MutationLock(dafnyValue.dtor_mutationLock().dtor_value())
+    if (dafnyValue.dtor_MutationLock().is_Some()) {
+      nativeBuilder.MutationLock(
+        ToNative.MutationLock(dafnyValue.dtor_MutationLock().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -716,9 +716,9 @@ public class ToNative {
   ) {
     GetMutationLockOutput.Builder nativeBuilder =
       GetMutationLockOutput.builder();
-    if (dafnyValue.dtor_mutationLock().is_Some()) {
-      nativeBuilder.mutationLock(
-        ToNative.MutationLock(dafnyValue.dtor_mutationLock().dtor_value())
+    if (dafnyValue.dtor_MutationLock().is_Some()) {
+      nativeBuilder.MutationLock(
+        ToNative.MutationLock(dafnyValue.dtor_MutationLock().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -844,10 +844,10 @@ public class ToNative {
   ) {
     QueryForVersionsInput.Builder nativeBuilder =
       QueryForVersionsInput.builder();
-    if (dafnyValue.dtor_exclusiveStartKey().is_Some()) {
-      nativeBuilder.exclusiveStartKey(
+    if (dafnyValue.dtor_ExclusiveStartKey().is_Some()) {
+      nativeBuilder.ExclusiveStartKey(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.ByteBuffer(
-          dafnyValue.dtor_exclusiveStartKey().dtor_value()
+          dafnyValue.dtor_ExclusiveStartKey().dtor_value()
         )
       );
     }
@@ -856,7 +856,7 @@ public class ToNative {
         dafnyValue.dtor_Identifier()
       )
     );
-    nativeBuilder.pageSize((dafnyValue.dtor_pageSize()));
+    nativeBuilder.PageSize((dafnyValue.dtor_PageSize()));
     return nativeBuilder.build();
   }
 
@@ -865,13 +865,13 @@ public class ToNative {
   ) {
     QueryForVersionsOutput.Builder nativeBuilder =
       QueryForVersionsOutput.builder();
-    nativeBuilder.exclusiveStartKey(
+    nativeBuilder.ExclusiveStartKey(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.ByteBuffer(
-        dafnyValue.dtor_exclusiveStartKey()
+        dafnyValue.dtor_ExclusiveStartKey()
       )
     );
-    nativeBuilder.items(
-      ToNative.EncryptedHierarchicalKeys(dafnyValue.dtor_items())
+    nativeBuilder.Items(
+      ToNative.EncryptedHierarchicalKeys(dafnyValue.dtor_Items())
     );
     return nativeBuilder.build();
   }
@@ -900,20 +900,20 @@ public class ToNative {
   ) {
     WriteInitializeMutationInput.Builder nativeBuilder =
       WriteInitializeMutationInput.builder();
-    nativeBuilder.active(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_active())
+    nativeBuilder.Active(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_Active())
     );
-    nativeBuilder.oldActive(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_oldActive())
+    nativeBuilder.OldActive(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_OldActive())
     );
-    nativeBuilder.version(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_version())
+    nativeBuilder.Version(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_Version())
     );
-    nativeBuilder.beacon(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_beacon())
+    nativeBuilder.Beacon(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_Beacon())
     );
-    nativeBuilder.mutationLock(
-      ToNative.MutationLock(dafnyValue.dtor_mutationLock())
+    nativeBuilder.MutationLock(
+      ToNative.MutationLock(dafnyValue.dtor_MutationLock())
     );
     return nativeBuilder.build();
   }
@@ -931,8 +931,8 @@ public class ToNative {
   ) {
     WriteMutatedVersionsInput.Builder nativeBuilder =
       WriteMutatedVersionsInput.builder();
-    nativeBuilder.items(
-      ToNative.EncryptedHierarchicalKeys(dafnyValue.dtor_items())
+    nativeBuilder.Items(
+      ToNative.EncryptedHierarchicalKeys(dafnyValue.dtor_Items())
     );
     nativeBuilder.Identifier(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
@@ -997,8 +997,8 @@ public class ToNative {
     nativeBuilder.Version(
       ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_Version())
     );
-    nativeBuilder.oldActive(
-      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_oldActive())
+    nativeBuilder.OldActive(
+      ToNative.EncryptedHierarchicalKey(dafnyValue.dtor_OldActive())
     );
     return nativeBuilder.build();
   }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -13,17 +13,24 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_CollectionOfErrors;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_Opaque;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException;
 import software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient;
 import software.amazon.cryptography.keystore.model.ActiveHierarchicalSymmetric;
 import software.amazon.cryptography.keystore.model.ActiveHierarchicalSymmetricBeacon;
+import software.amazon.cryptography.keystore.model.AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.model.AwsKms;
 import software.amazon.cryptography.keystore.model.BeaconKeyMaterials;
 import software.amazon.cryptography.keystore.model.BranchKeyMaterials;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.CollectionOfErrors;
 import software.amazon.cryptography.keystore.model.CreateKeyInput;
 import software.amazon.cryptography.keystore.model.CreateKeyOutput;
@@ -49,6 +56,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStoreInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.HierarchicalKeyType;
 import software.amazon.cryptography.keystore.model.HierarchicalSymmetric;
 import software.amazon.cryptography.keystore.model.KMSConfiguration;
@@ -58,6 +67,9 @@ import software.amazon.cryptography.keystore.model.KeyStoreConfig;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
 import software.amazon.cryptography.keystore.model.MRDiscovery;
 import software.amazon.cryptography.keystore.model.MutationLock;
+import software.amazon.cryptography.keystore.model.MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.model.NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.model.OldEncConditionFailed;
 import software.amazon.cryptography.keystore.model.OpaqueError;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
@@ -98,6 +110,19 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static AlreadyExistsConditionFailed Error(
+    Error_AlreadyExistsConditionFailed dafnyValue
+  ) {
+    AlreadyExistsConditionFailed.Builder nativeBuilder =
+      AlreadyExistsConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static KeyStorageException Error(
     Error_KeyStorageException dafnyValue
   ) {
@@ -120,6 +145,45 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static MutationLockConditionFailed Error(
+    Error_MutationLockConditionFailed dafnyValue
+  ) {
+    MutationLockConditionFailed.Builder nativeBuilder =
+      MutationLockConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static NoLongerExistsConditionFailed Error(
+    Error_NoLongerExistsConditionFailed dafnyValue
+  ) {
+    NoLongerExistsConditionFailed.Builder nativeBuilder =
+      NoLongerExistsConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static OldEncConditionFailed Error(
+    Error_OldEncConditionFailed dafnyValue
+  ) {
+    OldEncConditionFailed.Builder nativeBuilder =
+      OldEncConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static VersionRaceException Error(
     Error_VersionRaceException dafnyValue
   ) {
@@ -133,11 +197,23 @@ public class ToNative {
   }
 
   public static RuntimeException Error(Error dafnyValue) {
+    if (dafnyValue.is_AlreadyExistsConditionFailed()) {
+      return ToNative.Error((Error_AlreadyExistsConditionFailed) dafnyValue);
+    }
     if (dafnyValue.is_KeyStorageException()) {
       return ToNative.Error((Error_KeyStorageException) dafnyValue);
     }
     if (dafnyValue.is_KeyStoreException()) {
       return ToNative.Error((Error_KeyStoreException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationLockConditionFailed()) {
+      return ToNative.Error((Error_MutationLockConditionFailed) dafnyValue);
+    }
+    if (dafnyValue.is_NoLongerExistsConditionFailed()) {
+      return ToNative.Error((Error_NoLongerExistsConditionFailed) dafnyValue);
+    }
+    if (dafnyValue.is_OldEncConditionFailed()) {
+      return ToNative.Error((Error_OldEncConditionFailed) dafnyValue);
     }
     if (dafnyValue.is_VersionRaceException()) {
       return ToNative.Error((Error_VersionRaceException) dafnyValue);
@@ -252,6 +328,25 @@ public class ToNative {
         dafnyValue.dtor_branchKey()
       )
     );
+    return nativeBuilder.build();
+  }
+
+  public static ClobberMutationLockInput ClobberMutationLockInput(
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyValue
+  ) {
+    ClobberMutationLockInput.Builder nativeBuilder =
+      ClobberMutationLockInput.builder();
+    nativeBuilder.mutationLock(
+      ToNative.MutationLock(dafnyValue.dtor_mutationLock())
+    );
+    return nativeBuilder.build();
+  }
+
+  public static ClobberMutationLockOutput ClobberMutationLockOutput(
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput dafnyValue
+  ) {
+    ClobberMutationLockOutput.Builder nativeBuilder =
+      ClobberMutationLockOutput.builder();
     return nativeBuilder.build();
   }
 
@@ -601,6 +696,31 @@ public class ToNative {
     nativeBuilder.kmsConfiguration(
       ToNative.KMSConfiguration(dafnyValue.dtor_kmsConfiguration())
     );
+    return nativeBuilder.build();
+  }
+
+  public static GetMutationLockInput GetMutationLockInput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyValue
+  ) {
+    GetMutationLockInput.Builder nativeBuilder = GetMutationLockInput.builder();
+    nativeBuilder.Identifier(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_Identifier()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static GetMutationLockOutput GetMutationLockOutput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput dafnyValue
+  ) {
+    GetMutationLockOutput.Builder nativeBuilder =
+      GetMutationLockOutput.builder();
+    if (dafnyValue.dtor_mutationLock().is_Some()) {
+      nativeBuilder.mutationLock(
+        ToNative.MutationLock(dafnyValue.dtor_mutationLock().dtor_value())
+      );
+    }
     return nativeBuilder.build();
   }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/AlreadyExistsConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/AlreadyExistsConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed. An item already exists for this Branch Key ID & Type.
  */
-public class MutationInvalidException extends RuntimeException {
+public class AlreadyExistsConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected AlreadyExistsConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    AlreadyExistsConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(AlreadyExistsConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public AlreadyExistsConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new AlreadyExistsConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
@@ -13,10 +13,10 @@ public class ClobberMutationLockInput {
    * - only one Mutation affects a Branch Key at a time
    * - all items of a Branch Key are mutated consistently
    */
-  private final MutationLock mutationLock;
+  private final MutationLock MutationLock;
 
   protected ClobberMutationLockInput(BuilderImpl builder) {
-    this.mutationLock = builder.mutationLock();
+    this.MutationLock = builder.MutationLock();
   }
 
   /**
@@ -25,8 +25,8 @@ public class ClobberMutationLockInput {
    * - only one Mutation affects a Branch Key at a time
    * - all items of a Branch Key are mutated consistently
    */
-  public MutationLock mutationLock() {
-    return this.mutationLock;
+  public MutationLock MutationLock() {
+    return this.MutationLock;
   }
 
   public Builder toBuilder() {
@@ -39,12 +39,12 @@ public class ClobberMutationLockInput {
 
   public interface Builder {
     /**
-     * @param mutationLock Information an in-flight Mutation of a Branch Key.
+     * @param MutationLock Information an in-flight Mutation of a Branch Key.
      * This ensures:
      * - only one Mutation affects a Branch Key at a time
      * - all items of a Branch Key are mutated consistently
      */
-    Builder mutationLock(MutationLock mutationLock);
+    Builder MutationLock(MutationLock MutationLock);
 
     /**
      * @return Information an in-flight Mutation of a Branch Key.
@@ -52,34 +52,34 @@ public class ClobberMutationLockInput {
      * - only one Mutation affects a Branch Key at a time
      * - all items of a Branch Key are mutated consistently
      */
-    MutationLock mutationLock();
+    MutationLock MutationLock();
 
     ClobberMutationLockInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected MutationLock mutationLock;
+    protected MutationLock MutationLock;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(ClobberMutationLockInput model) {
-      this.mutationLock = model.mutationLock();
+      this.MutationLock = model.MutationLock();
     }
 
-    public Builder mutationLock(MutationLock mutationLock) {
-      this.mutationLock = mutationLock;
+    public Builder MutationLock(MutationLock MutationLock) {
+      this.MutationLock = MutationLock;
       return this;
     }
 
-    public MutationLock mutationLock() {
-      return this.mutationLock;
+    public MutationLock MutationLock() {
+      return this.MutationLock;
     }
 
     public ClobberMutationLockInput build() {
-      if (Objects.isNull(this.mutationLock())) {
+      if (Objects.isNull(this.MutationLock())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutationLock`"
+          "Missing value for required field `MutationLock`"
         );
       }
       return new ClobberMutationLockInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
@@ -1,0 +1,88 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.Objects;
+
+public class ClobberMutationLockInput {
+
+  /**
+   * Information an in-flight Mutation of a Branch Key.
+   * This ensures:
+   * - only one Mutation affects a Branch Key at a time
+   * - all items of a Branch Key are mutated consistently
+   */
+  private final MutationLock mutationLock;
+
+  protected ClobberMutationLockInput(BuilderImpl builder) {
+    this.mutationLock = builder.mutationLock();
+  }
+
+  /**
+   * @return Information an in-flight Mutation of a Branch Key.
+   * This ensures:
+   * - only one Mutation affects a Branch Key at a time
+   * - all items of a Branch Key are mutated consistently
+   */
+  public MutationLock mutationLock() {
+    return this.mutationLock;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param mutationLock Information an in-flight Mutation of a Branch Key.
+     * This ensures:
+     * - only one Mutation affects a Branch Key at a time
+     * - all items of a Branch Key are mutated consistently
+     */
+    Builder mutationLock(MutationLock mutationLock);
+
+    /**
+     * @return Information an in-flight Mutation of a Branch Key.
+     * This ensures:
+     * - only one Mutation affects a Branch Key at a time
+     * - all items of a Branch Key are mutated consistently
+     */
+    MutationLock mutationLock();
+
+    ClobberMutationLockInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected MutationLock mutationLock;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(ClobberMutationLockInput model) {
+      this.mutationLock = model.mutationLock();
+    }
+
+    public Builder mutationLock(MutationLock mutationLock) {
+      this.mutationLock = mutationLock;
+      return this;
+    }
+
+    public MutationLock mutationLock() {
+      return this.mutationLock;
+    }
+
+    public ClobberMutationLockInput build() {
+      if (Objects.isNull(this.mutationLock())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `mutationLock`"
+        );
+      }
+      return new ClobberMutationLockInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockOutput.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+public class ClobberMutationLockOutput {
+
+  protected ClobberMutationLockOutput(BuilderImpl builder) {}
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    ClobberMutationLockOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(ClobberMutationLockOutput model) {}
+
+    public ClobberMutationLockOutput build() {
+      return new ClobberMutationLockOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetItemsForInitializeMutationOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetItemsForInitializeMutationOutput.java
@@ -10,43 +10,43 @@ public class GetItemsForInitializeMutationOutput {
   /**
    * The materials for the Branch Key.
    */
-  private final EncryptedHierarchicalKey activeItem;
+  private final EncryptedHierarchicalKey ActiveItem;
 
   /**
    * The materials for the Beacon Key.
    */
-  private final EncryptedHierarchicalKey beaconItem;
+  private final EncryptedHierarchicalKey BeaconItem;
 
   /**
    * The Mutation Lock, if it exists.
    */
-  private final MutationLock mutationLock;
+  private final MutationLock MutationLock;
 
   protected GetItemsForInitializeMutationOutput(BuilderImpl builder) {
-    this.activeItem = builder.activeItem();
-    this.beaconItem = builder.beaconItem();
-    this.mutationLock = builder.mutationLock();
+    this.ActiveItem = builder.ActiveItem();
+    this.BeaconItem = builder.BeaconItem();
+    this.MutationLock = builder.MutationLock();
   }
 
   /**
    * @return The materials for the Branch Key.
    */
-  public EncryptedHierarchicalKey activeItem() {
-    return this.activeItem;
+  public EncryptedHierarchicalKey ActiveItem() {
+    return this.ActiveItem;
   }
 
   /**
    * @return The materials for the Beacon Key.
    */
-  public EncryptedHierarchicalKey beaconItem() {
-    return this.beaconItem;
+  public EncryptedHierarchicalKey BeaconItem() {
+    return this.BeaconItem;
   }
 
   /**
    * @return The Mutation Lock, if it exists.
    */
-  public MutationLock mutationLock() {
-    return this.mutationLock;
+  public MutationLock MutationLock() {
+    return this.MutationLock;
   }
 
   public Builder toBuilder() {
@@ -59,90 +59,90 @@ public class GetItemsForInitializeMutationOutput {
 
   public interface Builder {
     /**
-     * @param activeItem The materials for the Branch Key.
+     * @param ActiveItem The materials for the Branch Key.
      */
-    Builder activeItem(EncryptedHierarchicalKey activeItem);
+    Builder ActiveItem(EncryptedHierarchicalKey ActiveItem);
 
     /**
      * @return The materials for the Branch Key.
      */
-    EncryptedHierarchicalKey activeItem();
+    EncryptedHierarchicalKey ActiveItem();
 
     /**
-     * @param beaconItem The materials for the Beacon Key.
+     * @param BeaconItem The materials for the Beacon Key.
      */
-    Builder beaconItem(EncryptedHierarchicalKey beaconItem);
+    Builder BeaconItem(EncryptedHierarchicalKey BeaconItem);
 
     /**
      * @return The materials for the Beacon Key.
      */
-    EncryptedHierarchicalKey beaconItem();
+    EncryptedHierarchicalKey BeaconItem();
 
     /**
-     * @param mutationLock The Mutation Lock, if it exists.
+     * @param MutationLock The Mutation Lock, if it exists.
      */
-    Builder mutationLock(MutationLock mutationLock);
+    Builder MutationLock(MutationLock MutationLock);
 
     /**
      * @return The Mutation Lock, if it exists.
      */
-    MutationLock mutationLock();
+    MutationLock MutationLock();
 
     GetItemsForInitializeMutationOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected EncryptedHierarchicalKey activeItem;
+    protected EncryptedHierarchicalKey ActiveItem;
 
-    protected EncryptedHierarchicalKey beaconItem;
+    protected EncryptedHierarchicalKey BeaconItem;
 
-    protected MutationLock mutationLock;
+    protected MutationLock MutationLock;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(GetItemsForInitializeMutationOutput model) {
-      this.activeItem = model.activeItem();
-      this.beaconItem = model.beaconItem();
-      this.mutationLock = model.mutationLock();
+      this.ActiveItem = model.ActiveItem();
+      this.BeaconItem = model.BeaconItem();
+      this.MutationLock = model.MutationLock();
     }
 
-    public Builder activeItem(EncryptedHierarchicalKey activeItem) {
-      this.activeItem = activeItem;
+    public Builder ActiveItem(EncryptedHierarchicalKey ActiveItem) {
+      this.ActiveItem = ActiveItem;
       return this;
     }
 
-    public EncryptedHierarchicalKey activeItem() {
-      return this.activeItem;
+    public EncryptedHierarchicalKey ActiveItem() {
+      return this.ActiveItem;
     }
 
-    public Builder beaconItem(EncryptedHierarchicalKey beaconItem) {
-      this.beaconItem = beaconItem;
+    public Builder BeaconItem(EncryptedHierarchicalKey BeaconItem) {
+      this.BeaconItem = BeaconItem;
       return this;
     }
 
-    public EncryptedHierarchicalKey beaconItem() {
-      return this.beaconItem;
+    public EncryptedHierarchicalKey BeaconItem() {
+      return this.BeaconItem;
     }
 
-    public Builder mutationLock(MutationLock mutationLock) {
-      this.mutationLock = mutationLock;
+    public Builder MutationLock(MutationLock MutationLock) {
+      this.MutationLock = MutationLock;
       return this;
     }
 
-    public MutationLock mutationLock() {
-      return this.mutationLock;
+    public MutationLock MutationLock() {
+      return this.MutationLock;
     }
 
     public GetItemsForInitializeMutationOutput build() {
-      if (Objects.isNull(this.activeItem())) {
+      if (Objects.isNull(this.ActiveItem())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `activeItem`"
+          "Missing value for required field `ActiveItem`"
         );
       }
-      if (Objects.isNull(this.beaconItem())) {
+      if (Objects.isNull(this.BeaconItem())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `beaconItem`"
+          "Missing value for required field `BeaconItem`"
         );
       }
       return new GetItemsForInitializeMutationOutput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockInput.java
@@ -1,0 +1,76 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.Objects;
+
+public class GetMutationLockInput {
+
+  /**
+   * The Branch Key to check for a Mutation Lock.
+   */
+  private final String Identifier;
+
+  protected GetMutationLockInput(BuilderImpl builder) {
+    this.Identifier = builder.Identifier();
+  }
+
+  /**
+   * @return The Branch Key to check for a Mutation Lock.
+   */
+  public String Identifier() {
+    return this.Identifier;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param Identifier The Branch Key to check for a Mutation Lock.
+     */
+    Builder Identifier(String Identifier);
+
+    /**
+     * @return The Branch Key to check for a Mutation Lock.
+     */
+    String Identifier();
+
+    GetMutationLockInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected String Identifier;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetMutationLockInput model) {
+      this.Identifier = model.Identifier();
+    }
+
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
+      return this;
+    }
+
+    public String Identifier() {
+      return this.Identifier;
+    }
+
+    public GetMutationLockInput build() {
+      if (Objects.isNull(this.Identifier())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `Identifier`"
+        );
+      }
+      return new GetMutationLockInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
@@ -8,17 +8,17 @@ public class GetMutationLockOutput {
   /**
    * If not present, there is no Mutation Lock.
    */
-  private final MutationLock mutationLock;
+  private final MutationLock MutationLock;
 
   protected GetMutationLockOutput(BuilderImpl builder) {
-    this.mutationLock = builder.mutationLock();
+    this.MutationLock = builder.MutationLock();
   }
 
   /**
    * @return If not present, there is no Mutation Lock.
    */
-  public MutationLock mutationLock() {
-    return this.mutationLock;
+  public MutationLock MutationLock() {
+    return this.MutationLock;
   }
 
   public Builder toBuilder() {
@@ -31,35 +31,35 @@ public class GetMutationLockOutput {
 
   public interface Builder {
     /**
-     * @param mutationLock If not present, there is no Mutation Lock.
+     * @param MutationLock If not present, there is no Mutation Lock.
      */
-    Builder mutationLock(MutationLock mutationLock);
+    Builder MutationLock(MutationLock MutationLock);
 
     /**
      * @return If not present, there is no Mutation Lock.
      */
-    MutationLock mutationLock();
+    MutationLock MutationLock();
 
     GetMutationLockOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected MutationLock mutationLock;
+    protected MutationLock MutationLock;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(GetMutationLockOutput model) {
-      this.mutationLock = model.mutationLock();
+      this.MutationLock = model.MutationLock();
     }
 
-    public Builder mutationLock(MutationLock mutationLock) {
-      this.mutationLock = mutationLock;
+    public Builder MutationLock(MutationLock MutationLock) {
+      this.MutationLock = MutationLock;
       return this;
     }
 
-    public MutationLock mutationLock() {
-      return this.mutationLock;
+    public MutationLock MutationLock() {
+      return this.MutationLock;
     }
 
     public GetMutationLockOutput build() {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+public class GetMutationLockOutput {
+
+  /**
+   * If not present, there is no Mutation Lock.
+   */
+  private final MutationLock mutationLock;
+
+  protected GetMutationLockOutput(BuilderImpl builder) {
+    this.mutationLock = builder.mutationLock();
+  }
+
+  /**
+   * @return If not present, there is no Mutation Lock.
+   */
+  public MutationLock mutationLock() {
+    return this.mutationLock;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param mutationLock If not present, there is no Mutation Lock.
+     */
+    Builder mutationLock(MutationLock mutationLock);
+
+    /**
+     * @return If not present, there is no Mutation Lock.
+     */
+    MutationLock mutationLock();
+
+    GetMutationLockOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected MutationLock mutationLock;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetMutationLockOutput model) {
+      this.mutationLock = model.mutationLock();
+    }
+
+    public Builder mutationLock(MutationLock mutationLock) {
+      this.mutationLock = mutationLock;
+      return this;
+    }
+
+    public MutationLock mutationLock() {
+      return this.mutationLock;
+    }
+
+    public GetMutationLockOutput build() {
+      return new GetMutationLockOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/MutationLockConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/MutationLockConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed due to Mutation Lock condition failure.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationLockConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationLockConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationLockConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationLockConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationLockConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationLockConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/NoLongerExistsConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/NoLongerExistsConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed. Item was deleted since it was read.
  */
-public class MutationInvalidException extends RuntimeException {
+public class NoLongerExistsConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected NoLongerExistsConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    NoLongerExistsConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(NoLongerExistsConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public NoLongerExistsConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new NoLongerExistsConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/OldEncConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/OldEncConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed; cipher-text attribute of an item was updated since it was read.
  */
-public class MutationInvalidException extends RuntimeException {
+public class OldEncConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected OldEncConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    OldEncConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(OldEncConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public OldEncConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new OldEncConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/QueryForVersionsInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/QueryForVersionsInput.java
@@ -17,7 +17,7 @@ public class QueryForVersionsInput {
    *   Note: While the Default Storage is DDB,
    *   the Key Store transforms the exclusiveStartKey into an opaque representation.
    */
-  private final ByteBuffer exclusiveStartKey;
+  private final ByteBuffer ExclusiveStartKey;
 
   /**
    * The Identifier of the Branch Key.
@@ -27,12 +27,12 @@ public class QueryForVersionsInput {
   /**
    * The maximum read items.
    */
-  private final Integer pageSize;
+  private final Integer PageSize;
 
   protected QueryForVersionsInput(BuilderImpl builder) {
-    this.exclusiveStartKey = builder.exclusiveStartKey();
+    this.ExclusiveStartKey = builder.ExclusiveStartKey();
     this.Identifier = builder.Identifier();
-    this.pageSize = builder.pageSize();
+    this.PageSize = builder.PageSize();
   }
 
   /**
@@ -44,8 +44,8 @@ public class QueryForVersionsInput {
    *   Note: While the Default Storage is DDB,
    *   the Key Store transforms the exclusiveStartKey into an opaque representation.
    */
-  public ByteBuffer exclusiveStartKey() {
-    return this.exclusiveStartKey;
+  public ByteBuffer ExclusiveStartKey() {
+    return this.ExclusiveStartKey;
   }
 
   /**
@@ -58,8 +58,8 @@ public class QueryForVersionsInput {
   /**
    * @return The maximum read items.
    */
-  public Integer pageSize() {
-    return this.pageSize;
+  public Integer PageSize() {
+    return this.PageSize;
   }
 
   public Builder toBuilder() {
@@ -72,7 +72,7 @@ public class QueryForVersionsInput {
 
   public interface Builder {
     /**
-     * @param exclusiveStartKey Optional.
+     * @param ExclusiveStartKey Optional.
      *   If set, Query will start at this index and read forward.
      *   Otherwise, Query will start at the indexes begining.
      *   The Default Storage is DDB;
@@ -80,7 +80,7 @@ public class QueryForVersionsInput {
      *   Note: While the Default Storage is DDB,
      *   the Key Store transforms the exclusiveStartKey into an opaque representation.
      */
-    Builder exclusiveStartKey(ByteBuffer exclusiveStartKey);
+    Builder ExclusiveStartKey(ByteBuffer ExclusiveStartKey);
 
     /**
      * @return Optional.
@@ -91,7 +91,7 @@ public class QueryForVersionsInput {
      *   Note: While the Default Storage is DDB,
      *   the Key Store transforms the exclusiveStartKey into an opaque representation.
      */
-    ByteBuffer exclusiveStartKey();
+    ByteBuffer ExclusiveStartKey();
 
     /**
      * @param Identifier The Identifier of the Branch Key.
@@ -104,41 +104,41 @@ public class QueryForVersionsInput {
     String Identifier();
 
     /**
-     * @param pageSize The maximum read items.
+     * @param PageSize The maximum read items.
      */
-    Builder pageSize(Integer pageSize);
+    Builder PageSize(Integer PageSize);
 
     /**
      * @return The maximum read items.
      */
-    Integer pageSize();
+    Integer PageSize();
 
     QueryForVersionsInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected ByteBuffer exclusiveStartKey;
+    protected ByteBuffer ExclusiveStartKey;
 
     protected String Identifier;
 
-    protected Integer pageSize;
+    protected Integer PageSize;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(QueryForVersionsInput model) {
-      this.exclusiveStartKey = model.exclusiveStartKey();
+      this.ExclusiveStartKey = model.ExclusiveStartKey();
       this.Identifier = model.Identifier();
-      this.pageSize = model.pageSize();
+      this.PageSize = model.PageSize();
     }
 
-    public Builder exclusiveStartKey(ByteBuffer exclusiveStartKey) {
-      this.exclusiveStartKey = exclusiveStartKey;
+    public Builder ExclusiveStartKey(ByteBuffer ExclusiveStartKey) {
+      this.ExclusiveStartKey = ExclusiveStartKey;
       return this;
     }
 
-    public ByteBuffer exclusiveStartKey() {
-      return this.exclusiveStartKey;
+    public ByteBuffer ExclusiveStartKey() {
+      return this.ExclusiveStartKey;
     }
 
     public Builder Identifier(String Identifier) {
@@ -150,13 +150,13 @@ public class QueryForVersionsInput {
       return this.Identifier;
     }
 
-    public Builder pageSize(Integer pageSize) {
-      this.pageSize = pageSize;
+    public Builder PageSize(Integer PageSize) {
+      this.PageSize = PageSize;
       return this;
     }
 
-    public Integer pageSize() {
-      return this.pageSize;
+    public Integer PageSize() {
+      return this.PageSize;
     }
 
     public QueryForVersionsInput build() {
@@ -165,9 +165,9 @@ public class QueryForVersionsInput {
           "Missing value for required field `Identifier`"
         );
       }
-      if (Objects.isNull(this.pageSize())) {
+      if (Objects.isNull(this.PageSize())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `pageSize`"
+          "Missing value for required field `PageSize`"
         );
       }
       return new QueryForVersionsInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/QueryForVersionsOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/QueryForVersionsOutput.java
@@ -17,16 +17,16 @@ public class QueryForVersionsOutput {
    *   Note: While the Default Storage is DDB,
    *   the Key Store transforms the exclusiveStartKey into an opaque representation.
    */
-  private final ByteBuffer exclusiveStartKey;
+  private final ByteBuffer ExclusiveStartKey;
 
   /**
    * Up to pageSize list of version (decrypt only) items of a Branch Key.
    */
-  private final List<EncryptedHierarchicalKey> items;
+  private final List<EncryptedHierarchicalKey> Items;
 
   protected QueryForVersionsOutput(BuilderImpl builder) {
-    this.exclusiveStartKey = builder.exclusiveStartKey();
-    this.items = builder.items();
+    this.ExclusiveStartKey = builder.ExclusiveStartKey();
+    this.Items = builder.Items();
   }
 
   /**
@@ -37,15 +37,15 @@ public class QueryForVersionsOutput {
    *   Note: While the Default Storage is DDB,
    *   the Key Store transforms the exclusiveStartKey into an opaque representation.
    */
-  public ByteBuffer exclusiveStartKey() {
-    return this.exclusiveStartKey;
+  public ByteBuffer ExclusiveStartKey() {
+    return this.ExclusiveStartKey;
   }
 
   /**
    * @return Up to pageSize list of version (decrypt only) items of a Branch Key.
    */
-  public List<EncryptedHierarchicalKey> items() {
-    return this.items;
+  public List<EncryptedHierarchicalKey> Items() {
+    return this.Items;
   }
 
   public Builder toBuilder() {
@@ -58,14 +58,14 @@ public class QueryForVersionsOutput {
 
   public interface Builder {
     /**
-     * @param exclusiveStartKey If none-empty, Query did not finish searching storage.
+     * @param ExclusiveStartKey If none-empty, Query did not finish searching storage.
      *   Next Query should resume from here.
      *   The Default Storage is DDB;
      *   see Amazon DynamoDB's defination of exclusiveStartKey for details.
      *   Note: While the Default Storage is DDB,
      *   the Key Store transforms the exclusiveStartKey into an opaque representation.
      */
-    Builder exclusiveStartKey(ByteBuffer exclusiveStartKey);
+    Builder ExclusiveStartKey(ByteBuffer ExclusiveStartKey);
 
     /**
      * @return If none-empty, Query did not finish searching storage.
@@ -75,61 +75,61 @@ public class QueryForVersionsOutput {
      *   Note: While the Default Storage is DDB,
      *   the Key Store transforms the exclusiveStartKey into an opaque representation.
      */
-    ByteBuffer exclusiveStartKey();
+    ByteBuffer ExclusiveStartKey();
 
     /**
-     * @param items Up to pageSize list of version (decrypt only) items of a Branch Key.
+     * @param Items Up to pageSize list of version (decrypt only) items of a Branch Key.
      */
-    Builder items(List<EncryptedHierarchicalKey> items);
+    Builder Items(List<EncryptedHierarchicalKey> Items);
 
     /**
      * @return Up to pageSize list of version (decrypt only) items of a Branch Key.
      */
-    List<EncryptedHierarchicalKey> items();
+    List<EncryptedHierarchicalKey> Items();
 
     QueryForVersionsOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected ByteBuffer exclusiveStartKey;
+    protected ByteBuffer ExclusiveStartKey;
 
-    protected List<EncryptedHierarchicalKey> items;
+    protected List<EncryptedHierarchicalKey> Items;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(QueryForVersionsOutput model) {
-      this.exclusiveStartKey = model.exclusiveStartKey();
-      this.items = model.items();
+      this.ExclusiveStartKey = model.ExclusiveStartKey();
+      this.Items = model.Items();
     }
 
-    public Builder exclusiveStartKey(ByteBuffer exclusiveStartKey) {
-      this.exclusiveStartKey = exclusiveStartKey;
+    public Builder ExclusiveStartKey(ByteBuffer ExclusiveStartKey) {
+      this.ExclusiveStartKey = ExclusiveStartKey;
       return this;
     }
 
-    public ByteBuffer exclusiveStartKey() {
-      return this.exclusiveStartKey;
+    public ByteBuffer ExclusiveStartKey() {
+      return this.ExclusiveStartKey;
     }
 
-    public Builder items(List<EncryptedHierarchicalKey> items) {
-      this.items = items;
+    public Builder Items(List<EncryptedHierarchicalKey> Items) {
+      this.Items = Items;
       return this;
     }
 
-    public List<EncryptedHierarchicalKey> items() {
-      return this.items;
+    public List<EncryptedHierarchicalKey> Items() {
+      return this.Items;
     }
 
     public QueryForVersionsOutput build() {
-      if (Objects.isNull(this.exclusiveStartKey())) {
+      if (Objects.isNull(this.ExclusiveStartKey())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `exclusiveStartKey`"
+          "Missing value for required field `ExclusiveStartKey`"
         );
       }
-      if (Objects.isNull(this.items())) {
+      if (Objects.isNull(this.Items())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `items`"
+          "Missing value for required field `Items`"
         );
       }
       return new QueryForVersionsOutput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteInitializeMutationInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteInitializeMutationInput.java
@@ -13,7 +13,7 @@ public class WriteInitializeMutationInput {
    *   generated with the Mutation's terminal properities.
    *   The plain-text cryptographic material of the Active must be the same as the Version.
    */
-  private final EncryptedHierarchicalKey active;
+  private final EncryptedHierarchicalKey Active;
 
   /**
    *
@@ -22,7 +22,7 @@ public class WriteInitializeMutationInput {
    *   This means that when updating the current active record
    *   the existing active record should be equal to this value.
    */
-  private final EncryptedHierarchicalKey oldActive;
+  private final EncryptedHierarchicalKey OldActive;
 
   /**
    *
@@ -30,7 +30,7 @@ public class WriteInitializeMutationInput {
    *   generated with the Mutation's terminal properities.
    *   The plain-text cryptographic material of the `Version` must be the same as the `Active`.
    */
-  private final EncryptedHierarchicalKey version;
+  private final EncryptedHierarchicalKey Version;
 
   /**
    *
@@ -38,7 +38,7 @@ public class WriteInitializeMutationInput {
    *   The cryptographic material is identical to the existing beacon,
    *   but is now authorized with the Mutation's terminal properities.
    */
-  private final EncryptedHierarchicalKey beacon;
+  private final EncryptedHierarchicalKey Beacon;
 
   /**
    * Information an in-flight Mutation of a Branch Key.
@@ -46,14 +46,14 @@ public class WriteInitializeMutationInput {
    * - only one Mutation affects a Branch Key at a time
    * - all items of a Branch Key are mutated consistently
    */
-  private final MutationLock mutationLock;
+  private final MutationLock MutationLock;
 
   protected WriteInitializeMutationInput(BuilderImpl builder) {
-    this.active = builder.active();
-    this.oldActive = builder.oldActive();
-    this.version = builder.version();
-    this.beacon = builder.beacon();
-    this.mutationLock = builder.mutationLock();
+    this.Active = builder.Active();
+    this.OldActive = builder.OldActive();
+    this.Version = builder.Version();
+    this.Beacon = builder.Beacon();
+    this.MutationLock = builder.MutationLock();
   }
 
   /**
@@ -62,8 +62,8 @@ public class WriteInitializeMutationInput {
    *   generated with the Mutation's terminal properities.
    *   The plain-text cryptographic material of the Active must be the same as the Version.
    */
-  public EncryptedHierarchicalKey active() {
-    return this.active;
+  public EncryptedHierarchicalKey Active() {
+    return this.Active;
   }
 
   /**
@@ -73,8 +73,8 @@ public class WriteInitializeMutationInput {
    *   This means that when updating the current active record
    *   the existing active record should be equal to this value.
    */
-  public EncryptedHierarchicalKey oldActive() {
-    return this.oldActive;
+  public EncryptedHierarchicalKey OldActive() {
+    return this.OldActive;
   }
 
   /**
@@ -83,8 +83,8 @@ public class WriteInitializeMutationInput {
    *   generated with the Mutation's terminal properities.
    *   The plain-text cryptographic material of the `Version` must be the same as the `Active`.
    */
-  public EncryptedHierarchicalKey version() {
-    return this.version;
+  public EncryptedHierarchicalKey Version() {
+    return this.Version;
   }
 
   /**
@@ -93,8 +93,8 @@ public class WriteInitializeMutationInput {
    *   The cryptographic material is identical to the existing beacon,
    *   but is now authorized with the Mutation's terminal properities.
    */
-  public EncryptedHierarchicalKey beacon() {
-    return this.beacon;
+  public EncryptedHierarchicalKey Beacon() {
+    return this.Beacon;
   }
 
   /**
@@ -103,8 +103,8 @@ public class WriteInitializeMutationInput {
    * - only one Mutation affects a Branch Key at a time
    * - all items of a Branch Key are mutated consistently
    */
-  public MutationLock mutationLock() {
-    return this.mutationLock;
+  public MutationLock MutationLock() {
+    return this.MutationLock;
   }
 
   public Builder toBuilder() {
@@ -117,12 +117,12 @@ public class WriteInitializeMutationInput {
 
   public interface Builder {
     /**
-     * @param active
+     * @param Active
      *   The active representation of this branch key,
      *   generated with the Mutation's terminal properities.
      *   The plain-text cryptographic material of the Active must be the same as the Version.
      */
-    Builder active(EncryptedHierarchicalKey active);
+    Builder Active(EncryptedHierarchicalKey Active);
 
     /**
      * @return
@@ -130,16 +130,16 @@ public class WriteInitializeMutationInput {
      *   generated with the Mutation's terminal properities.
      *   The plain-text cryptographic material of the Active must be the same as the Version.
      */
-    EncryptedHierarchicalKey active();
+    EncryptedHierarchicalKey Active();
 
     /**
-     * @param oldActive
+     * @param OldActive
      *   The previous active version.
      *   This key should be used as an optimistic lock on the new version.
      *   This means that when updating the current active record
      *   the existing active record should be equal to this value.
      */
-    Builder oldActive(EncryptedHierarchicalKey oldActive);
+    Builder OldActive(EncryptedHierarchicalKey OldActive);
 
     /**
      * @return
@@ -148,15 +148,15 @@ public class WriteInitializeMutationInput {
      *   This means that when updating the current active record
      *   the existing active record should be equal to this value.
      */
-    EncryptedHierarchicalKey oldActive();
+    EncryptedHierarchicalKey OldActive();
 
     /**
-     * @param version
+     * @param Version
      *   The decrypt representation of this branch key version,
      *   generated with the Mutation's terminal properities.
      *   The plain-text cryptographic material of the `Version` must be the same as the `Active`.
      */
-    Builder version(EncryptedHierarchicalKey version);
+    Builder Version(EncryptedHierarchicalKey Version);
 
     /**
      * @return
@@ -164,15 +164,15 @@ public class WriteInitializeMutationInput {
      *   generated with the Mutation's terminal properities.
      *   The plain-text cryptographic material of the `Version` must be the same as the `Active`.
      */
-    EncryptedHierarchicalKey version();
+    EncryptedHierarchicalKey Version();
 
     /**
-     * @param beacon
+     * @param Beacon
      *   The mutated HMAC key used to support searchable encryption.
      *   The cryptographic material is identical to the existing beacon,
      *   but is now authorized with the Mutation's terminal properities.
      */
-    Builder beacon(EncryptedHierarchicalKey beacon);
+    Builder Beacon(EncryptedHierarchicalKey Beacon);
 
     /**
      * @return
@@ -180,15 +180,15 @@ public class WriteInitializeMutationInput {
      *   The cryptographic material is identical to the existing beacon,
      *   but is now authorized with the Mutation's terminal properities.
      */
-    EncryptedHierarchicalKey beacon();
+    EncryptedHierarchicalKey Beacon();
 
     /**
-     * @param mutationLock Information an in-flight Mutation of a Branch Key.
+     * @param MutationLock Information an in-flight Mutation of a Branch Key.
      * This ensures:
      * - only one Mutation affects a Branch Key at a time
      * - all items of a Branch Key are mutated consistently
      */
-    Builder mutationLock(MutationLock mutationLock);
+    Builder MutationLock(MutationLock MutationLock);
 
     /**
      * @return Information an in-flight Mutation of a Branch Key.
@@ -196,102 +196,102 @@ public class WriteInitializeMutationInput {
      * - only one Mutation affects a Branch Key at a time
      * - all items of a Branch Key are mutated consistently
      */
-    MutationLock mutationLock();
+    MutationLock MutationLock();
 
     WriteInitializeMutationInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected EncryptedHierarchicalKey active;
+    protected EncryptedHierarchicalKey Active;
 
-    protected EncryptedHierarchicalKey oldActive;
+    protected EncryptedHierarchicalKey OldActive;
 
-    protected EncryptedHierarchicalKey version;
+    protected EncryptedHierarchicalKey Version;
 
-    protected EncryptedHierarchicalKey beacon;
+    protected EncryptedHierarchicalKey Beacon;
 
-    protected MutationLock mutationLock;
+    protected MutationLock MutationLock;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(WriteInitializeMutationInput model) {
-      this.active = model.active();
-      this.oldActive = model.oldActive();
-      this.version = model.version();
-      this.beacon = model.beacon();
-      this.mutationLock = model.mutationLock();
+      this.Active = model.Active();
+      this.OldActive = model.OldActive();
+      this.Version = model.Version();
+      this.Beacon = model.Beacon();
+      this.MutationLock = model.MutationLock();
     }
 
-    public Builder active(EncryptedHierarchicalKey active) {
-      this.active = active;
+    public Builder Active(EncryptedHierarchicalKey Active) {
+      this.Active = Active;
       return this;
     }
 
-    public EncryptedHierarchicalKey active() {
-      return this.active;
+    public EncryptedHierarchicalKey Active() {
+      return this.Active;
     }
 
-    public Builder oldActive(EncryptedHierarchicalKey oldActive) {
-      this.oldActive = oldActive;
+    public Builder OldActive(EncryptedHierarchicalKey OldActive) {
+      this.OldActive = OldActive;
       return this;
     }
 
-    public EncryptedHierarchicalKey oldActive() {
-      return this.oldActive;
+    public EncryptedHierarchicalKey OldActive() {
+      return this.OldActive;
     }
 
-    public Builder version(EncryptedHierarchicalKey version) {
-      this.version = version;
+    public Builder Version(EncryptedHierarchicalKey Version) {
+      this.Version = Version;
       return this;
     }
 
-    public EncryptedHierarchicalKey version() {
-      return this.version;
+    public EncryptedHierarchicalKey Version() {
+      return this.Version;
     }
 
-    public Builder beacon(EncryptedHierarchicalKey beacon) {
-      this.beacon = beacon;
+    public Builder Beacon(EncryptedHierarchicalKey Beacon) {
+      this.Beacon = Beacon;
       return this;
     }
 
-    public EncryptedHierarchicalKey beacon() {
-      return this.beacon;
+    public EncryptedHierarchicalKey Beacon() {
+      return this.Beacon;
     }
 
-    public Builder mutationLock(MutationLock mutationLock) {
-      this.mutationLock = mutationLock;
+    public Builder MutationLock(MutationLock MutationLock) {
+      this.MutationLock = MutationLock;
       return this;
     }
 
-    public MutationLock mutationLock() {
-      return this.mutationLock;
+    public MutationLock MutationLock() {
+      return this.MutationLock;
     }
 
     public WriteInitializeMutationInput build() {
-      if (Objects.isNull(this.active())) {
+      if (Objects.isNull(this.Active())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `active`"
+          "Missing value for required field `Active`"
         );
       }
-      if (Objects.isNull(this.oldActive())) {
+      if (Objects.isNull(this.OldActive())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `oldActive`"
+          "Missing value for required field `OldActive`"
         );
       }
-      if (Objects.isNull(this.version())) {
+      if (Objects.isNull(this.Version())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `version`"
+          "Missing value for required field `Version`"
         );
       }
-      if (Objects.isNull(this.beacon())) {
+      if (Objects.isNull(this.Beacon())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `beacon`"
+          "Missing value for required field `Beacon`"
         );
       }
-      if (Objects.isNull(this.mutationLock())) {
+      if (Objects.isNull(this.MutationLock())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutationLock`"
+          "Missing value for required field `MutationLock`"
         );
       }
       return new WriteInitializeMutationInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
@@ -12,7 +12,7 @@ public class WriteMutatedVersionsInput {
   /**
    * List of version (decrypt only) items of a Branch Key to overwrite conditionally.
    */
-  private final List<EncryptedHierarchicalKey> items;
+  private final List<EncryptedHierarchicalKey> Items;
 
   /**
    * The Identifier of the Branch Key.
@@ -35,7 +35,7 @@ public class WriteMutatedVersionsInput {
   private final Boolean CompleteMutation;
 
   protected WriteMutatedVersionsInput(BuilderImpl builder) {
-    this.items = builder.items();
+    this.Items = builder.Items();
     this.Identifier = builder.Identifier();
     this.Original = builder.Original();
     this.Terminal = builder.Terminal();
@@ -45,8 +45,8 @@ public class WriteMutatedVersionsInput {
   /**
    * @return List of version (decrypt only) items of a Branch Key to overwrite conditionally.
    */
-  public List<EncryptedHierarchicalKey> items() {
-    return this.items;
+  public List<EncryptedHierarchicalKey> Items() {
+    return this.Items;
   }
 
   /**
@@ -87,14 +87,14 @@ public class WriteMutatedVersionsInput {
 
   public interface Builder {
     /**
-     * @param items List of version (decrypt only) items of a Branch Key to overwrite conditionally.
+     * @param Items List of version (decrypt only) items of a Branch Key to overwrite conditionally.
      */
-    Builder items(List<EncryptedHierarchicalKey> items);
+    Builder Items(List<EncryptedHierarchicalKey> Items);
 
     /**
      * @return List of version (decrypt only) items of a Branch Key to overwrite conditionally.
      */
-    List<EncryptedHierarchicalKey> items();
+    List<EncryptedHierarchicalKey> Items();
 
     /**
      * @param Identifier The Identifier of the Branch Key.
@@ -141,7 +141,7 @@ public class WriteMutatedVersionsInput {
 
   static class BuilderImpl implements Builder {
 
-    protected List<EncryptedHierarchicalKey> items;
+    protected List<EncryptedHierarchicalKey> Items;
 
     protected String Identifier;
 
@@ -154,20 +154,20 @@ public class WriteMutatedVersionsInput {
     protected BuilderImpl() {}
 
     protected BuilderImpl(WriteMutatedVersionsInput model) {
-      this.items = model.items();
+      this.Items = model.Items();
       this.Identifier = model.Identifier();
       this.Original = model.Original();
       this.Terminal = model.Terminal();
       this.CompleteMutation = model.CompleteMutation();
     }
 
-    public Builder items(List<EncryptedHierarchicalKey> items) {
-      this.items = items;
+    public Builder Items(List<EncryptedHierarchicalKey> Items) {
+      this.Items = Items;
       return this;
     }
 
-    public List<EncryptedHierarchicalKey> items() {
-      return this.items;
+    public List<EncryptedHierarchicalKey> Items() {
+      return this.Items;
     }
 
     public Builder Identifier(String Identifier) {
@@ -207,9 +207,9 @@ public class WriteMutatedVersionsInput {
     }
 
     public WriteMutatedVersionsInput build() {
-      if (Objects.isNull(this.items())) {
+      if (Objects.isNull(this.Items())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `items`"
+          "Missing value for required field `Items`"
         );
       }
       if (Objects.isNull(this.Identifier())) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
@@ -30,7 +30,7 @@ public class WriteMutatedVersionsInput {
   private final ByteBuffer Terminal;
 
   /**
-   * If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+   * If set to True, the Mutation Lock will be deleted.
    */
   private final Boolean CompleteMutation;
 
@@ -71,7 +71,7 @@ public class WriteMutatedVersionsInput {
   }
 
   /**
-   * @return If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+   * @return If set to True, the Mutation Lock will be deleted.
    */
   public Boolean CompleteMutation() {
     return this.CompleteMutation;
@@ -127,12 +127,12 @@ public class WriteMutatedVersionsInput {
     ByteBuffer Terminal();
 
     /**
-     * @param CompleteMutation If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+     * @param CompleteMutation If set to True, the Mutation Lock will be deleted.
      */
     Builder CompleteMutation(Boolean CompleteMutation);
 
     /**
-     * @return If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+     * @return If set to True, the Mutation Lock will be deleted.
      */
     Boolean CompleteMutation();
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteNewEncryptedBranchKeyVersionInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteNewEncryptedBranchKeyVersionInput.java
@@ -36,12 +36,12 @@ public class WriteNewEncryptedBranchKeyVersionInput {
    *   the existing active record should be equal to this value.
    *
    */
-  private final EncryptedHierarchicalKey oldActive;
+  private final EncryptedHierarchicalKey OldActive;
 
   protected WriteNewEncryptedBranchKeyVersionInput(BuilderImpl builder) {
     this.Active = builder.Active();
     this.Version = builder.Version();
-    this.oldActive = builder.oldActive();
+    this.OldActive = builder.OldActive();
   }
 
   /**
@@ -72,8 +72,8 @@ public class WriteNewEncryptedBranchKeyVersionInput {
    *   the existing active record should be equal to this value.
    *
    */
-  public EncryptedHierarchicalKey oldActive() {
-    return this.oldActive;
+  public EncryptedHierarchicalKey OldActive() {
+    return this.OldActive;
   }
 
   public Builder toBuilder() {
@@ -118,14 +118,14 @@ public class WriteNewEncryptedBranchKeyVersionInput {
     EncryptedHierarchicalKey Version();
 
     /**
-     * @param oldActive
+     * @param OldActive
      *   The previous active version.
      *   This key should be used as an optimistic lock on the new version.
      *   This means that when updating the current active record
      *   the existing active record should be equal to this value.
      *
      */
-    Builder oldActive(EncryptedHierarchicalKey oldActive);
+    Builder OldActive(EncryptedHierarchicalKey OldActive);
 
     /**
      * @return
@@ -135,7 +135,7 @@ public class WriteNewEncryptedBranchKeyVersionInput {
      *   the existing active record should be equal to this value.
      *
      */
-    EncryptedHierarchicalKey oldActive();
+    EncryptedHierarchicalKey OldActive();
 
     WriteNewEncryptedBranchKeyVersionInput build();
   }
@@ -146,14 +146,14 @@ public class WriteNewEncryptedBranchKeyVersionInput {
 
     protected EncryptedHierarchicalKey Version;
 
-    protected EncryptedHierarchicalKey oldActive;
+    protected EncryptedHierarchicalKey OldActive;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(WriteNewEncryptedBranchKeyVersionInput model) {
       this.Active = model.Active();
       this.Version = model.Version();
-      this.oldActive = model.oldActive();
+      this.OldActive = model.OldActive();
     }
 
     public Builder Active(EncryptedHierarchicalKey Active) {
@@ -174,13 +174,13 @@ public class WriteNewEncryptedBranchKeyVersionInput {
       return this.Version;
     }
 
-    public Builder oldActive(EncryptedHierarchicalKey oldActive) {
-      this.oldActive = oldActive;
+    public Builder OldActive(EncryptedHierarchicalKey OldActive) {
+      this.OldActive = OldActive;
       return this;
     }
 
-    public EncryptedHierarchicalKey oldActive() {
-      return this.oldActive;
+    public EncryptedHierarchicalKey OldActive() {
+      return this.OldActive;
     }
 
     public WriteNewEncryptedBranchKeyVersionInput build() {
@@ -194,9 +194,9 @@ public class WriteNewEncryptedBranchKeyVersionInput {
           "Missing value for required field `Version`"
         );
       }
-      if (Objects.isNull(this.oldActive())) {
+      if (Objects.isNull(this.OldActive())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `oldActive`"
+          "Missing value for required field `OldActive`"
         );
       }
       return new WriteNewEncryptedBranchKeyVersionInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
@@ -110,18 +110,18 @@ public class ToDafny {
     software.amazon.cryptography.keystoreadmin.model.ApplyMutationInput nativeValue
   ) {
     MutationToken mutationToken;
-    mutationToken = ToDafny.MutationToken(nativeValue.mutationToken());
+    mutationToken = ToDafny.MutationToken(nativeValue.MutationToken());
     Option<Integer> pageSize;
     pageSize =
-      Objects.nonNull(nativeValue.pageSize())
-        ? Option.create_Some(TypeDescriptor.INT, (nativeValue.pageSize()))
+      Objects.nonNull(nativeValue.PageSize())
+        ? Option.create_Some(TypeDescriptor.INT, (nativeValue.PageSize()))
         : Option.create_None(TypeDescriptor.INT);
     Option<KeyManagementStrategy> strategy;
     strategy =
-      Objects.nonNull(nativeValue.strategy())
+      Objects.nonNull(nativeValue.Strategy())
         ? Option.create_Some(
           KeyManagementStrategy._typeDescriptor(),
-          ToDafny.KeyManagementStrategy(nativeValue.strategy())
+          ToDafny.KeyManagementStrategy(nativeValue.Strategy())
         )
         : Option.create_None(KeyManagementStrategy._typeDescriptor());
     return new ApplyMutationInput(mutationToken, pageSize, strategy);
@@ -130,24 +130,24 @@ public class ToDafny {
   public static ApplyMutationOutput ApplyMutationOutput(
     software.amazon.cryptography.keystoreadmin.model.ApplyMutationOutput nativeValue
   ) {
-    ApplyMutationResult result;
-    result = ToDafny.ApplyMutationResult(nativeValue.result());
+    ApplyMutationResult mutationResult;
+    mutationResult = ToDafny.ApplyMutationResult(nativeValue.MutationResult());
     DafnySequence<? extends MutatedBranchKeyItem> mutatedBranchKeyItems;
     mutatedBranchKeyItems =
-      ToDafny.MutatedBranchKeyItems(nativeValue.mutatedBranchKeyItems());
-    return new ApplyMutationOutput(result, mutatedBranchKeyItems);
+      ToDafny.MutatedBranchKeyItems(nativeValue.MutatedBranchKeyItems());
+    return new ApplyMutationOutput(mutationResult, mutatedBranchKeyItems);
   }
 
   public static CreateKeyInput CreateKeyInput(
     software.amazon.cryptography.keystoreadmin.model.CreateKeyInput nativeValue
   ) {
-    Option<DafnySequence<? extends Character>> branchKeyIdentifier;
-    branchKeyIdentifier =
-      Objects.nonNull(nativeValue.branchKeyIdentifier())
+    Option<DafnySequence<? extends Character>> identifier;
+    identifier =
+      Objects.nonNull(nativeValue.Identifier())
         ? Option.create_Some(
           DafnySequence._typeDescriptor(TypeDescriptor.CHAR),
           software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-            nativeValue.branchKeyIdentifier()
+            nativeValue.Identifier()
           )
         )
         : Option.create_None(
@@ -160,15 +160,15 @@ public class ToDafny {
       >
     > encryptionContext;
     encryptionContext =
-      (Objects.nonNull(nativeValue.encryptionContext()) &&
-          nativeValue.encryptionContext().size() > 0)
+      (Objects.nonNull(nativeValue.EncryptionContext()) &&
+          nativeValue.EncryptionContext().size() > 0)
         ? Option.create_Some(
           DafnyMap._typeDescriptor(
             DafnySequence._typeDescriptor(TypeDescriptor.BYTE),
             DafnySequence._typeDescriptor(TypeDescriptor.BYTE)
           ),
           software.amazon.cryptography.keystore.ToDafny.EncryptionContext(
-            nativeValue.encryptionContext()
+            nativeValue.EncryptionContext()
           )
         )
         : Option.create_None(
@@ -178,67 +178,58 @@ public class ToDafny {
           )
         );
     KMSIdentifier kmsArn;
-    kmsArn = ToDafny.KMSIdentifier(nativeValue.kmsArn());
+    kmsArn = ToDafny.KMSIdentifier(nativeValue.KmsArn());
     Option<KeyManagementStrategy> strategy;
     strategy =
-      Objects.nonNull(nativeValue.strategy())
+      Objects.nonNull(nativeValue.Strategy())
         ? Option.create_Some(
           KeyManagementStrategy._typeDescriptor(),
-          ToDafny.KeyManagementStrategy(nativeValue.strategy())
+          ToDafny.KeyManagementStrategy(nativeValue.Strategy())
         )
         : Option.create_None(KeyManagementStrategy._typeDescriptor());
-    return new CreateKeyInput(
-      branchKeyIdentifier,
-      encryptionContext,
-      kmsArn,
-      strategy
-    );
+    return new CreateKeyInput(identifier, encryptionContext, kmsArn, strategy);
   }
 
   public static CreateKeyOutput CreateKeyOutput(
     software.amazon.cryptography.keystoreadmin.model.CreateKeyOutput nativeValue
   ) {
-    DafnySequence<? extends Character> branchKeyIdentifier;
-    branchKeyIdentifier =
+    DafnySequence<? extends Character> identifier;
+    identifier =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-        nativeValue.branchKeyIdentifier()
+        nativeValue.Identifier()
       );
-    return new CreateKeyOutput(branchKeyIdentifier);
+    return new CreateKeyOutput(identifier);
   }
 
   public static InitializeMutationInput InitializeMutationInput(
     software.amazon.cryptography.keystoreadmin.model.InitializeMutationInput nativeValue
   ) {
-    DafnySequence<? extends Character> branchKeyIdentifier;
-    branchKeyIdentifier =
+    DafnySequence<? extends Character> identifier;
+    identifier =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-        nativeValue.branchKeyIdentifier()
+        nativeValue.Identifier()
       );
     Mutations mutations;
-    mutations = ToDafny.Mutations(nativeValue.mutations());
+    mutations = ToDafny.Mutations(nativeValue.Mutations());
     Option<KeyManagementStrategy> strategy;
     strategy =
-      Objects.nonNull(nativeValue.strategy())
+      Objects.nonNull(nativeValue.Strategy())
         ? Option.create_Some(
           KeyManagementStrategy._typeDescriptor(),
-          ToDafny.KeyManagementStrategy(nativeValue.strategy())
+          ToDafny.KeyManagementStrategy(nativeValue.Strategy())
         )
         : Option.create_None(KeyManagementStrategy._typeDescriptor());
-    return new InitializeMutationInput(
-      branchKeyIdentifier,
-      mutations,
-      strategy
-    );
+    return new InitializeMutationInput(identifier, mutations, strategy);
   }
 
   public static InitializeMutationOutput InitializeMutationOutput(
     software.amazon.cryptography.keystoreadmin.model.InitializeMutationOutput nativeValue
   ) {
     MutationToken mutationToken;
-    mutationToken = ToDafny.MutationToken(nativeValue.mutationToken());
+    mutationToken = ToDafny.MutationToken(nativeValue.MutationToken());
     DafnySequence<? extends MutatedBranchKeyItem> mutatedBranchKeyItems;
     mutatedBranchKeyItems =
-      ToDafny.MutatedBranchKeyItems(nativeValue.mutatedBranchKeyItems());
+      ToDafny.MutatedBranchKeyItems(nativeValue.MutatedBranchKeyItems());
     return new InitializeMutationOutput(mutationToken, mutatedBranchKeyItems);
   }
 
@@ -264,12 +255,12 @@ public class ToDafny {
     DafnySequence<? extends Character> itemType;
     itemType =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-        nativeValue.itemType()
+        nativeValue.ItemType()
       );
     DafnySequence<? extends Character> description;
     description =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-        nativeValue.description()
+        nativeValue.Description()
       );
     return new MutatedBranchKeyItem(itemType, description);
   }
@@ -285,11 +276,11 @@ public class ToDafny {
   ) {
     Option<DafnySequence<? extends Character>> terminalKmsArn;
     terminalKmsArn =
-      Objects.nonNull(nativeValue.terminalKmsArn())
+      Objects.nonNull(nativeValue.TerminalKmsArn())
         ? Option.create_Some(
           DafnySequence._typeDescriptor(TypeDescriptor.CHAR),
           software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-            nativeValue.terminalKmsArn()
+            nativeValue.TerminalKmsArn()
           )
         )
         : Option.create_None(
@@ -302,15 +293,15 @@ public class ToDafny {
       >
     > terminalEncryptionContext;
     terminalEncryptionContext =
-      (Objects.nonNull(nativeValue.terminalEncryptionContext()) &&
-          nativeValue.terminalEncryptionContext().size() > 0)
+      (Objects.nonNull(nativeValue.TerminalEncryptionContext()) &&
+          nativeValue.TerminalEncryptionContext().size() > 0)
         ? Option.create_Some(
           DafnyMap._typeDescriptor(
             DafnySequence._typeDescriptor(TypeDescriptor.CHAR),
             DafnySequence._typeDescriptor(TypeDescriptor.CHAR)
           ),
           software.amazon.cryptography.keystore.ToDafny.EncryptionContextString(
-            nativeValue.terminalEncryptionContext()
+            nativeValue.TerminalEncryptionContext()
           )
         )
         : Option.create_None(
@@ -382,22 +373,22 @@ public class ToDafny {
   public static VersionKeyInput VersionKeyInput(
     software.amazon.cryptography.keystoreadmin.model.VersionKeyInput nativeValue
   ) {
-    DafnySequence<? extends Character> branchKeyIdentifier;
-    branchKeyIdentifier =
+    DafnySequence<? extends Character> identifier;
+    identifier =
       software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-        nativeValue.branchKeyIdentifier()
+        nativeValue.Identifier()
       );
     KMSIdentifier kmsArn;
-    kmsArn = ToDafny.KMSIdentifier(nativeValue.kmsArn());
+    kmsArn = ToDafny.KMSIdentifier(nativeValue.KmsArn());
     Option<KeyManagementStrategy> strategy;
     strategy =
-      Objects.nonNull(nativeValue.strategy())
+      Objects.nonNull(nativeValue.Strategy())
         ? Option.create_Some(
           KeyManagementStrategy._typeDescriptor(),
-          ToDafny.KeyManagementStrategy(nativeValue.strategy())
+          ToDafny.KeyManagementStrategy(nativeValue.Strategy())
         )
         : Option.create_None(KeyManagementStrategy._typeDescriptor());
-    return new VersionKeyInput(branchKeyIdentifier, kmsArn, strategy);
+    return new VersionKeyInput(identifier, kmsArn, strategy);
   }
 
   public static VersionKeyOutput VersionKeyOutput(
@@ -481,14 +472,14 @@ public class ToDafny {
   public static ApplyMutationResult ApplyMutationResult(
     software.amazon.cryptography.keystoreadmin.model.ApplyMutationResult nativeValue
   ) {
-    if (Objects.nonNull(nativeValue.continueMutation())) {
-      return ApplyMutationResult.create_continueMutation(
-        ToDafny.MutationToken(nativeValue.continueMutation())
+    if (Objects.nonNull(nativeValue.ContinueMutation())) {
+      return ApplyMutationResult.create_ContinueMutation(
+        ToDafny.MutationToken(nativeValue.ContinueMutation())
       );
     }
-    if (Objects.nonNull(nativeValue.completeMutation())) {
-      return ApplyMutationResult.create_completeMutation(
-        ToDafny.MutationComplete(nativeValue.completeMutation())
+    if (Objects.nonNull(nativeValue.CompleteMutation())) {
+      return ApplyMutationResult.create_CompleteMutation(
+        ToDafny.MutationComplete(nativeValue.CompleteMutation())
       );
     }
     throw new IllegalArgumentException(
@@ -518,17 +509,17 @@ public class ToDafny {
   public static KMSIdentifier KMSIdentifier(
     software.amazon.cryptography.keystoreadmin.model.KMSIdentifier nativeValue
   ) {
-    if (Objects.nonNull(nativeValue.kmsKeyArn())) {
-      return KMSIdentifier.create_kmsKeyArn(
+    if (Objects.nonNull(nativeValue.KmsKeyArn())) {
+      return KMSIdentifier.create_KmsKeyArn(
         software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-          nativeValue.kmsKeyArn()
+          nativeValue.KmsKeyArn()
         )
       );
     }
-    if (Objects.nonNull(nativeValue.kmsMRKeyArn())) {
-      return KMSIdentifier.create_kmsMRKeyArn(
+    if (Objects.nonNull(nativeValue.KmsMRKeyArn())) {
+      return KMSIdentifier.create_KmsMRKeyArn(
         software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
-          nativeValue.kmsMRKeyArn()
+          nativeValue.KmsMRKeyArn()
         )
       );
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
@@ -23,8 +23,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyO
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.IKeyStoreAdminClient;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput;
@@ -41,8 +44,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKey
 import software.amazon.cryptography.keystoreadmin.model.CollectionOfErrors;
 import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.model.MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.model.MutationFromException;
 import software.amazon.cryptography.keystoreadmin.model.MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.model.MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.model.MutationToException;
+import software.amazon.cryptography.keystoreadmin.model.MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.model.OpaqueError;
 import software.amazon.cryptography.keystoreadmin.model.UnexpectedStateException;
 
@@ -55,11 +61,20 @@ public class ToDafny {
     if (nativeValue instanceof MutationConflictException) {
       return ToDafny.Error((MutationConflictException) nativeValue);
     }
+    if (nativeValue instanceof MutationFromException) {
+      return ToDafny.Error((MutationFromException) nativeValue);
+    }
     if (nativeValue instanceof MutationInvalidException) {
       return ToDafny.Error((MutationInvalidException) nativeValue);
     }
     if (nativeValue instanceof MutationLockInvalidException) {
       return ToDafny.Error((MutationLockInvalidException) nativeValue);
+    }
+    if (nativeValue instanceof MutationToException) {
+      return ToDafny.Error((MutationToException) nativeValue);
+    }
+    if (nativeValue instanceof MutationVerificationException) {
+      return ToDafny.Error((MutationVerificationException) nativeValue);
     }
     if (nativeValue instanceof UnexpectedStateException) {
       return ToDafny.Error((UnexpectedStateException) nativeValue);
@@ -409,6 +424,15 @@ public class ToDafny {
     return new Error_MutationConflictException(message);
   }
 
+  public static Error Error(MutationFromException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationFromException(message);
+  }
+
   public static Error Error(MutationInvalidException nativeValue) {
     DafnySequence<? extends Character> message;
     message =
@@ -425,6 +449,24 @@ public class ToDafny {
         nativeValue.message()
       );
     return new Error_MutationLockInvalidException(message);
+  }
+
+  public static Error Error(MutationToException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationToException(message);
+  }
+
+  public static Error Error(MutationVerificationException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationVerificationException(message);
   }
 
   public static Error Error(UnexpectedStateException nativeValue) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
@@ -10,8 +10,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_CollectionOfErrors;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_Opaque;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.IKeyStoreAdminClient;
@@ -30,9 +33,12 @@ import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.model.MutatedBranchKeyItem;
 import software.amazon.cryptography.keystoreadmin.model.MutationComplete;
 import software.amazon.cryptography.keystoreadmin.model.MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.model.MutationFromException;
 import software.amazon.cryptography.keystoreadmin.model.MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.model.MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.model.MutationToException;
 import software.amazon.cryptography.keystoreadmin.model.MutationToken;
+import software.amazon.cryptography.keystoreadmin.model.MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.model.Mutations;
 import software.amazon.cryptography.keystoreadmin.model.OpaqueError;
 import software.amazon.cryptography.keystoreadmin.model.UnexpectedStateException;
@@ -89,6 +95,19 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static MutationFromException Error(
+    Error_MutationFromException dafnyValue
+  ) {
+    MutationFromException.Builder nativeBuilder =
+      MutationFromException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static MutationInvalidException Error(
     Error_MutationInvalidException dafnyValue
   ) {
@@ -107,6 +126,31 @@ public class ToNative {
   ) {
     MutationLockInvalidException.Builder nativeBuilder =
       MutationLockInvalidException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static MutationToException Error(
+    Error_MutationToException dafnyValue
+  ) {
+    MutationToException.Builder nativeBuilder = MutationToException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static MutationVerificationException Error(
+    Error_MutationVerificationException dafnyValue
+  ) {
+    MutationVerificationException.Builder nativeBuilder =
+      MutationVerificationException.builder();
     nativeBuilder.message(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
         dafnyValue.dtor_message()
@@ -135,11 +179,20 @@ public class ToNative {
     if (dafnyValue.is_MutationConflictException()) {
       return ToNative.Error((Error_MutationConflictException) dafnyValue);
     }
+    if (dafnyValue.is_MutationFromException()) {
+      return ToNative.Error((Error_MutationFromException) dafnyValue);
+    }
     if (dafnyValue.is_MutationInvalidException()) {
       return ToNative.Error((Error_MutationInvalidException) dafnyValue);
     }
     if (dafnyValue.is_MutationLockInvalidException()) {
       return ToNative.Error((Error_MutationLockInvalidException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationToException()) {
+      return ToNative.Error((Error_MutationToException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationVerificationException()) {
+      return ToNative.Error((Error_MutationVerificationException) dafnyValue);
     }
     if (dafnyValue.is_UnexpectedStateException()) {
       return ToNative.Error((Error_UnexpectedStateException) dafnyValue);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
@@ -227,15 +227,15 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput dafnyValue
   ) {
     ApplyMutationInput.Builder nativeBuilder = ApplyMutationInput.builder();
-    nativeBuilder.mutationToken(
-      ToNative.MutationToken(dafnyValue.dtor_mutationToken())
+    nativeBuilder.MutationToken(
+      ToNative.MutationToken(dafnyValue.dtor_MutationToken())
     );
-    if (dafnyValue.dtor_pageSize().is_Some()) {
-      nativeBuilder.pageSize((dafnyValue.dtor_pageSize().dtor_value()));
+    if (dafnyValue.dtor_PageSize().is_Some()) {
+      nativeBuilder.PageSize((dafnyValue.dtor_PageSize().dtor_value()));
     }
-    if (dafnyValue.dtor_strategy().is_Some()) {
-      nativeBuilder.strategy(
-        ToNative.KeyManagementStrategy(dafnyValue.dtor_strategy().dtor_value())
+    if (dafnyValue.dtor_Strategy().is_Some()) {
+      nativeBuilder.Strategy(
+        ToNative.KeyManagementStrategy(dafnyValue.dtor_Strategy().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -245,11 +245,11 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput dafnyValue
   ) {
     ApplyMutationOutput.Builder nativeBuilder = ApplyMutationOutput.builder();
-    nativeBuilder.result(
-      ToNative.ApplyMutationResult(dafnyValue.dtor_result())
+    nativeBuilder.MutationResult(
+      ToNative.ApplyMutationResult(dafnyValue.dtor_MutationResult())
     );
-    nativeBuilder.mutatedBranchKeyItems(
-      ToNative.MutatedBranchKeyItems(dafnyValue.dtor_mutatedBranchKeyItems())
+    nativeBuilder.MutatedBranchKeyItems(
+      ToNative.MutatedBranchKeyItems(dafnyValue.dtor_MutatedBranchKeyItems())
     );
     return nativeBuilder.build();
   }
@@ -258,24 +258,24 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput dafnyValue
   ) {
     CreateKeyInput.Builder nativeBuilder = CreateKeyInput.builder();
-    if (dafnyValue.dtor_branchKeyIdentifier().is_Some()) {
-      nativeBuilder.branchKeyIdentifier(
+    if (dafnyValue.dtor_Identifier().is_Some()) {
+      nativeBuilder.Identifier(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-          dafnyValue.dtor_branchKeyIdentifier().dtor_value()
+          dafnyValue.dtor_Identifier().dtor_value()
         )
       );
     }
-    if (dafnyValue.dtor_encryptionContext().is_Some()) {
-      nativeBuilder.encryptionContext(
+    if (dafnyValue.dtor_EncryptionContext().is_Some()) {
+      nativeBuilder.EncryptionContext(
         software.amazon.cryptography.keystore.ToNative.EncryptionContext(
-          dafnyValue.dtor_encryptionContext().dtor_value()
+          dafnyValue.dtor_EncryptionContext().dtor_value()
         )
       );
     }
-    nativeBuilder.kmsArn(ToNative.KMSIdentifier(dafnyValue.dtor_kmsArn()));
-    if (dafnyValue.dtor_strategy().is_Some()) {
-      nativeBuilder.strategy(
-        ToNative.KeyManagementStrategy(dafnyValue.dtor_strategy().dtor_value())
+    nativeBuilder.KmsArn(ToNative.KMSIdentifier(dafnyValue.dtor_KmsArn()));
+    if (dafnyValue.dtor_Strategy().is_Some()) {
+      nativeBuilder.Strategy(
+        ToNative.KeyManagementStrategy(dafnyValue.dtor_Strategy().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -285,9 +285,9 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput dafnyValue
   ) {
     CreateKeyOutput.Builder nativeBuilder = CreateKeyOutput.builder();
-    nativeBuilder.branchKeyIdentifier(
+    nativeBuilder.Identifier(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-        dafnyValue.dtor_branchKeyIdentifier()
+        dafnyValue.dtor_Identifier()
       )
     );
     return nativeBuilder.build();
@@ -298,15 +298,15 @@ public class ToNative {
   ) {
     InitializeMutationInput.Builder nativeBuilder =
       InitializeMutationInput.builder();
-    nativeBuilder.branchKeyIdentifier(
+    nativeBuilder.Identifier(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-        dafnyValue.dtor_branchKeyIdentifier()
+        dafnyValue.dtor_Identifier()
       )
     );
-    nativeBuilder.mutations(ToNative.Mutations(dafnyValue.dtor_mutations()));
-    if (dafnyValue.dtor_strategy().is_Some()) {
-      nativeBuilder.strategy(
-        ToNative.KeyManagementStrategy(dafnyValue.dtor_strategy().dtor_value())
+    nativeBuilder.Mutations(ToNative.Mutations(dafnyValue.dtor_Mutations()));
+    if (dafnyValue.dtor_Strategy().is_Some()) {
+      nativeBuilder.Strategy(
+        ToNative.KeyManagementStrategy(dafnyValue.dtor_Strategy().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -317,11 +317,11 @@ public class ToNative {
   ) {
     InitializeMutationOutput.Builder nativeBuilder =
       InitializeMutationOutput.builder();
-    nativeBuilder.mutationToken(
-      ToNative.MutationToken(dafnyValue.dtor_mutationToken())
+    nativeBuilder.MutationToken(
+      ToNative.MutationToken(dafnyValue.dtor_MutationToken())
     );
-    nativeBuilder.mutatedBranchKeyItems(
-      ToNative.MutatedBranchKeyItems(dafnyValue.dtor_mutatedBranchKeyItems())
+    nativeBuilder.MutatedBranchKeyItems(
+      ToNative.MutatedBranchKeyItems(dafnyValue.dtor_MutatedBranchKeyItems())
     );
     return nativeBuilder.build();
   }
@@ -347,14 +347,14 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem dafnyValue
   ) {
     MutatedBranchKeyItem.Builder nativeBuilder = MutatedBranchKeyItem.builder();
-    nativeBuilder.itemType(
+    nativeBuilder.ItemType(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-        dafnyValue.dtor_itemType()
+        dafnyValue.dtor_ItemType()
       )
     );
-    nativeBuilder.description(
+    nativeBuilder.Description(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-        dafnyValue.dtor_description()
+        dafnyValue.dtor_Description()
       )
     );
     return nativeBuilder.build();
@@ -371,17 +371,17 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations dafnyValue
   ) {
     Mutations.Builder nativeBuilder = Mutations.builder();
-    if (dafnyValue.dtor_terminalKmsArn().is_Some()) {
-      nativeBuilder.terminalKmsArn(
+    if (dafnyValue.dtor_TerminalKmsArn().is_Some()) {
+      nativeBuilder.TerminalKmsArn(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-          dafnyValue.dtor_terminalKmsArn().dtor_value()
+          dafnyValue.dtor_TerminalKmsArn().dtor_value()
         )
       );
     }
-    if (dafnyValue.dtor_terminalEncryptionContext().is_Some()) {
-      nativeBuilder.terminalEncryptionContext(
+    if (dafnyValue.dtor_TerminalEncryptionContext().is_Some()) {
+      nativeBuilder.TerminalEncryptionContext(
         software.amazon.cryptography.keystore.ToNative.EncryptionContextString(
-          dafnyValue.dtor_terminalEncryptionContext().dtor_value()
+          dafnyValue.dtor_TerminalEncryptionContext().dtor_value()
         )
       );
     }
@@ -433,15 +433,15 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput dafnyValue
   ) {
     VersionKeyInput.Builder nativeBuilder = VersionKeyInput.builder();
-    nativeBuilder.branchKeyIdentifier(
+    nativeBuilder.Identifier(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-        dafnyValue.dtor_branchKeyIdentifier()
+        dafnyValue.dtor_Identifier()
       )
     );
-    nativeBuilder.kmsArn(ToNative.KMSIdentifier(dafnyValue.dtor_kmsArn()));
-    if (dafnyValue.dtor_strategy().is_Some()) {
-      nativeBuilder.strategy(
-        ToNative.KeyManagementStrategy(dafnyValue.dtor_strategy().dtor_value())
+    nativeBuilder.KmsArn(ToNative.KMSIdentifier(dafnyValue.dtor_KmsArn()));
+    if (dafnyValue.dtor_Strategy().is_Some()) {
+      nativeBuilder.Strategy(
+        ToNative.KeyManagementStrategy(dafnyValue.dtor_Strategy().dtor_value())
       );
     }
     return nativeBuilder.build();
@@ -458,14 +458,14 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult dafnyValue
   ) {
     ApplyMutationResult.Builder nativeBuilder = ApplyMutationResult.builder();
-    if (dafnyValue.is_continueMutation()) {
-      nativeBuilder.continueMutation(
-        ToNative.MutationToken(dafnyValue.dtor_continueMutation())
+    if (dafnyValue.is_ContinueMutation()) {
+      nativeBuilder.ContinueMutation(
+        ToNative.MutationToken(dafnyValue.dtor_ContinueMutation())
       );
     }
-    if (dafnyValue.is_completeMutation()) {
-      nativeBuilder.completeMutation(
-        ToNative.MutationComplete(dafnyValue.dtor_completeMutation())
+    if (dafnyValue.is_CompleteMutation()) {
+      nativeBuilder.CompleteMutation(
+        ToNative.MutationComplete(dafnyValue.dtor_CompleteMutation())
       );
     }
     return nativeBuilder.build();
@@ -490,17 +490,17 @@ public class ToNative {
     software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier dafnyValue
   ) {
     KMSIdentifier.Builder nativeBuilder = KMSIdentifier.builder();
-    if (dafnyValue.is_kmsKeyArn()) {
-      nativeBuilder.kmsKeyArn(
+    if (dafnyValue.is_KmsKeyArn()) {
+      nativeBuilder.KmsKeyArn(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-          dafnyValue.dtor_kmsKeyArn()
+          dafnyValue.dtor_KmsKeyArn()
         )
       );
     }
-    if (dafnyValue.is_kmsMRKeyArn()) {
-      nativeBuilder.kmsMRKeyArn(
+    if (dafnyValue.is_KmsMRKeyArn()) {
+      nativeBuilder.KmsMRKeyArn(
         software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
-          dafnyValue.dtor_kmsMRKeyArn()
+          dafnyValue.dtor_KmsMRKeyArn()
         )
       );
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationInput.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 public class ApplyMutationInput {
 
-  private final MutationToken mutationToken;
+  private final MutationToken MutationToken;
 
   /**
    * For Default DynamoDB Table Storage, the maximum page size is 99.
@@ -16,21 +16,21 @@ public class ApplyMutationInput {
    *   an additional "item" is consumed by the Mutation Lock verification.
    *   Thus, if the pageSize is 24, 25 requests will be sent in the Transact Write Request.
    */
-  private final Integer pageSize;
+  private final Integer PageSize;
 
   /**
    * Optional. Defaults to reEncrypt with a default KMS Client.
    */
-  private final KeyManagementStrategy strategy;
+  private final KeyManagementStrategy Strategy;
 
   protected ApplyMutationInput(BuilderImpl builder) {
-    this.mutationToken = builder.mutationToken();
-    this.pageSize = builder.pageSize();
-    this.strategy = builder.strategy();
+    this.MutationToken = builder.MutationToken();
+    this.PageSize = builder.PageSize();
+    this.Strategy = builder.Strategy();
   }
 
-  public MutationToken mutationToken() {
-    return this.mutationToken;
+  public MutationToken MutationToken() {
+    return this.MutationToken;
   }
 
   /**
@@ -40,15 +40,15 @@ public class ApplyMutationInput {
    *   an additional "item" is consumed by the Mutation Lock verification.
    *   Thus, if the pageSize is 24, 25 requests will be sent in the Transact Write Request.
    */
-  public Integer pageSize() {
-    return this.pageSize;
+  public Integer PageSize() {
+    return this.PageSize;
   }
 
   /**
    * @return Optional. Defaults to reEncrypt with a default KMS Client.
    */
-  public KeyManagementStrategy strategy() {
-    return this.strategy;
+  public KeyManagementStrategy Strategy() {
+    return this.Strategy;
   }
 
   public Builder toBuilder() {
@@ -60,18 +60,18 @@ public class ApplyMutationInput {
   }
 
   public interface Builder {
-    Builder mutationToken(MutationToken mutationToken);
+    Builder MutationToken(MutationToken MutationToken);
 
-    MutationToken mutationToken();
+    MutationToken MutationToken();
 
     /**
-     * @param pageSize For Default DynamoDB Table Storage, the maximum page size is 99.
+     * @param PageSize For Default DynamoDB Table Storage, the maximum page size is 99.
      *   At most, Apply Mutation will mutate pageSize Items.
      *   Note that, at least for Storage:DynamoDBTable,
      *   an additional "item" is consumed by the Mutation Lock verification.
      *   Thus, if the pageSize is 24, 25 requests will be sent in the Transact Write Request.
      */
-    Builder pageSize(Integer pageSize);
+    Builder PageSize(Integer PageSize);
 
     /**
      * @return For Default DynamoDB Table Storage, the maximum page size is 99.
@@ -80,68 +80,68 @@ public class ApplyMutationInput {
      *   an additional "item" is consumed by the Mutation Lock verification.
      *   Thus, if the pageSize is 24, 25 requests will be sent in the Transact Write Request.
      */
-    Integer pageSize();
+    Integer PageSize();
 
     /**
-     * @param strategy Optional. Defaults to reEncrypt with a default KMS Client.
+     * @param Strategy Optional. Defaults to reEncrypt with a default KMS Client.
      */
-    Builder strategy(KeyManagementStrategy strategy);
+    Builder Strategy(KeyManagementStrategy Strategy);
 
     /**
      * @return Optional. Defaults to reEncrypt with a default KMS Client.
      */
-    KeyManagementStrategy strategy();
+    KeyManagementStrategy Strategy();
 
     ApplyMutationInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected MutationToken mutationToken;
+    protected MutationToken MutationToken;
 
-    protected Integer pageSize;
+    protected Integer PageSize;
 
-    protected KeyManagementStrategy strategy;
+    protected KeyManagementStrategy Strategy;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(ApplyMutationInput model) {
-      this.mutationToken = model.mutationToken();
-      this.pageSize = model.pageSize();
-      this.strategy = model.strategy();
+      this.MutationToken = model.MutationToken();
+      this.PageSize = model.PageSize();
+      this.Strategy = model.Strategy();
     }
 
-    public Builder mutationToken(MutationToken mutationToken) {
-      this.mutationToken = mutationToken;
+    public Builder MutationToken(MutationToken MutationToken) {
+      this.MutationToken = MutationToken;
       return this;
     }
 
-    public MutationToken mutationToken() {
-      return this.mutationToken;
+    public MutationToken MutationToken() {
+      return this.MutationToken;
     }
 
-    public Builder pageSize(Integer pageSize) {
-      this.pageSize = pageSize;
+    public Builder PageSize(Integer PageSize) {
+      this.PageSize = PageSize;
       return this;
     }
 
-    public Integer pageSize() {
-      return this.pageSize;
+    public Integer PageSize() {
+      return this.PageSize;
     }
 
-    public Builder strategy(KeyManagementStrategy strategy) {
-      this.strategy = strategy;
+    public Builder Strategy(KeyManagementStrategy Strategy) {
+      this.Strategy = Strategy;
       return this;
     }
 
-    public KeyManagementStrategy strategy() {
-      return this.strategy;
+    public KeyManagementStrategy Strategy() {
+      return this.Strategy;
     }
 
     public ApplyMutationInput build() {
-      if (Objects.isNull(this.mutationToken())) {
+      if (Objects.isNull(this.MutationToken())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutationToken`"
+          "Missing value for required field `MutationToken`"
         );
       }
       return new ApplyMutationInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationOutput.java
@@ -8,27 +8,27 @@ import java.util.Objects;
 
 public class ApplyMutationOutput {
 
-  private final ApplyMutationResult result;
+  private final ApplyMutationResult MutationResult;
 
   /**
    * Details what items of the Branch Key ID were changed on this invocation.
    */
-  private final List<MutatedBranchKeyItem> mutatedBranchKeyItems;
+  private final List<MutatedBranchKeyItem> MutatedBranchKeyItems;
 
   protected ApplyMutationOutput(BuilderImpl builder) {
-    this.result = builder.result();
-    this.mutatedBranchKeyItems = builder.mutatedBranchKeyItems();
+    this.MutationResult = builder.MutationResult();
+    this.MutatedBranchKeyItems = builder.MutatedBranchKeyItems();
   }
 
-  public ApplyMutationResult result() {
-    return this.result;
+  public ApplyMutationResult MutationResult() {
+    return this.MutationResult;
   }
 
   /**
    * @return Details what items of the Branch Key ID were changed on this invocation.
    */
-  public List<MutatedBranchKeyItem> mutatedBranchKeyItems() {
-    return this.mutatedBranchKeyItems;
+  public List<MutatedBranchKeyItem> MutatedBranchKeyItems() {
+    return this.MutatedBranchKeyItems;
   }
 
   public Builder toBuilder() {
@@ -40,67 +40,67 @@ public class ApplyMutationOutput {
   }
 
   public interface Builder {
-    Builder result(ApplyMutationResult result);
+    Builder MutationResult(ApplyMutationResult MutationResult);
 
-    ApplyMutationResult result();
+    ApplyMutationResult MutationResult();
 
     /**
-     * @param mutatedBranchKeyItems Details what items of the Branch Key ID were changed on this invocation.
+     * @param MutatedBranchKeyItems Details what items of the Branch Key ID were changed on this invocation.
      */
-    Builder mutatedBranchKeyItems(
-      List<MutatedBranchKeyItem> mutatedBranchKeyItems
+    Builder MutatedBranchKeyItems(
+      List<MutatedBranchKeyItem> MutatedBranchKeyItems
     );
 
     /**
      * @return Details what items of the Branch Key ID were changed on this invocation.
      */
-    List<MutatedBranchKeyItem> mutatedBranchKeyItems();
+    List<MutatedBranchKeyItem> MutatedBranchKeyItems();
 
     ApplyMutationOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected ApplyMutationResult result;
+    protected ApplyMutationResult MutationResult;
 
-    protected List<MutatedBranchKeyItem> mutatedBranchKeyItems;
+    protected List<MutatedBranchKeyItem> MutatedBranchKeyItems;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(ApplyMutationOutput model) {
-      this.result = model.result();
-      this.mutatedBranchKeyItems = model.mutatedBranchKeyItems();
+      this.MutationResult = model.MutationResult();
+      this.MutatedBranchKeyItems = model.MutatedBranchKeyItems();
     }
 
-    public Builder result(ApplyMutationResult result) {
-      this.result = result;
+    public Builder MutationResult(ApplyMutationResult MutationResult) {
+      this.MutationResult = MutationResult;
       return this;
     }
 
-    public ApplyMutationResult result() {
-      return this.result;
+    public ApplyMutationResult MutationResult() {
+      return this.MutationResult;
     }
 
-    public Builder mutatedBranchKeyItems(
-      List<MutatedBranchKeyItem> mutatedBranchKeyItems
+    public Builder MutatedBranchKeyItems(
+      List<MutatedBranchKeyItem> MutatedBranchKeyItems
     ) {
-      this.mutatedBranchKeyItems = mutatedBranchKeyItems;
+      this.MutatedBranchKeyItems = MutatedBranchKeyItems;
       return this;
     }
 
-    public List<MutatedBranchKeyItem> mutatedBranchKeyItems() {
-      return this.mutatedBranchKeyItems;
+    public List<MutatedBranchKeyItem> MutatedBranchKeyItems() {
+      return this.MutatedBranchKeyItems;
     }
 
     public ApplyMutationOutput build() {
-      if (Objects.isNull(this.result())) {
+      if (Objects.isNull(this.MutationResult())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `result`"
+          "Missing value for required field `MutationResult`"
         );
       }
-      if (Objects.isNull(this.mutatedBranchKeyItems())) {
+      if (Objects.isNull(this.MutatedBranchKeyItems())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutatedBranchKeyItems`"
+          "Missing value for required field `MutatedBranchKeyItems`"
         );
       }
       return new ApplyMutationOutput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationResult.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/ApplyMutationResult.java
@@ -10,30 +10,30 @@ public class ApplyMutationResult {
   /**
    * Continue applying the mutation. Invoke Apply Mutation with this Mutation Token.
    */
-  private final MutationToken continueMutation;
+  private final MutationToken ContinueMutation;
 
   /**
    * All items have been mutated; the Mutation Lock has been removed. The mutation is complete.
    */
-  private final MutationComplete completeMutation;
+  private final MutationComplete CompleteMutation;
 
   protected ApplyMutationResult(BuilderImpl builder) {
-    this.continueMutation = builder.continueMutation();
-    this.completeMutation = builder.completeMutation();
+    this.ContinueMutation = builder.ContinueMutation();
+    this.CompleteMutation = builder.CompleteMutation();
   }
 
   /**
    * @return Continue applying the mutation. Invoke Apply Mutation with this Mutation Token.
    */
-  public MutationToken continueMutation() {
-    return this.continueMutation;
+  public MutationToken ContinueMutation() {
+    return this.ContinueMutation;
   }
 
   /**
    * @return All items have been mutated; the Mutation Lock has been removed. The mutation is complete.
    */
-  public MutationComplete completeMutation() {
-    return this.completeMutation;
+  public MutationComplete CompleteMutation() {
+    return this.CompleteMutation;
   }
 
   public Builder toBuilder() {
@@ -46,57 +46,57 @@ public class ApplyMutationResult {
 
   public interface Builder {
     /**
-     * @param continueMutation Continue applying the mutation. Invoke Apply Mutation with this Mutation Token.
+     * @param ContinueMutation Continue applying the mutation. Invoke Apply Mutation with this Mutation Token.
      */
-    Builder continueMutation(MutationToken continueMutation);
+    Builder ContinueMutation(MutationToken ContinueMutation);
 
     /**
      * @return Continue applying the mutation. Invoke Apply Mutation with this Mutation Token.
      */
-    MutationToken continueMutation();
+    MutationToken ContinueMutation();
 
     /**
-     * @param completeMutation All items have been mutated; the Mutation Lock has been removed. The mutation is complete.
+     * @param CompleteMutation All items have been mutated; the Mutation Lock has been removed. The mutation is complete.
      */
-    Builder completeMutation(MutationComplete completeMutation);
+    Builder CompleteMutation(MutationComplete CompleteMutation);
 
     /**
      * @return All items have been mutated; the Mutation Lock has been removed. The mutation is complete.
      */
-    MutationComplete completeMutation();
+    MutationComplete CompleteMutation();
 
     ApplyMutationResult build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected MutationToken continueMutation;
+    protected MutationToken ContinueMutation;
 
-    protected MutationComplete completeMutation;
+    protected MutationComplete CompleteMutation;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(ApplyMutationResult model) {
-      this.continueMutation = model.continueMutation();
-      this.completeMutation = model.completeMutation();
+      this.ContinueMutation = model.ContinueMutation();
+      this.CompleteMutation = model.CompleteMutation();
     }
 
-    public Builder continueMutation(MutationToken continueMutation) {
-      this.continueMutation = continueMutation;
+    public Builder ContinueMutation(MutationToken ContinueMutation) {
+      this.ContinueMutation = ContinueMutation;
       return this;
     }
 
-    public MutationToken continueMutation() {
-      return this.continueMutation;
+    public MutationToken ContinueMutation() {
+      return this.ContinueMutation;
     }
 
-    public Builder completeMutation(MutationComplete completeMutation) {
-      this.completeMutation = completeMutation;
+    public Builder CompleteMutation(MutationComplete CompleteMutation) {
+      this.CompleteMutation = CompleteMutation;
       return this;
     }
 
-    public MutationComplete completeMutation() {
-      return this.completeMutation;
+    public MutationComplete CompleteMutation() {
+      return this.CompleteMutation;
     }
 
     public ApplyMutationResult build() {
@@ -109,7 +109,7 @@ public class ApplyMutationResult {
     }
 
     private boolean onlyOneNonNull() {
-      Object[] allValues = { this.continueMutation, this.completeMutation };
+      Object[] allValues = { this.ContinueMutation, this.CompleteMutation };
       boolean haveOneNonNull = false;
       for (Object o : allValues) {
         if (Objects.nonNull(o)) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/CreateKeyInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/CreateKeyInput.java
@@ -11,62 +11,62 @@ public class CreateKeyInput {
   /**
    * The identifier for the created Branch Key.
    */
-  private final String branchKeyIdentifier;
+  private final String Identifier;
 
   /**
    * Custom encryption context for the Branch Key.
    *   Required if branchKeyIdentifier is set.
    */
-  private final Map<String, String> encryptionContext;
+  private final Map<String, String> EncryptionContext;
 
   /**
    * Multi-Region or Single Region AWS KMS Key
    *   used to protect the Branch Key, but not aliases!
    */
-  private final KMSIdentifier kmsArn;
+  private final KMSIdentifier KmsArn;
 
   /**
    * This configures which Key Management Operations will be used
    *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
    */
-  private final KeyManagementStrategy strategy;
+  private final KeyManagementStrategy Strategy;
 
   protected CreateKeyInput(BuilderImpl builder) {
-    this.branchKeyIdentifier = builder.branchKeyIdentifier();
-    this.encryptionContext = builder.encryptionContext();
-    this.kmsArn = builder.kmsArn();
-    this.strategy = builder.strategy();
+    this.Identifier = builder.Identifier();
+    this.EncryptionContext = builder.EncryptionContext();
+    this.KmsArn = builder.KmsArn();
+    this.Strategy = builder.Strategy();
   }
 
   /**
    * @return The identifier for the created Branch Key.
    */
-  public String branchKeyIdentifier() {
-    return this.branchKeyIdentifier;
+  public String Identifier() {
+    return this.Identifier;
   }
 
   /**
    * @return Custom encryption context for the Branch Key.
    *   Required if branchKeyIdentifier is set.
    */
-  public Map<String, String> encryptionContext() {
-    return this.encryptionContext;
+  public Map<String, String> EncryptionContext() {
+    return this.EncryptionContext;
   }
 
   /**
    * @return Multi-Region or Single Region AWS KMS Key
    *   used to protect the Branch Key, but not aliases!
    */
-  public KMSIdentifier kmsArn() {
-    return this.kmsArn;
+  public KMSIdentifier KmsArn() {
+    return this.KmsArn;
   }
 
   /**
    * @return This configures which Key Management Operations will be used
    *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
    */
-  public KeyManagementStrategy strategy() {
-    return this.strategy;
+  public KeyManagementStrategy Strategy() {
+    return this.Strategy;
   }
 
   public Builder toBuilder() {
@@ -79,113 +79,113 @@ public class CreateKeyInput {
 
   public interface Builder {
     /**
-     * @param branchKeyIdentifier The identifier for the created Branch Key.
+     * @param Identifier The identifier for the created Branch Key.
      */
-    Builder branchKeyIdentifier(String branchKeyIdentifier);
+    Builder Identifier(String Identifier);
 
     /**
      * @return The identifier for the created Branch Key.
      */
-    String branchKeyIdentifier();
+    String Identifier();
 
     /**
-     * @param encryptionContext Custom encryption context for the Branch Key.
+     * @param EncryptionContext Custom encryption context for the Branch Key.
      *   Required if branchKeyIdentifier is set.
      */
-    Builder encryptionContext(Map<String, String> encryptionContext);
+    Builder EncryptionContext(Map<String, String> EncryptionContext);
 
     /**
      * @return Custom encryption context for the Branch Key.
      *   Required if branchKeyIdentifier is set.
      */
-    Map<String, String> encryptionContext();
+    Map<String, String> EncryptionContext();
 
     /**
-     * @param kmsArn Multi-Region or Single Region AWS KMS Key
+     * @param KmsArn Multi-Region or Single Region AWS KMS Key
      *   used to protect the Branch Key, but not aliases!
      */
-    Builder kmsArn(KMSIdentifier kmsArn);
+    Builder KmsArn(KMSIdentifier KmsArn);
 
     /**
      * @return Multi-Region or Single Region AWS KMS Key
      *   used to protect the Branch Key, but not aliases!
      */
-    KMSIdentifier kmsArn();
+    KMSIdentifier KmsArn();
 
     /**
-     * @param strategy This configures which Key Management Operations will be used
+     * @param Strategy This configures which Key Management Operations will be used
      *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
      */
-    Builder strategy(KeyManagementStrategy strategy);
+    Builder Strategy(KeyManagementStrategy Strategy);
 
     /**
      * @return This configures which Key Management Operations will be used
      *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
      */
-    KeyManagementStrategy strategy();
+    KeyManagementStrategy Strategy();
 
     CreateKeyInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String branchKeyIdentifier;
+    protected String Identifier;
 
-    protected Map<String, String> encryptionContext;
+    protected Map<String, String> EncryptionContext;
 
-    protected KMSIdentifier kmsArn;
+    protected KMSIdentifier KmsArn;
 
-    protected KeyManagementStrategy strategy;
+    protected KeyManagementStrategy Strategy;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(CreateKeyInput model) {
-      this.branchKeyIdentifier = model.branchKeyIdentifier();
-      this.encryptionContext = model.encryptionContext();
-      this.kmsArn = model.kmsArn();
-      this.strategy = model.strategy();
+      this.Identifier = model.Identifier();
+      this.EncryptionContext = model.EncryptionContext();
+      this.KmsArn = model.KmsArn();
+      this.Strategy = model.Strategy();
     }
 
-    public Builder branchKeyIdentifier(String branchKeyIdentifier) {
-      this.branchKeyIdentifier = branchKeyIdentifier;
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
       return this;
     }
 
-    public String branchKeyIdentifier() {
-      return this.branchKeyIdentifier;
+    public String Identifier() {
+      return this.Identifier;
     }
 
-    public Builder encryptionContext(Map<String, String> encryptionContext) {
-      this.encryptionContext = encryptionContext;
+    public Builder EncryptionContext(Map<String, String> EncryptionContext) {
+      this.EncryptionContext = EncryptionContext;
       return this;
     }
 
-    public Map<String, String> encryptionContext() {
-      return this.encryptionContext;
+    public Map<String, String> EncryptionContext() {
+      return this.EncryptionContext;
     }
 
-    public Builder kmsArn(KMSIdentifier kmsArn) {
-      this.kmsArn = kmsArn;
+    public Builder KmsArn(KMSIdentifier KmsArn) {
+      this.KmsArn = KmsArn;
       return this;
     }
 
-    public KMSIdentifier kmsArn() {
-      return this.kmsArn;
+    public KMSIdentifier KmsArn() {
+      return this.KmsArn;
     }
 
-    public Builder strategy(KeyManagementStrategy strategy) {
-      this.strategy = strategy;
+    public Builder Strategy(KeyManagementStrategy Strategy) {
+      this.Strategy = Strategy;
       return this;
     }
 
-    public KeyManagementStrategy strategy() {
-      return this.strategy;
+    public KeyManagementStrategy Strategy() {
+      return this.Strategy;
     }
 
     public CreateKeyInput build() {
-      if (Objects.isNull(this.kmsArn())) {
+      if (Objects.isNull(this.KmsArn())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `kmsArn`"
+          "Missing value for required field `KmsArn`"
         );
       }
       return new CreateKeyInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/CreateKeyOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/CreateKeyOutput.java
@@ -10,17 +10,17 @@ public class CreateKeyOutput {
   /**
    * A identifier for the created Branch Key.
    */
-  private final String branchKeyIdentifier;
+  private final String Identifier;
 
   protected CreateKeyOutput(BuilderImpl builder) {
-    this.branchKeyIdentifier = builder.branchKeyIdentifier();
+    this.Identifier = builder.Identifier();
   }
 
   /**
    * @return A identifier for the created Branch Key.
    */
-  public String branchKeyIdentifier() {
-    return this.branchKeyIdentifier;
+  public String Identifier() {
+    return this.Identifier;
   }
 
   public Builder toBuilder() {
@@ -33,41 +33,41 @@ public class CreateKeyOutput {
 
   public interface Builder {
     /**
-     * @param branchKeyIdentifier A identifier for the created Branch Key.
+     * @param Identifier A identifier for the created Branch Key.
      */
-    Builder branchKeyIdentifier(String branchKeyIdentifier);
+    Builder Identifier(String Identifier);
 
     /**
      * @return A identifier for the created Branch Key.
      */
-    String branchKeyIdentifier();
+    String Identifier();
 
     CreateKeyOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String branchKeyIdentifier;
+    protected String Identifier;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(CreateKeyOutput model) {
-      this.branchKeyIdentifier = model.branchKeyIdentifier();
+      this.Identifier = model.Identifier();
     }
 
-    public Builder branchKeyIdentifier(String branchKeyIdentifier) {
-      this.branchKeyIdentifier = branchKeyIdentifier;
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
       return this;
     }
 
-    public String branchKeyIdentifier() {
-      return this.branchKeyIdentifier;
+    public String Identifier() {
+      return this.Identifier;
     }
 
     public CreateKeyOutput build() {
-      if (Objects.isNull(this.branchKeyIdentifier())) {
+      if (Objects.isNull(this.Identifier())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `branchKeyIdentifier`"
+          "Missing value for required field `Identifier`"
         );
       }
       return new CreateKeyOutput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/InitializeMutationInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/InitializeMutationInput.java
@@ -10,43 +10,43 @@ public class InitializeMutationInput {
   /**
    * The identifier for the Branch Key to be mutated.
    */
-  private final String branchKeyIdentifier;
+  private final String Identifier;
 
   /**
    * Describes the Mutation that will be applied to all Items of the Branch Key.
    */
-  private final Mutations mutations;
+  private final Mutations Mutations;
 
   /**
    * Optional. Defaults to reEncrypt with a default KMS Client.
    */
-  private final KeyManagementStrategy strategy;
+  private final KeyManagementStrategy Strategy;
 
   protected InitializeMutationInput(BuilderImpl builder) {
-    this.branchKeyIdentifier = builder.branchKeyIdentifier();
-    this.mutations = builder.mutations();
-    this.strategy = builder.strategy();
+    this.Identifier = builder.Identifier();
+    this.Mutations = builder.Mutations();
+    this.Strategy = builder.Strategy();
   }
 
   /**
    * @return The identifier for the Branch Key to be mutated.
    */
-  public String branchKeyIdentifier() {
-    return this.branchKeyIdentifier;
+  public String Identifier() {
+    return this.Identifier;
   }
 
   /**
    * @return Describes the Mutation that will be applied to all Items of the Branch Key.
    */
-  public Mutations mutations() {
-    return this.mutations;
+  public Mutations Mutations() {
+    return this.Mutations;
   }
 
   /**
    * @return Optional. Defaults to reEncrypt with a default KMS Client.
    */
-  public KeyManagementStrategy strategy() {
-    return this.strategy;
+  public KeyManagementStrategy Strategy() {
+    return this.Strategy;
   }
 
   public Builder toBuilder() {
@@ -59,90 +59,90 @@ public class InitializeMutationInput {
 
   public interface Builder {
     /**
-     * @param branchKeyIdentifier The identifier for the Branch Key to be mutated.
+     * @param Identifier The identifier for the Branch Key to be mutated.
      */
-    Builder branchKeyIdentifier(String branchKeyIdentifier);
+    Builder Identifier(String Identifier);
 
     /**
      * @return The identifier for the Branch Key to be mutated.
      */
-    String branchKeyIdentifier();
+    String Identifier();
 
     /**
-     * @param mutations Describes the Mutation that will be applied to all Items of the Branch Key.
+     * @param Mutations Describes the Mutation that will be applied to all Items of the Branch Key.
      */
-    Builder mutations(Mutations mutations);
+    Builder Mutations(Mutations Mutations);
 
     /**
      * @return Describes the Mutation that will be applied to all Items of the Branch Key.
      */
-    Mutations mutations();
+    Mutations Mutations();
 
     /**
-     * @param strategy Optional. Defaults to reEncrypt with a default KMS Client.
+     * @param Strategy Optional. Defaults to reEncrypt with a default KMS Client.
      */
-    Builder strategy(KeyManagementStrategy strategy);
+    Builder Strategy(KeyManagementStrategy Strategy);
 
     /**
      * @return Optional. Defaults to reEncrypt with a default KMS Client.
      */
-    KeyManagementStrategy strategy();
+    KeyManagementStrategy Strategy();
 
     InitializeMutationInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String branchKeyIdentifier;
+    protected String Identifier;
 
-    protected Mutations mutations;
+    protected Mutations Mutations;
 
-    protected KeyManagementStrategy strategy;
+    protected KeyManagementStrategy Strategy;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(InitializeMutationInput model) {
-      this.branchKeyIdentifier = model.branchKeyIdentifier();
-      this.mutations = model.mutations();
-      this.strategy = model.strategy();
+      this.Identifier = model.Identifier();
+      this.Mutations = model.Mutations();
+      this.Strategy = model.Strategy();
     }
 
-    public Builder branchKeyIdentifier(String branchKeyIdentifier) {
-      this.branchKeyIdentifier = branchKeyIdentifier;
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
       return this;
     }
 
-    public String branchKeyIdentifier() {
-      return this.branchKeyIdentifier;
+    public String Identifier() {
+      return this.Identifier;
     }
 
-    public Builder mutations(Mutations mutations) {
-      this.mutations = mutations;
+    public Builder Mutations(Mutations Mutations) {
+      this.Mutations = Mutations;
       return this;
     }
 
-    public Mutations mutations() {
-      return this.mutations;
+    public Mutations Mutations() {
+      return this.Mutations;
     }
 
-    public Builder strategy(KeyManagementStrategy strategy) {
-      this.strategy = strategy;
+    public Builder Strategy(KeyManagementStrategy Strategy) {
+      this.Strategy = Strategy;
       return this;
     }
 
-    public KeyManagementStrategy strategy() {
-      return this.strategy;
+    public KeyManagementStrategy Strategy() {
+      return this.Strategy;
     }
 
     public InitializeMutationInput build() {
-      if (Objects.isNull(this.branchKeyIdentifier())) {
+      if (Objects.isNull(this.Identifier())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `branchKeyIdentifier`"
+          "Missing value for required field `Identifier`"
         );
       }
-      if (Objects.isNull(this.mutations())) {
+      if (Objects.isNull(this.Mutations())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutations`"
+          "Missing value for required field `Mutations`"
         );
       }
       return new InitializeMutationInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/InitializeMutationOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/InitializeMutationOutput.java
@@ -11,30 +11,30 @@ public class InitializeMutationOutput {
   /**
    * Pass the Mutation Token to the Apply Mutation operation to continue the Mutation.
    */
-  private final MutationToken mutationToken;
+  private final MutationToken MutationToken;
 
   /**
    * Details what items of the Branch Key ID were changed on this invocation.
    */
-  private final List<MutatedBranchKeyItem> mutatedBranchKeyItems;
+  private final List<MutatedBranchKeyItem> MutatedBranchKeyItems;
 
   protected InitializeMutationOutput(BuilderImpl builder) {
-    this.mutationToken = builder.mutationToken();
-    this.mutatedBranchKeyItems = builder.mutatedBranchKeyItems();
+    this.MutationToken = builder.MutationToken();
+    this.MutatedBranchKeyItems = builder.MutatedBranchKeyItems();
   }
 
   /**
    * @return Pass the Mutation Token to the Apply Mutation operation to continue the Mutation.
    */
-  public MutationToken mutationToken() {
-    return this.mutationToken;
+  public MutationToken MutationToken() {
+    return this.MutationToken;
   }
 
   /**
    * @return Details what items of the Branch Key ID were changed on this invocation.
    */
-  public List<MutatedBranchKeyItem> mutatedBranchKeyItems() {
-    return this.mutatedBranchKeyItems;
+  public List<MutatedBranchKeyItem> MutatedBranchKeyItems() {
+    return this.MutatedBranchKeyItems;
   }
 
   public Builder toBuilder() {
@@ -47,72 +47,72 @@ public class InitializeMutationOutput {
 
   public interface Builder {
     /**
-     * @param mutationToken Pass the Mutation Token to the Apply Mutation operation to continue the Mutation.
+     * @param MutationToken Pass the Mutation Token to the Apply Mutation operation to continue the Mutation.
      */
-    Builder mutationToken(MutationToken mutationToken);
+    Builder MutationToken(MutationToken MutationToken);
 
     /**
      * @return Pass the Mutation Token to the Apply Mutation operation to continue the Mutation.
      */
-    MutationToken mutationToken();
+    MutationToken MutationToken();
 
     /**
-     * @param mutatedBranchKeyItems Details what items of the Branch Key ID were changed on this invocation.
+     * @param MutatedBranchKeyItems Details what items of the Branch Key ID were changed on this invocation.
      */
-    Builder mutatedBranchKeyItems(
-      List<MutatedBranchKeyItem> mutatedBranchKeyItems
+    Builder MutatedBranchKeyItems(
+      List<MutatedBranchKeyItem> MutatedBranchKeyItems
     );
 
     /**
      * @return Details what items of the Branch Key ID were changed on this invocation.
      */
-    List<MutatedBranchKeyItem> mutatedBranchKeyItems();
+    List<MutatedBranchKeyItem> MutatedBranchKeyItems();
 
     InitializeMutationOutput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected MutationToken mutationToken;
+    protected MutationToken MutationToken;
 
-    protected List<MutatedBranchKeyItem> mutatedBranchKeyItems;
+    protected List<MutatedBranchKeyItem> MutatedBranchKeyItems;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(InitializeMutationOutput model) {
-      this.mutationToken = model.mutationToken();
-      this.mutatedBranchKeyItems = model.mutatedBranchKeyItems();
+      this.MutationToken = model.MutationToken();
+      this.MutatedBranchKeyItems = model.MutatedBranchKeyItems();
     }
 
-    public Builder mutationToken(MutationToken mutationToken) {
-      this.mutationToken = mutationToken;
+    public Builder MutationToken(MutationToken MutationToken) {
+      this.MutationToken = MutationToken;
       return this;
     }
 
-    public MutationToken mutationToken() {
-      return this.mutationToken;
+    public MutationToken MutationToken() {
+      return this.MutationToken;
     }
 
-    public Builder mutatedBranchKeyItems(
-      List<MutatedBranchKeyItem> mutatedBranchKeyItems
+    public Builder MutatedBranchKeyItems(
+      List<MutatedBranchKeyItem> MutatedBranchKeyItems
     ) {
-      this.mutatedBranchKeyItems = mutatedBranchKeyItems;
+      this.MutatedBranchKeyItems = MutatedBranchKeyItems;
       return this;
     }
 
-    public List<MutatedBranchKeyItem> mutatedBranchKeyItems() {
-      return this.mutatedBranchKeyItems;
+    public List<MutatedBranchKeyItem> MutatedBranchKeyItems() {
+      return this.MutatedBranchKeyItems;
     }
 
     public InitializeMutationOutput build() {
-      if (Objects.isNull(this.mutationToken())) {
+      if (Objects.isNull(this.MutationToken())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutationToken`"
+          "Missing value for required field `MutationToken`"
         );
       }
-      if (Objects.isNull(this.mutatedBranchKeyItems())) {
+      if (Objects.isNull(this.MutatedBranchKeyItems())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `mutatedBranchKeyItems`"
+          "Missing value for required field `MutatedBranchKeyItems`"
         );
       }
       return new InitializeMutationOutput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/KMSIdentifier.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/KMSIdentifier.java
@@ -17,7 +17,7 @@ public class KMSIdentifier {
    *   is persisted in Branch Keys and
    *   MUST strictly equal this value to be considered valid.
    */
-  private final String kmsKeyArn;
+  private final String KmsKeyArn;
 
   /**
    * If an MRK ARN is provided,
@@ -27,11 +27,11 @@ public class KMSIdentifier {
    *   If either ARN is not an MRK ARN, then
    *   kmsMRKeyArn behaves exactly as kmsKeyArn.
    */
-  private final String kmsMRKeyArn;
+  private final String KmsMRKeyArn;
 
   protected KMSIdentifier(BuilderImpl builder) {
-    this.kmsKeyArn = builder.kmsKeyArn();
-    this.kmsMRKeyArn = builder.kmsMRKeyArn();
+    this.KmsKeyArn = builder.KmsKeyArn();
+    this.KmsMRKeyArn = builder.KmsMRKeyArn();
   }
 
   /**
@@ -44,8 +44,8 @@ public class KMSIdentifier {
    *   is persisted in Branch Keys and
    *   MUST strictly equal this value to be considered valid.
    */
-  public String kmsKeyArn() {
-    return this.kmsKeyArn;
+  public String KmsKeyArn() {
+    return this.KmsKeyArn;
   }
 
   /**
@@ -56,8 +56,8 @@ public class KMSIdentifier {
    *   If either ARN is not an MRK ARN, then
    *   kmsMRKeyArn behaves exactly as kmsKeyArn.
    */
-  public String kmsMRKeyArn() {
-    return this.kmsMRKeyArn;
+  public String KmsMRKeyArn() {
+    return this.KmsMRKeyArn;
   }
 
   public Builder toBuilder() {
@@ -70,7 +70,7 @@ public class KMSIdentifier {
 
   public interface Builder {
     /**
-     * @param kmsKeyArn Key Store is restricted to only this KMS Key ARN.
+     * @param KmsKeyArn Key Store is restricted to only this KMS Key ARN.
      *   If a different KMS Key ARN is encountered
      *   when creating, versioning, or getting a Branch Key or Beacon Key,
      *   KMS is never called and an exception is thrown.
@@ -79,7 +79,7 @@ public class KMSIdentifier {
      *   is persisted in Branch Keys and
      *   MUST strictly equal this value to be considered valid.
      */
-    Builder kmsKeyArn(String kmsKeyArn);
+    Builder KmsKeyArn(String KmsKeyArn);
 
     /**
      * @return Key Store is restricted to only this KMS Key ARN.
@@ -91,17 +91,17 @@ public class KMSIdentifier {
      *   is persisted in Branch Keys and
      *   MUST strictly equal this value to be considered valid.
      */
-    String kmsKeyArn();
+    String KmsKeyArn();
 
     /**
-     * @param kmsMRKeyArn If an MRK ARN is provided,
+     * @param KmsMRKeyArn If an MRK ARN is provided,
      *   and the persisted Branch Key holds an MRK ARN,
      *   then those two ARNs may differ in region,
      *   although they must be otherwise equal.
      *   If either ARN is not an MRK ARN, then
      *   kmsMRKeyArn behaves exactly as kmsKeyArn.
      */
-    Builder kmsMRKeyArn(String kmsMRKeyArn);
+    Builder KmsMRKeyArn(String KmsMRKeyArn);
 
     /**
      * @return If an MRK ARN is provided,
@@ -111,40 +111,40 @@ public class KMSIdentifier {
      *   If either ARN is not an MRK ARN, then
      *   kmsMRKeyArn behaves exactly as kmsKeyArn.
      */
-    String kmsMRKeyArn();
+    String KmsMRKeyArn();
 
     KMSIdentifier build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String kmsKeyArn;
+    protected String KmsKeyArn;
 
-    protected String kmsMRKeyArn;
+    protected String KmsMRKeyArn;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(KMSIdentifier model) {
-      this.kmsKeyArn = model.kmsKeyArn();
-      this.kmsMRKeyArn = model.kmsMRKeyArn();
+      this.KmsKeyArn = model.KmsKeyArn();
+      this.KmsMRKeyArn = model.KmsMRKeyArn();
     }
 
-    public Builder kmsKeyArn(String kmsKeyArn) {
-      this.kmsKeyArn = kmsKeyArn;
+    public Builder KmsKeyArn(String KmsKeyArn) {
+      this.KmsKeyArn = KmsKeyArn;
       return this;
     }
 
-    public String kmsKeyArn() {
-      return this.kmsKeyArn;
+    public String KmsKeyArn() {
+      return this.KmsKeyArn;
     }
 
-    public Builder kmsMRKeyArn(String kmsMRKeyArn) {
-      this.kmsMRKeyArn = kmsMRKeyArn;
+    public Builder KmsMRKeyArn(String KmsMRKeyArn) {
+      this.KmsMRKeyArn = KmsMRKeyArn;
       return this;
     }
 
-    public String kmsMRKeyArn() {
-      return this.kmsMRKeyArn;
+    public String KmsMRKeyArn() {
+      return this.KmsMRKeyArn;
     }
 
     public KMSIdentifier build() {
@@ -157,7 +157,7 @@ public class KMSIdentifier {
     }
 
     private boolean onlyOneNonNull() {
-      Object[] allValues = { this.kmsKeyArn, this.kmsMRKeyArn };
+      Object[] allValues = { this.KmsKeyArn, this.KmsMRKeyArn };
       boolean haveOneNonNull = false;
       for (Object o : allValues) {
         if (Objects.nonNull(o)) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutatedBranchKeyItem.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutatedBranchKeyItem.java
@@ -10,30 +10,30 @@ public class MutatedBranchKeyItem {
   /**
    * The item type changed. i.e: branch:version:<uuid> or MUTATION_LOCK:<uuid>
    */
-  private final String itemType;
+  private final String ItemType;
 
   /**
    * Brief description of what occurred. i.e: Mutation Applied, New Active Created, Mutation Lock Created, Mutation Lock Removed.
    */
-  private final String description;
+  private final String Description;
 
   protected MutatedBranchKeyItem(BuilderImpl builder) {
-    this.itemType = builder.itemType();
-    this.description = builder.description();
+    this.ItemType = builder.ItemType();
+    this.Description = builder.Description();
   }
 
   /**
    * @return The item type changed. i.e: branch:version:<uuid> or MUTATION_LOCK:<uuid>
    */
-  public String itemType() {
-    return this.itemType;
+  public String ItemType() {
+    return this.ItemType;
   }
 
   /**
    * @return Brief description of what occurred. i.e: Mutation Applied, New Active Created, Mutation Lock Created, Mutation Lock Removed.
    */
-  public String description() {
-    return this.description;
+  public String Description() {
+    return this.Description;
   }
 
   public Builder toBuilder() {
@@ -46,68 +46,68 @@ public class MutatedBranchKeyItem {
 
   public interface Builder {
     /**
-     * @param itemType The item type changed. i.e: branch:version:<uuid> or MUTATION_LOCK:<uuid>
+     * @param ItemType The item type changed. i.e: branch:version:<uuid> or MUTATION_LOCK:<uuid>
      */
-    Builder itemType(String itemType);
+    Builder ItemType(String ItemType);
 
     /**
      * @return The item type changed. i.e: branch:version:<uuid> or MUTATION_LOCK:<uuid>
      */
-    String itemType();
+    String ItemType();
 
     /**
-     * @param description Brief description of what occurred. i.e: Mutation Applied, New Active Created, Mutation Lock Created, Mutation Lock Removed.
+     * @param Description Brief description of what occurred. i.e: Mutation Applied, New Active Created, Mutation Lock Created, Mutation Lock Removed.
      */
-    Builder description(String description);
+    Builder Description(String Description);
 
     /**
      * @return Brief description of what occurred. i.e: Mutation Applied, New Active Created, Mutation Lock Created, Mutation Lock Removed.
      */
-    String description();
+    String Description();
 
     MutatedBranchKeyItem build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String itemType;
+    protected String ItemType;
 
-    protected String description;
+    protected String Description;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(MutatedBranchKeyItem model) {
-      this.itemType = model.itemType();
-      this.description = model.description();
+      this.ItemType = model.ItemType();
+      this.Description = model.Description();
     }
 
-    public Builder itemType(String itemType) {
-      this.itemType = itemType;
+    public Builder ItemType(String ItemType) {
+      this.ItemType = ItemType;
       return this;
     }
 
-    public String itemType() {
-      return this.itemType;
+    public String ItemType() {
+      return this.ItemType;
     }
 
-    public Builder description(String description) {
-      this.description = description;
+    public Builder Description(String Description) {
+      this.Description = Description;
       return this;
     }
 
-    public String description() {
-      return this.description;
+    public String Description() {
+      return this.Description;
     }
 
     public MutatedBranchKeyItem build() {
-      if (Objects.isNull(this.itemType())) {
+      if (Objects.isNull(this.ItemType())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `itemType`"
+          "Missing value for required field `ItemType`"
         );
       }
-      if (Objects.isNull(this.description())) {
+      if (Objects.isNull(this.Description())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `description`"
+          "Missing value for required field `Description`"
         );
       }
       return new MutatedBranchKeyItem(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationFromException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationFromException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while mutating
+ * an item from original to terminal.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationFromException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationFromException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationFromException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationFromException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationFromException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationFromException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationLockInvalidException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationLockInvalidException.java
@@ -6,7 +6,12 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Mutation Lock is failing authentication. Mutation Lock still exists but Mutation cannot proceed. No items were changed. Recommend identifying latest author of Mutation Lock and validating their access.
+ * Mutation Lock disagrees with provided Mutation Token.
+ * Mutation Lock still exists but Mutation cannot proceed.
+ * No items were changed.
+ * Recommend identifying latest author of Mutation Lock
+ * and validating their access;
+ * or checking the integrity of Mutation Token.
  */
 public class MutationLockInvalidException extends RuntimeException {
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationToException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationToException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while mutating
+ * an item from original to terminal.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationToException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationToException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationToException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationToException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationToException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationToException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationVerificationException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationVerificationException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while authenticating
+ * an item already in the terminal state.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationVerificationException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationVerificationException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationVerificationException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationVerificationException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationVerificationException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationVerificationException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/Mutations.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/Mutations.java
@@ -24,18 +24,18 @@ public class Mutations {
    *   A Multi-Region or Single Region AWS KMS Key are permitted,
    *   but not aliases!
    */
-  private final String terminalKmsArn;
+  private final String TerminalKmsArn;
 
   /**
    * ReEncrypt all Items of the Branch Key
    *   to be authorized with this custom encryption context.
    *   An empty Encyrption Context is not allowed.
    */
-  private final Map<String, String> terminalEncryptionContext;
+  private final Map<String, String> TerminalEncryptionContext;
 
   protected Mutations(BuilderImpl builder) {
-    this.terminalKmsArn = builder.terminalKmsArn();
-    this.terminalEncryptionContext = builder.terminalEncryptionContext();
+    this.TerminalKmsArn = builder.TerminalKmsArn();
+    this.TerminalEncryptionContext = builder.TerminalEncryptionContext();
   }
 
   /**
@@ -45,8 +45,8 @@ public class Mutations {
    *   A Multi-Region or Single Region AWS KMS Key are permitted,
    *   but not aliases!
    */
-  public String terminalKmsArn() {
-    return this.terminalKmsArn;
+  public String TerminalKmsArn() {
+    return this.TerminalKmsArn;
   }
 
   /**
@@ -54,8 +54,8 @@ public class Mutations {
    *   to be authorized with this custom encryption context.
    *   An empty Encyrption Context is not allowed.
    */
-  public Map<String, String> terminalEncryptionContext() {
-    return this.terminalEncryptionContext;
+  public Map<String, String> TerminalEncryptionContext() {
+    return this.TerminalEncryptionContext;
   }
 
   public Builder toBuilder() {
@@ -68,13 +68,13 @@ public class Mutations {
 
   public interface Builder {
     /**
-     * @param terminalKmsArn ReEncrypt all Items of the Branch Key
+     * @param TerminalKmsArn ReEncrypt all Items of the Branch Key
      *   to be authorized by this
      *   AWS Key Management Service Key.
      *   A Multi-Region or Single Region AWS KMS Key are permitted,
      *   but not aliases!
      */
-    Builder terminalKmsArn(String terminalKmsArn);
+    Builder TerminalKmsArn(String TerminalKmsArn);
 
     /**
      * @return ReEncrypt all Items of the Branch Key
@@ -83,15 +83,15 @@ public class Mutations {
      *   A Multi-Region or Single Region AWS KMS Key are permitted,
      *   but not aliases!
      */
-    String terminalKmsArn();
+    String TerminalKmsArn();
 
     /**
-     * @param terminalEncryptionContext ReEncrypt all Items of the Branch Key
+     * @param TerminalEncryptionContext ReEncrypt all Items of the Branch Key
      *   to be authorized with this custom encryption context.
      *   An empty Encyrption Context is not allowed.
      */
-    Builder terminalEncryptionContext(
-      Map<String, String> terminalEncryptionContext
+    Builder TerminalEncryptionContext(
+      Map<String, String> TerminalEncryptionContext
     );
 
     /**
@@ -99,42 +99,42 @@ public class Mutations {
      *   to be authorized with this custom encryption context.
      *   An empty Encyrption Context is not allowed.
      */
-    Map<String, String> terminalEncryptionContext();
+    Map<String, String> TerminalEncryptionContext();
 
     Mutations build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String terminalKmsArn;
+    protected String TerminalKmsArn;
 
-    protected Map<String, String> terminalEncryptionContext;
+    protected Map<String, String> TerminalEncryptionContext;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(Mutations model) {
-      this.terminalKmsArn = model.terminalKmsArn();
-      this.terminalEncryptionContext = model.terminalEncryptionContext();
+      this.TerminalKmsArn = model.TerminalKmsArn();
+      this.TerminalEncryptionContext = model.TerminalEncryptionContext();
     }
 
-    public Builder terminalKmsArn(String terminalKmsArn) {
-      this.terminalKmsArn = terminalKmsArn;
+    public Builder TerminalKmsArn(String TerminalKmsArn) {
+      this.TerminalKmsArn = TerminalKmsArn;
       return this;
     }
 
-    public String terminalKmsArn() {
-      return this.terminalKmsArn;
+    public String TerminalKmsArn() {
+      return this.TerminalKmsArn;
     }
 
-    public Builder terminalEncryptionContext(
-      Map<String, String> terminalEncryptionContext
+    public Builder TerminalEncryptionContext(
+      Map<String, String> TerminalEncryptionContext
     ) {
-      this.terminalEncryptionContext = terminalEncryptionContext;
+      this.TerminalEncryptionContext = TerminalEncryptionContext;
       return this;
     }
 
-    public Map<String, String> terminalEncryptionContext() {
-      return this.terminalEncryptionContext;
+    public Map<String, String> TerminalEncryptionContext() {
+      return this.TerminalEncryptionContext;
     }
 
     public Mutations build() {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/UnexpectedStateException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/UnexpectedStateException.java
@@ -6,7 +6,14 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * An Item was encountered that is not in an expected state. Mutation Lock is still present; no items were changed by this request. Recommend audting backing table access; an Item of a Branch Key MUST only be in one of two states during a Mutation; this item is in a third state.
+ * An Item was encountered that is not
+ * in an expected state.
+ * Mutation Lock is still present;
+ * no items were changed by this request.
+ * Recommend audting backing table access;
+ * an Item of a Branch Key MUST be in
+ * either the original or terminal states during a Mutation;
+ * encountered item(s) in other states.
  */
 public class UnexpectedStateException extends RuntimeException {
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/VersionKeyInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/VersionKeyInput.java
@@ -10,45 +10,45 @@ public class VersionKeyInput {
   /**
    * The identifier for the Branch Key to be versioned.
    */
-  private final String branchKeyIdentifier;
+  private final String Identifier;
 
   /**
    * Multi-Region or Single Region AWS KMS Key used to protect the Branch Key, but not aliases!
    */
-  private final KMSIdentifier kmsArn;
+  private final KMSIdentifier KmsArn;
 
   /**
    * This configures which Key Management Operations will be used
    *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
    */
-  private final KeyManagementStrategy strategy;
+  private final KeyManagementStrategy Strategy;
 
   protected VersionKeyInput(BuilderImpl builder) {
-    this.branchKeyIdentifier = builder.branchKeyIdentifier();
-    this.kmsArn = builder.kmsArn();
-    this.strategy = builder.strategy();
+    this.Identifier = builder.Identifier();
+    this.KmsArn = builder.KmsArn();
+    this.Strategy = builder.Strategy();
   }
 
   /**
    * @return The identifier for the Branch Key to be versioned.
    */
-  public String branchKeyIdentifier() {
-    return this.branchKeyIdentifier;
+  public String Identifier() {
+    return this.Identifier;
   }
 
   /**
    * @return Multi-Region or Single Region AWS KMS Key used to protect the Branch Key, but not aliases!
    */
-  public KMSIdentifier kmsArn() {
-    return this.kmsArn;
+  public KMSIdentifier KmsArn() {
+    return this.KmsArn;
   }
 
   /**
    * @return This configures which Key Management Operations will be used
    *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
    */
-  public KeyManagementStrategy strategy() {
-    return this.strategy;
+  public KeyManagementStrategy Strategy() {
+    return this.Strategy;
   }
 
   public Builder toBuilder() {
@@ -61,92 +61,92 @@ public class VersionKeyInput {
 
   public interface Builder {
     /**
-     * @param branchKeyIdentifier The identifier for the Branch Key to be versioned.
+     * @param Identifier The identifier for the Branch Key to be versioned.
      */
-    Builder branchKeyIdentifier(String branchKeyIdentifier);
+    Builder Identifier(String Identifier);
 
     /**
      * @return The identifier for the Branch Key to be versioned.
      */
-    String branchKeyIdentifier();
+    String Identifier();
 
     /**
-     * @param kmsArn Multi-Region or Single Region AWS KMS Key used to protect the Branch Key, but not aliases!
+     * @param KmsArn Multi-Region or Single Region AWS KMS Key used to protect the Branch Key, but not aliases!
      */
-    Builder kmsArn(KMSIdentifier kmsArn);
+    Builder KmsArn(KMSIdentifier KmsArn);
 
     /**
      * @return Multi-Region or Single Region AWS KMS Key used to protect the Branch Key, but not aliases!
      */
-    KMSIdentifier kmsArn();
+    KMSIdentifier KmsArn();
 
     /**
-     * @param strategy This configures which Key Management Operations will be used
+     * @param Strategy This configures which Key Management Operations will be used
      *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
      */
-    Builder strategy(KeyManagementStrategy strategy);
+    Builder Strategy(KeyManagementStrategy Strategy);
 
     /**
      * @return This configures which Key Management Operations will be used
      *    AND the Key Management Clients (and Grant Tokens) used to invoke those Operations.
      */
-    KeyManagementStrategy strategy();
+    KeyManagementStrategy Strategy();
 
     VersionKeyInput build();
   }
 
   static class BuilderImpl implements Builder {
 
-    protected String branchKeyIdentifier;
+    protected String Identifier;
 
-    protected KMSIdentifier kmsArn;
+    protected KMSIdentifier KmsArn;
 
-    protected KeyManagementStrategy strategy;
+    protected KeyManagementStrategy Strategy;
 
     protected BuilderImpl() {}
 
     protected BuilderImpl(VersionKeyInput model) {
-      this.branchKeyIdentifier = model.branchKeyIdentifier();
-      this.kmsArn = model.kmsArn();
-      this.strategy = model.strategy();
+      this.Identifier = model.Identifier();
+      this.KmsArn = model.KmsArn();
+      this.Strategy = model.Strategy();
     }
 
-    public Builder branchKeyIdentifier(String branchKeyIdentifier) {
-      this.branchKeyIdentifier = branchKeyIdentifier;
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
       return this;
     }
 
-    public String branchKeyIdentifier() {
-      return this.branchKeyIdentifier;
+    public String Identifier() {
+      return this.Identifier;
     }
 
-    public Builder kmsArn(KMSIdentifier kmsArn) {
-      this.kmsArn = kmsArn;
+    public Builder KmsArn(KMSIdentifier KmsArn) {
+      this.KmsArn = KmsArn;
       return this;
     }
 
-    public KMSIdentifier kmsArn() {
-      return this.kmsArn;
+    public KMSIdentifier KmsArn() {
+      return this.KmsArn;
     }
 
-    public Builder strategy(KeyManagementStrategy strategy) {
-      this.strategy = strategy;
+    public Builder Strategy(KeyManagementStrategy Strategy) {
+      this.Strategy = Strategy;
       return this;
     }
 
-    public KeyManagementStrategy strategy() {
-      return this.strategy;
+    public KeyManagementStrategy Strategy() {
+      return this.Strategy;
     }
 
     public VersionKeyInput build() {
-      if (Objects.isNull(this.branchKeyIdentifier())) {
+      if (Objects.isNull(this.Identifier())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `branchKeyIdentifier`"
+          "Missing value for required field `Identifier`"
         );
       }
-      if (Objects.isNull(this.kmsArn())) {
+      if (Objects.isNull(this.KmsArn())) {
         throw new IllegalArgumentException(
-          "Missing value for required field `kmsArn`"
+          "Missing value for required field `KmsArn`"
         );
       }
       return new VersionKeyInput(this);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
@@ -111,14 +111,14 @@ public class Fixtures {
       QueryForVersionsInput
         .builder()
         .Identifier(branchKeyId)
-        .pageSize(99)
+        .PageSize(99)
         .build()
     );
     String physicalName = storage
       .GetKeyStorageInfo(GetKeyStorageInfoInput.builder().build())
       .Name();
     versions
-      .items()
+      .Items()
       .forEach(item ->
         deleteKeyStoreDdbItem(
           item.Identifier(),

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
@@ -10,11 +10,16 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class Fixtures {
 
@@ -25,6 +30,17 @@ public class Fixtures {
     "arn:aws:kms:us-west-2:370957321024:key/bc127593-f7da-452c-a1f3-cd34c46f81f8";
   public static final String KEYSTORE_KMS_ARN =
     "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126";
+  public static final String MRK_ARN_EAST =
+    "arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String MRK_ARN_WEST =
+    "arn:aws:kms:us-west-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  // Key MUST NOT exist in ap-south-2
+  public static final String MRK_ARN_AP =
+    "arn:aws:kms:ap-south-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String LIMITED_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-Limited-KMS-us-west-2";
+  public static final String NO_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-No-KMS-us-west-2";
 
   public static final AwsCredentialsProvider defaultCreds =
     DefaultCredentialsProvider.create();
@@ -32,15 +48,23 @@ public class Fixtures {
     .builder()
     .connectionTimeToLive(Duration.ofSeconds(5))
     .build();
-  public static final DynamoDbClient dynamoDbClient = DynamoDbClient
+  public static final DynamoDbClient ddbClientWest2 = DynamoDbClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
     .build();
-  public static final KmsClient kmsClient = KmsClient
+  public static final KmsClient kmsClientWest2 = KmsClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
+    .build();
+  public static final KmsClient kmsClientEast1 = KmsClient
+    .builder()
+    .httpClient(httpClient)
+    .credentialsProvider(defaultCreds)
+    .region(Region.US_EAST_1)
     .build();
 
   public static void deleteKeyStoreDdbItem(
@@ -76,6 +100,45 @@ public class Fixtures {
     dynamoDbClient = AdminProvider.dynamoDB(dynamoDbClient);
     return dynamoDbClient.getItem(builder ->
       builder.tableName(physicalName).key(ddbKey)
+    );
+  }
+
+  public static void cleanUpBranchKeyId(
+    KeyStorageInterface storage,
+    String branchKeyId
+  ) {
+    QueryForVersionsOutput versions = storage.QueryForVersions(
+      QueryForVersionsInput
+        .builder()
+        .Identifier(branchKeyId)
+        .pageSize(99)
+        .build()
+    );
+    String physicalName = storage
+      .GetKeyStorageInfo(GetKeyStorageInfoInput.builder().build())
+      .Name();
+    versions
+      .items()
+      .forEach(item ->
+        deleteKeyStoreDdbItem(
+          item.Identifier(),
+          item.EncryptionContext().get("type"),
+          physicalName,
+          ddbClientWest2
+        )
+      );
+
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "branch:ACTIVE",
+      physicalName,
+      ddbClientWest2
+    );
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "beacon:ACTIVE",
+      physicalName,
+      ddbClientWest2
     );
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
@@ -5,8 +5,6 @@ package software.amazon.cryptography.example.hierarchy;
 import org.testng.annotations.Test;
 import software.amazon.cryptography.example.Fixtures;
 import software.amazon.cryptography.keystore.KeyStorageInterface;
-import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
-import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class ExampleTests {
 
@@ -16,7 +14,8 @@ public class ExampleTests {
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
       Fixtures.KEYSTORE_KMS_ARN,
-      Fixtures.dynamoDbClient
+      null,
+      Fixtures.ddbClientWest2
     );
     branchKeyId =
       MutationExample.End2End(
@@ -24,8 +23,8 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient,
-        Fixtures.kmsClient
+        Fixtures.ddbClientWest2,
+        Fixtures.kmsClientWest2
       );
     branchKeyId =
       VersionKeyExample.VersionKey(
@@ -33,42 +32,13 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient
+        Fixtures.ddbClientWest2
       );
     KeyStorageInterface storage = StorageCheater.create(
-      Fixtures.dynamoDbClient,
+      Fixtures.ddbClientWest2,
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME
     );
-    QueryForVersionsOutput versions = storage.QueryForVersions(
-      QueryForVersionsInput
-        .builder()
-        .Identifier(branchKeyId)
-        .pageSize(10)
-        .build()
-    );
-    versions
-      .items()
-      .forEach(item ->
-        Fixtures.deleteKeyStoreDdbItem(
-          item.Identifier(),
-          item.Type().HierarchicalSymmetricVersion().Version(),
-          Fixtures.TEST_KEYSTORE_NAME,
-          Fixtures.dynamoDbClient
-        )
-      );
-
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "branch:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "beacon:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -79,24 +79,24 @@ public class MutationKmsAccessInFlightTest {
 
     Mutations mutations = Mutations
       .builder()
-      .terminalEncryptionContext(terminalEC)
-      .terminalKmsArn(MRK_ARN_WEST)
+      .TerminalEncryptionContext(terminalEC)
+      .TerminalKmsArn(MRK_ARN_WEST)
       .build();
 
     InitializeMutationInput initInput = InitializeMutationInput
       .builder()
-      .mutations(mutations)
-      .branchKeyIdentifier(branchKeyId)
-      .strategy(strategyWest2)
+      .Mutations(mutations)
+      .Identifier(branchKeyId)
+      .Strategy(strategyWest2)
       .build();
 
     InitializeMutationOutput initOutput = admin.InitializeMutation(initInput);
-    MutationToken token = initOutput.mutationToken();
+    MutationToken token = initOutput.MutationToken();
     System.out.println(
       "InitLogs: " +
       branchKeyId +
       " items: \n" +
-      AdminProvider.mutatedItemsToString(initOutput.mutatedBranchKeyItems())
+      AdminProvider.mutatedItemsToString(initOutput.MutatedBranchKeyItems())
     );
     boolean done = false;
     List<KmsException> kmsExceptions = new ArrayList<>();
@@ -110,24 +110,24 @@ public class MutationKmsAccessInFlightTest {
         if (limitLoop == 0) done = true;
         ApplyMutationInput applyInput = ApplyMutationInput
           .builder()
-          .mutationToken(token)
-          .pageSize(1)
-          .strategy(strategyDenyMrk)
+          .MutationToken(token)
+          .PageSize(1)
+          .Strategy(strategyDenyMrk)
           .build();
         ApplyMutationOutput applyOutput = admin.ApplyMutation(applyInput);
-        ApplyMutationResult result = applyOutput.result();
+        ApplyMutationResult result = applyOutput.MutationResult();
         System.out.println(
           "ApplyLogs: " +
           branchKeyId +
           " items: \n" +
           AdminProvider.mutatedItemsToString(
-            applyOutput.mutatedBranchKeyItems()
+            applyOutput.MutatedBranchKeyItems()
           )
         );
 
-        if (result.continueMutation() != null) token =
-          result.continueMutation();
-        if (result.completeMutation() != null) done = true;
+        if (result.ContinueMutation() != null) token =
+          result.ContinueMutation();
+        if (result.CompleteMutation() != null) done = true;
       } catch (KmsException accessDenied) {
         boolean isFrom = accessDenied.getMessage().contains("ReEncryptFrom");
         isFromThrown = isFromThrown || isFrom;
@@ -146,11 +146,11 @@ public class MutationKmsAccessInFlightTest {
           QueryForVersionsInput
             .builder()
             .Identifier(branchKeyId)
-            .pageSize(1)
+            .PageSize(1)
             .build()
         );
         versions
-          .items()
+          .Items()
           .forEach(item -> {
             String typStr = item.EncryptionContext().get("type");
             Fixtures.deleteKeyStoreDdbItem(

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -1,0 +1,160 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.cryptography.example.CredentialUtils;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
+import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationResult;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.KeyManagementStrategy;
+import software.amazon.cryptography.keystoreadmin.model.MutationToken;
+import software.amazon.cryptography.keystoreadmin.model.Mutations;
+import software.amazon.cryptography.example.Fixtures;
+
+import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;
+import static software.amazon.cryptography.example.Fixtures.POSTAL_HORN_KEY_ARN;
+
+public class MutationKmsAccessInFlightTest {
+  static final String testPrefix = "mutation-kms-access-in-flight-test-";
+  @Test
+  public void test() {
+    KeyStorageInterface storage = StorageCheater.create(
+      Fixtures.ddbClientWest2,
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME
+    );
+    final String branchKeyId = testPrefix + java.util.UUID.randomUUID().toString();
+    CreateKeyExample.CreateKey(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      POSTAL_HORN_KEY_ARN,
+      branchKeyId,
+      Fixtures.ddbClientWest2
+    );
+    KeyManagementStrategy strategyWest2 = AdminProvider.strategy(Fixtures.kmsClientWest2);
+    KmsClient denyMrk = KmsClient.builder()
+        .credentialsProvider(
+          CredentialUtils.credsForRole(
+            Fixtures.LIMITED_KMS_ACCESS_IAM_ROLE,
+            "java-mpl-examples",
+            Region.US_WEST_2,
+            Fixtures.httpClient,
+            Fixtures.defaultCreds))
+      .region(Region.US_WEST_2)
+      .httpClient(Fixtures.httpClient)
+      .build();
+
+    KeyManagementStrategy strategyDenyMrk = AdminProvider.strategy(denyMrk);
+    KeyStoreAdmin admin = AdminProvider.admin(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      Fixtures.ddbClientWest2
+    );
+
+    System.out.println("BranchKey ID to mutate: " + branchKeyId);
+    HashMap<String, String> terminalEC = new HashMap<>();
+    terminalEC.put("Robbie", "is a dog.");
+
+    Mutations mutations = Mutations
+      .builder()
+      .terminalEncryptionContext(terminalEC)
+      .terminalKmsArn(MRK_ARN_WEST)
+      .build();
+
+    InitializeMutationInput initInput = InitializeMutationInput
+      .builder()
+      .mutations(mutations)
+      .branchKeyIdentifier(branchKeyId)
+      .strategy(strategyWest2)
+      .build();
+
+    InitializeMutationOutput initOutput = admin.InitializeMutation(initInput);
+    MutationToken token = initOutput.mutationToken();
+    System.out.println(
+      "InitLogs: " +
+      branchKeyId +
+      " items: \n" +
+      AdminProvider.mutatedItemsToString(initOutput.mutatedBranchKeyItems())
+    );
+    boolean done = false;
+    List<KmsException> kmsExceptions = new ArrayList<>();
+    boolean isFromThrown = false;
+    boolean isToThrown = false;
+    int limitLoop = 5;
+
+    while (!done) {
+      try {
+        limitLoop--;
+        if (limitLoop == 0) done = true;
+        ApplyMutationInput applyInput = ApplyMutationInput
+          .builder()
+          .mutationToken(token)
+          .pageSize(1)
+          .strategy(strategyDenyMrk)
+          .build();
+        ApplyMutationOutput applyOutput = admin.ApplyMutation(applyInput);
+        ApplyMutationResult result = applyOutput.result();
+        System.out.println(
+          "ApplyLogs: " +
+          branchKeyId +
+          " items: \n" +
+          AdminProvider.mutatedItemsToString(applyOutput.mutatedBranchKeyItems())
+        );
+
+        if (result.continueMutation() != null) token = result.continueMutation();
+        if (result.completeMutation() != null) done = true;
+
+      } catch (KmsException accessDenied) {
+        boolean isFrom = accessDenied.getMessage().contains("ReEncryptFrom");
+        isFromThrown = isFromThrown || isFrom;
+        boolean isTo = accessDenied.getMessage().contains("ReEncryptTo");
+        isToThrown = isToThrown || isTo;
+        Assert.assertTrue((isTo || isFrom),
+          "KMS Exception does not meet expectations. testId: " + branchKeyId + ". KMS Exception: " + accessDenied);
+        kmsExceptions.add(accessDenied);
+        // An exception was thrown, let's delete the item
+        QueryForVersionsOutput versions = storage.QueryForVersions(
+          QueryForVersionsInput
+            .builder()
+            .Identifier(branchKeyId)
+            .pageSize(1)
+            .build()
+        );
+        versions
+          .items()
+          .forEach(item ->
+            Fixtures.deleteKeyStoreDdbItem(
+              item.Identifier(),
+              item.EncryptionContext().get("type"),
+              Fixtures.TEST_KEYSTORE_NAME,
+              Fixtures.ddbClientWest2
+            )
+          );
+      }
+    }
+
+    // Clean Up
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
+    Assert.assertTrue((kmsExceptions.size() == 2),
+      "More KMS Exceptions thrown than expected. kmsExceptions: " + kmsExceptions);
+    Assert.assertTrue(isFromThrown, "Apply never verified the new decrypt.");
+    Assert.assertTrue(isToThrown, "Apply never mutated the old decrypt.");
+  }
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -151,14 +151,21 @@ public class MutationKmsAccessInFlightTest {
         );
         versions
           .items()
-          .forEach(item ->
+          .forEach(item -> {
+            String typStr = item.EncryptionContext().get("type");
             Fixtures.deleteKeyStoreDdbItem(
               item.Identifier(),
-              item.EncryptionContext().get("type"),
+              typStr,
               Fixtures.TEST_KEYSTORE_NAME,
               Fixtures.ddbClientWest2
-            )
-          );
+            );
+            System.out.println(
+              "\nItem: " +
+              typStr +
+              " \tKMS Exception: " +
+              accessDenied.getMessage()
+            );
+          });
       }
     }
 

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/AlreadyExistsConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/AlreadyExistsConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class AlreadyExistsConditionFailed : Exception
+  {
+    public AlreadyExistsConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockInput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class ClobberMutationLockInput
+  {
+    private AWS.Cryptography.KeyStore.MutationLock _mutationLock;
+    public AWS.Cryptography.KeyStore.MutationLock MutationLock
+    {
+      get { return this._mutationLock; }
+      set { this._mutationLock = value; }
+    }
+    public bool IsSetMutationLock()
+    {
+      return this._mutationLock != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetMutationLock()) throw new System.ArgumentException("Missing value for required property 'MutationLock'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockOutput.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class ClobberMutationLockOutput
+  {
+
+
+    public void Validate()
+    {
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockInput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetMutationLockInput
+  {
+    private string _identifier;
+    public string Identifier
+    {
+      get { return this._identifier; }
+      set { this._identifier = value; }
+    }
+    public bool IsSetIdentifier()
+    {
+      return this._identifier != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockOutput.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetMutationLockOutput
+  {
+    private AWS.Cryptography.KeyStore.MutationLock _mutationLock;
+    public AWS.Cryptography.KeyStore.MutationLock MutationLock
+    {
+      get { return this._mutationLock; }
+      set { this._mutationLock = value; }
+    }
+    public bool IsSetMutationLock()
+    {
+      return this._mutationLock != null;
+    }
+    public void Validate()
+    {
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/IKeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/IKeyStorageInterface.cs
@@ -17,5 +17,7 @@ namespace AWS.Cryptography.KeyStore
     AWS.Cryptography.KeyStore.WriteInitializeMutationOutput WriteInitializeMutation(AWS.Cryptography.KeyStore.WriteInitializeMutationInput input);
     AWS.Cryptography.KeyStore.QueryForVersionsOutput QueryForVersions(AWS.Cryptography.KeyStore.QueryForVersionsInput input);
     AWS.Cryptography.KeyStore.WriteMutatedVersionsOutput WriteMutatedVersions(AWS.Cryptography.KeyStore.WriteMutatedVersionsInput input);
+    AWS.Cryptography.KeyStore.GetMutationLockOutput GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input);
+    AWS.Cryptography.KeyStore.ClobberMutationLockOutput ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterface.cs
@@ -47,6 +47,13 @@ namespace AWS.Cryptography.KeyStore
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
       return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput(result.dtor_value);
     }
+    protected override AWS.Cryptography.KeyStore.GetMutationLockOutput _GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.GetMutationLock(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(result.dtor_value);
+    }
     protected override AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionOutput _WriteNewEncryptedBranchKeyVersion(AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionInput input)
     {
       software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput(input);
@@ -60,6 +67,13 @@ namespace AWS.Cryptography.KeyStore
       Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.QueryForVersions(internalInput);
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
       return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput(result.dtor_value);
+    }
+    protected override AWS.Cryptography.KeyStore.ClobberMutationLockOutput _ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.ClobberMutationLock(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(result.dtor_value);
     }
     protected override AWS.Cryptography.KeyStore.GetKeyStorageInfoOutput _GetKeyStorageInfo(AWS.Cryptography.KeyStore.GetKeyStorageInfoInput input)
     {

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterfaceBase.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterfaceBase.cs
@@ -57,5 +57,15 @@ namespace AWS.Cryptography.KeyStore
       input.Validate(); return _WriteMutatedVersions(input);
     }
     protected abstract AWS.Cryptography.KeyStore.WriteMutatedVersionsOutput _WriteMutatedVersions(AWS.Cryptography.KeyStore.WriteMutatedVersionsInput input);
+    public AWS.Cryptography.KeyStore.GetMutationLockOutput GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input)
+    {
+      input.Validate(); return _GetMutationLock(input);
+    }
+    protected abstract AWS.Cryptography.KeyStore.GetMutationLockOutput _GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input);
+    public AWS.Cryptography.KeyStore.ClobberMutationLockOutput ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input)
+    {
+      input.Validate(); return _ClobberMutationLock(input);
+    }
+    protected abstract AWS.Cryptography.KeyStore.ClobberMutationLockOutput _ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/MutationLockConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/MutationLockConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class MutationLockConditionFailed : Exception
+  {
+    public MutationLockConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NativeWrapper_KeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NativeWrapper_KeyStorageInterface.cs
@@ -157,6 +157,34 @@ namespace AWS.Cryptography.KeyStore
     {
       throw new KeyStoreException("Not supported at this time.");
     }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> GetMutationLock(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput input)
+    {
+      void validateOutput(AWS.Cryptography.KeyStore.GetMutationLockOutput nativeOutput)
+      {
+        try { nativeOutput.Validate(); }
+        catch (ArgumentException e)
+        {
+          var message = $"Output of {_impl}._GetMutationLock is invalid. {e.Message}";
+          throw new KeyStoreException(message);
+        }
+      }
+      AWS.Cryptography.KeyStore.GetMutationLockInput nativeInput = TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(input);
+      try
+      {
+        AWS.Cryptography.KeyStore.GetMutationLockOutput nativeOutput = _impl.GetMutationLock(nativeInput);
+        _ = nativeOutput ?? throw new KeyStoreException($"{_impl}._GetMutationLock returned null, should be {typeof(AWS.Cryptography.KeyStore.GetMutationLockOutput)}");
+        validateOutput(nativeOutput);
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Success(TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(nativeOutput));
+      }
+      catch (Exception e)
+      {
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Failure(TypeConversion.ToDafny_CommonError(e));
+      }
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> GetMutationLock_k(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput input)
+    {
+      throw new KeyStoreException("Not supported at this time.");
+    }
     public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> WriteNewEncryptedBranchKeyVersion(software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionInput input)
     {
       void validateOutput(AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionOutput nativeOutput)
@@ -210,6 +238,34 @@ namespace AWS.Cryptography.KeyStore
       }
     }
     public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> QueryForVersions_k(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput input)
+    {
+      throw new KeyStoreException("Not supported at this time.");
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> ClobberMutationLock(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput input)
+    {
+      void validateOutput(AWS.Cryptography.KeyStore.ClobberMutationLockOutput nativeOutput)
+      {
+        try { nativeOutput.Validate(); }
+        catch (ArgumentException e)
+        {
+          var message = $"Output of {_impl}._ClobberMutationLock is invalid. {e.Message}";
+          throw new KeyStoreException(message);
+        }
+      }
+      AWS.Cryptography.KeyStore.ClobberMutationLockInput nativeInput = TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(input);
+      try
+      {
+        AWS.Cryptography.KeyStore.ClobberMutationLockOutput nativeOutput = _impl.ClobberMutationLock(nativeInput);
+        _ = nativeOutput ?? throw new KeyStoreException($"{_impl}._ClobberMutationLock returned null, should be {typeof(AWS.Cryptography.KeyStore.ClobberMutationLockOutput)}");
+        validateOutput(nativeOutput);
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Success(TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(nativeOutput));
+      }
+      catch (Exception e)
+      {
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Failure(TypeConversion.ToDafny_CommonError(e));
+      }
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> ClobberMutationLock_k(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput input)
     {
       throw new KeyStoreException("Not supported at this time.");
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NoLongerExistsConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NoLongerExistsConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class NoLongerExistsConditionFailed : Exception
+  {
+    public NoLongerExistsConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/OldEncConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/OldEncConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class OldEncConditionFailed : Exception
+  {
+    public OldEncConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -11,6 +11,39 @@ namespace AWS.Cryptography.KeyStore
 
     private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
 
+    public static AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.ClobberMutationLockInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput)value; AWS.Cryptography.KeyStore.ClobberMutationLockInput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockInput(); converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(concrete._mutationLock); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(AWS.Cryptography.KeyStore.ClobberMutationLockInput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(value.MutationLock));
+    }
+    public static AWS.Cryptography.KeyStore.ClobberMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput)value; AWS.Cryptography.KeyStore.ClobberMutationLockOutput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockOutput(); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(AWS.Cryptography.KeyStore.ClobberMutationLockOutput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput();
+    }
     public static AWS.Cryptography.KeyStore.CreateKeyInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput(software.amazon.cryptography.keystore.internaldafny.types._ICreateKeyInput value)
     {
       software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput)value; AWS.Cryptography.KeyStore.CreateKeyInput converted = new AWS.Cryptography.KeyStore.CreateKeyInput(); if (concrete._branchKeyIdentifier.is_Some) converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
@@ -232,6 +265,26 @@ namespace AWS.Cryptography.KeyStore
 
       return new software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M10_keyStoreId(value.KeyStoreId), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M12_keyStoreName(value.KeyStoreName), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M19_logicalKeyStoreName(value.LogicalKeyStoreName), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M11_grantTokens(value.GrantTokens), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M16_kmsConfiguration(value.KmsConfiguration));
     }
+    public static AWS.Cryptography.KeyStore.GetMutationLockInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput)value; AWS.Cryptography.KeyStore.GetMutationLockInput converted = new AWS.Cryptography.KeyStore.GetMutationLockInput(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(concrete._Identifier); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(AWS.Cryptography.KeyStore.GetMutationLockInput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(value.Identifier));
+    }
+    public static AWS.Cryptography.KeyStore.GetMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput)value; AWS.Cryptography.KeyStore.GetMutationLockOutput converted = new AWS.Cryptography.KeyStore.GetMutationLockOutput(); if (concrete._mutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(concrete._mutationLock); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(AWS.Cryptography.KeyStore.GetMutationLockOutput value)
+    {
+      value.Validate();
+      AWS.Cryptography.KeyStore.MutationLock var_mutationLock = value.IsSetMutationLock() ? value.MutationLock : (AWS.Cryptography.KeyStore.MutationLock)null;
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(var_mutationLock));
+    }
     public static AWS.Cryptography.KeyStore.HierarchicalKeyType FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_HierarchicalKeyType(software.amazon.cryptography.keystore.internaldafny.types._IHierarchicalKeyType value)
     {
       software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType concrete = (software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType)value;
@@ -380,6 +433,45 @@ namespace AWS.Cryptography.KeyStore
         return software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration.create_mrDiscovery(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_mrDiscovery(value.MrDiscovery));
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStore.KMSConfiguration state");
+    }
+    public static AWS.Cryptography.KeyStore.MutationLockConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.MutationLockConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(AWS.Cryptography.KeyStore.MutationLockConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.OldEncConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.OldEncConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(AWS.Cryptography.KeyStore.OldEncConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(value.Message)
+      );
     }
     public static AWS.Cryptography.KeyStore.QueryForVersionsInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput value)
     {
@@ -555,6 +647,22 @@ namespace AWS.Cryptography.KeyStore
       value.Validate();
 
       return new software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionOutput();
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput__M19_branchKeyIdentifier(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
     {
@@ -788,6 +896,22 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration(value);
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
+    {
+      return value.is_None ? (AWS.Cryptography.KeyStore.MutationLock)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value.Extract());
+    }
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock((AWS.Cryptography.KeyStore.MutationLock)value));
+    }
     public static AWS.Cryptography.KeyStore.ActiveHierarchicalSymmetric FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_HierarchicalKeyType__M34_ActiveHierarchicalSymmetricVersion(software.amazon.cryptography.keystore.internaldafny.types._IActiveHierarchicalSymmetric value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_ActiveHierarchicalSymmetric(value);
@@ -939,6 +1063,30 @@ namespace AWS.Cryptography.KeyStore
     public static software.amazon.cryptography.keystore.internaldafny.types._IMRDiscovery ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_mrDiscovery(AWS.Cryptography.KeyStore.MRDiscovery value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S11_MRDiscovery(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(Wrappers_Compile._IOption<Dafny.ISequence<byte>> value)
     {
@@ -1148,6 +1296,20 @@ namespace AWS.Cryptography.KeyStore
     {
       return Dafny.Sequence<char>.FromString(value);
     }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.MutationLock concrete = (software.amazon.cryptography.keystore.internaldafny.types.MutationLock)value; AWS.Cryptography.KeyStore.MutationLock converted = new AWS.Cryptography.KeyStore.MutationLock(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(concrete._Identifier);
+      converted.CreateTime = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(concrete._CreateTime);
+      converted.UUID = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(concrete._UUID);
+      converted.Original = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(concrete._Original);
+      converted.Terminal = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(concrete._Terminal); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.MutationLock(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(value.UUID), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(value.Terminal));
+    }
     public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext(Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>> value)
     {
       return value.ItemEnumerable.ToDictionary(pair => FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M3_key(pair.Car), pair => FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M5_value(pair.Cdr));
@@ -1207,20 +1369,6 @@ namespace AWS.Cryptography.KeyStore
       value.Validate();
 
       return new software.amazon.cryptography.keystore.internaldafny.types.EncryptedHierarchicalKey(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M4_Type(value.Type), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M6_KmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M17_EncryptionContext(value.EncryptionContext), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M14_CiphertextBlob(value.CiphertextBlob));
-    }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
-    {
-      software.amazon.cryptography.keystore.internaldafny.types.MutationLock concrete = (software.amazon.cryptography.keystore.internaldafny.types.MutationLock)value; AWS.Cryptography.KeyStore.MutationLock converted = new AWS.Cryptography.KeyStore.MutationLock(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(concrete._Identifier);
-      converted.CreateTime = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(concrete._CreateTime);
-      converted.UUID = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(concrete._UUID);
-      converted.Original = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(concrete._Original);
-      converted.Terminal = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(concrete._Terminal); return converted;
-    }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
-    {
-      value.Validate();
-
-      return new software.amazon.cryptography.keystore.internaldafny.types.MutationLock(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(value.UUID), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(value.Terminal));
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(Dafny.ISequence<byte> value)
     {
@@ -1405,6 +1553,46 @@ namespace AWS.Cryptography.KeyStore
     {
       return value;
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M3_key(Dafny.ISequence<byte> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(value);
@@ -1530,46 +1718,6 @@ namespace AWS.Cryptography.KeyStore
       return FromDafny_N6_smithy__N3_api__S4_Blob(value);
     }
     public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M14_CiphertextBlob(System.IO.MemoryStream value)
-    {
-      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(Dafny.ISequence<byte> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(System.IO.MemoryStream value)
-    {
-      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(Dafny.ISequence<byte> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(System.IO.MemoryStream value)
     {
       return ToDafny_N6_smithy__N3_api__S4_Blob(value);
     }
@@ -1730,10 +1878,18 @@ namespace AWS.Cryptography.KeyStore
           return Com.Amazonaws.Kms.TypeConversion.FromDafny_CommonError( // Manual edit KMS. -> Kms.
             dafnyVal._ComAmazonawsKms
           );
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_KeyStoreException(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_VersionRaceException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_CollectionOfErrors dafnyVal:
@@ -1763,10 +1919,18 @@ namespace AWS.Cryptography.KeyStore
       }
       switch (value)
       {
+        case AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(exception);
         case AWS.Cryptography.KeyStore.KeyStorageException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(exception);
         case AWS.Cryptography.KeyStore.KeyStoreException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S17_KeyStoreException(exception);
+        case AWS.Cryptography.KeyStore.MutationLockConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(exception);
+        case AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(exception);
+        case AWS.Cryptography.KeyStore.OldEncConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(exception);
         case AWS.Cryptography.KeyStore.VersionRaceException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_VersionRaceException(exception);
         case CollectionOfErrors collectionOfErrors:

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -26,13 +26,13 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.ClobberMutationLockInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput)value; AWS.Cryptography.KeyStore.ClobberMutationLockInput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockInput(); converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(concrete._mutationLock); return converted;
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput)value; AWS.Cryptography.KeyStore.ClobberMutationLockInput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockInput(); converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_MutationLock(concrete._MutationLock); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(AWS.Cryptography.KeyStore.ClobberMutationLockInput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(value.MutationLock));
+      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_MutationLock(value.MutationLock));
     }
     public static AWS.Cryptography.KeyStore.ClobberMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput value)
     {
@@ -220,15 +220,15 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetItemsForInitializeMutationOutput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput)value; AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput converted = new AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput(); converted.ActiveItem = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_activeItem(concrete._activeItem);
-      converted.BeaconItem = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_beaconItem(concrete._beaconItem);
-      if (concrete._mutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_mutationLock(concrete._mutationLock); return converted;
+      software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput)value; AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput converted = new AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput(); converted.ActiveItem = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_ActiveItem(concrete._ActiveItem);
+      converted.BeaconItem = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_BeaconItem(concrete._BeaconItem);
+      if (concrete._MutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_MutationLock(concrete._MutationLock); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IGetItemsForInitializeMutationOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput(AWS.Cryptography.KeyStore.GetItemsForInitializeMutationOutput value)
     {
       value.Validate();
       AWS.Cryptography.KeyStore.MutationLock var_mutationLock = value.IsSetMutationLock() ? value.MutationLock : (AWS.Cryptography.KeyStore.MutationLock)null;
-      return new software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_activeItem(value.ActiveItem), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_beaconItem(value.BeaconItem), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_mutationLock(var_mutationLock));
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInitializeMutationOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_ActiveItem(value.ActiveItem), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_BeaconItem(value.BeaconItem), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_MutationLock(var_mutationLock));
     }
     public static AWS.Cryptography.KeyStore.GetKeyStorageInfoInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_GetKeyStorageInfoInput(software.amazon.cryptography.keystore.internaldafny.types._IGetKeyStorageInfoInput value)
     {
@@ -277,13 +277,13 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.GetMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput)value; AWS.Cryptography.KeyStore.GetMutationLockOutput converted = new AWS.Cryptography.KeyStore.GetMutationLockOutput(); if (concrete._mutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(concrete._mutationLock); return converted;
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput)value; AWS.Cryptography.KeyStore.GetMutationLockOutput converted = new AWS.Cryptography.KeyStore.GetMutationLockOutput(); if (concrete._MutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_MutationLock(concrete._MutationLock); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(AWS.Cryptography.KeyStore.GetMutationLockOutput value)
     {
       value.Validate();
       AWS.Cryptography.KeyStore.MutationLock var_mutationLock = value.IsSetMutationLock() ? value.MutationLock : (AWS.Cryptography.KeyStore.MutationLock)null;
-      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(var_mutationLock));
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_MutationLock(var_mutationLock));
     }
     public static AWS.Cryptography.KeyStore.HierarchicalKeyType FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_HierarchicalKeyType(software.amazon.cryptography.keystore.internaldafny.types._IHierarchicalKeyType value)
     {
@@ -475,26 +475,26 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.QueryForVersionsInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput)value; AWS.Cryptography.KeyStore.QueryForVersionsInput converted = new AWS.Cryptography.KeyStore.QueryForVersionsInput(); if (concrete._exclusiveStartKey.is_Some) converted.ExclusiveStartKey = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(concrete._exclusiveStartKey);
+      software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput)value; AWS.Cryptography.KeyStore.QueryForVersionsInput converted = new AWS.Cryptography.KeyStore.QueryForVersionsInput(); if (concrete._ExclusiveStartKey.is_Some) converted.ExclusiveStartKey = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_ExclusiveStartKey(concrete._ExclusiveStartKey);
       converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M10_Identifier(concrete._Identifier);
-      converted.PageSize = (int)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_pageSize(concrete._pageSize); return converted;
+      converted.PageSize = (int)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_PageSize(concrete._PageSize); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput(AWS.Cryptography.KeyStore.QueryForVersionsInput value)
     {
       value.Validate();
       System.IO.MemoryStream var_exclusiveStartKey = value.IsSetExclusiveStartKey() ? value.ExclusiveStartKey : (System.IO.MemoryStream)null;
-      return new software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(var_exclusiveStartKey), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_pageSize(value.PageSize));
+      return new software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_ExclusiveStartKey(var_exclusiveStartKey), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_PageSize(value.PageSize));
     }
     public static AWS.Cryptography.KeyStore.QueryForVersionsOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput)value; AWS.Cryptography.KeyStore.QueryForVersionsOutput converted = new AWS.Cryptography.KeyStore.QueryForVersionsOutput(); converted.ExclusiveStartKey = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_exclusiveStartKey(concrete._exclusiveStartKey);
-      converted.Items = (System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey>)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_items(concrete._items); return converted;
+      software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput)value; AWS.Cryptography.KeyStore.QueryForVersionsOutput converted = new AWS.Cryptography.KeyStore.QueryForVersionsOutput(); converted.ExclusiveStartKey = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_ExclusiveStartKey(concrete._ExclusiveStartKey);
+      converted.Items = (System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey>)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_Items(concrete._Items); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput(AWS.Cryptography.KeyStore.QueryForVersionsOutput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_exclusiveStartKey(value.ExclusiveStartKey), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_items(value.Items));
+      return new software.amazon.cryptography.keystore.internaldafny.types.QueryForVersionsOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_ExclusiveStartKey(value.ExclusiveStartKey), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_Items(value.Items));
     }
     public static AWS.Cryptography.KeyStore.Storage FromDafny_N3_aws__N12_cryptography__N8_keyStore__S7_Storage(software.amazon.cryptography.keystore.internaldafny.types._IStorage value)
     {
@@ -558,17 +558,17 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.WriteInitializeMutationInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput(software.amazon.cryptography.keystore.internaldafny.types._IWriteInitializeMutationInput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput)value; AWS.Cryptography.KeyStore.WriteInitializeMutationInput converted = new AWS.Cryptography.KeyStore.WriteInitializeMutationInput(); converted.Active = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_active(concrete._active);
-      converted.OldActive = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_oldActive(concrete._oldActive);
-      converted.Version = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_version(concrete._version);
-      converted.Beacon = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_beacon(concrete._beacon);
-      converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_mutationLock(concrete._mutationLock); return converted;
+      software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput)value; AWS.Cryptography.KeyStore.WriteInitializeMutationInput converted = new AWS.Cryptography.KeyStore.WriteInitializeMutationInput(); converted.Active = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Active(concrete._Active);
+      converted.OldActive = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_OldActive(concrete._OldActive);
+      converted.Version = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_Version(concrete._Version);
+      converted.Beacon = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Beacon(concrete._Beacon);
+      converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_MutationLock(concrete._MutationLock); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IWriteInitializeMutationInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput(AWS.Cryptography.KeyStore.WriteInitializeMutationInput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_active(value.Active), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_oldActive(value.OldActive), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_version(value.Version), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_beacon(value.Beacon), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_mutationLock(value.MutationLock));
+      return new software.amazon.cryptography.keystore.internaldafny.types.WriteInitializeMutationInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Active(value.Active), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_OldActive(value.OldActive), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_Version(value.Version), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Beacon(value.Beacon), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_MutationLock(value.MutationLock));
     }
     public static AWS.Cryptography.KeyStore.WriteInitializeMutationOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_WriteInitializeMutationOutput(software.amazon.cryptography.keystore.internaldafny.types._IWriteInitializeMutationOutput value)
     {
@@ -582,7 +582,7 @@ namespace AWS.Cryptography.KeyStore
     }
     public static AWS.Cryptography.KeyStore.WriteMutatedVersionsInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput(software.amazon.cryptography.keystore.internaldafny.types._IWriteMutatedVersionsInput value)
     {
-      software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput)value; AWS.Cryptography.KeyStore.WriteMutatedVersionsInput converted = new AWS.Cryptography.KeyStore.WriteMutatedVersionsInput(); converted.Items = (System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey>)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_items(concrete._items);
+      software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput)value; AWS.Cryptography.KeyStore.WriteMutatedVersionsInput converted = new AWS.Cryptography.KeyStore.WriteMutatedVersionsInput(); converted.Items = (System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey>)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_Items(concrete._Items);
       converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M10_Identifier(concrete._Identifier);
       converted.Original = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Original(concrete._Original);
       converted.Terminal = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Terminal(concrete._Terminal);
@@ -592,7 +592,7 @@ namespace AWS.Cryptography.KeyStore
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_items(value.Items), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Terminal(value.Terminal), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M16_CompleteMutation(value.CompleteMutation));
+      return new software.amazon.cryptography.keystore.internaldafny.types.WriteMutatedVersionsInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_Items(value.Items), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M8_Terminal(value.Terminal), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M16_CompleteMutation(value.CompleteMutation));
     }
     public static AWS.Cryptography.KeyStore.WriteMutatedVersionsOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S26_WriteMutatedVersionsOutput(software.amazon.cryptography.keystore.internaldafny.types._IWriteMutatedVersionsOutput value)
     {
@@ -630,13 +630,13 @@ namespace AWS.Cryptography.KeyStore
     {
       software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput)value; AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionInput converted = new AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionInput(); converted.Active = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M6_Active(concrete._Active);
       converted.Version = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M7_Version(concrete._Version);
-      converted.OldActive = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_oldActive(concrete._oldActive); return converted;
+      converted.OldActive = (AWS.Cryptography.KeyStore.EncryptedHierarchicalKey)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_OldActive(concrete._OldActive); return converted;
     }
     public static software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput(AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionInput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M6_Active(value.Active), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M7_Version(value.Version), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_oldActive(value.OldActive));
+      return new software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M6_Active(value.Active), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M7_Version(value.Version), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_OldActive(value.OldActive));
     }
     public static AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S39_WriteNewEncryptedBranchKeyVersionOutput(software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionOutput value)
     {
@@ -656,11 +656,11 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
@@ -816,27 +816,27 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_activeItem(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_ActiveItem(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_activeItem(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_ActiveItem(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_beaconItem(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_BeaconItem(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_beaconItem(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M10_BeaconItem(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_mutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_MutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStore.MutationLock)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput__M12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock((AWS.Cryptography.KeyStore.MutationLock)value));
     }
@@ -904,11 +904,11 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_MutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStore.MutationLock)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock((AWS.Cryptography.KeyStore.MutationLock)value));
     }
@@ -1088,11 +1088,11 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(Wrappers_Compile._IOption<Dafny.ISequence<byte>> value)
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_ExclusiveStartKey(Wrappers_Compile._IOption<Dafny.ISequence<byte>> value)
     {
       return value.is_None ? (System.IO.MemoryStream)null : FromDafny_N6_smithy__N3_api__S4_Blob(value.Extract());
     }
-    public static Wrappers_Compile._IOption<Dafny.ISequence<byte>> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(System.IO.MemoryStream value)
+    public static Wrappers_Compile._IOption<Dafny.ISequence<byte>> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_ExclusiveStartKey(System.IO.MemoryStream value)
     {
       return value == null ? Wrappers_Compile.Option<Dafny.ISequence<byte>>.create_None() : Wrappers_Compile.Option<Dafny.ISequence<byte>>.create_Some(ToDafny_N6_smithy__N3_api__S4_Blob((System.IO.MemoryStream)value));
     }
@@ -1104,27 +1104,27 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static int FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_pageSize(int value)
+    public static int FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_PageSize(int value)
     {
       return FromDafny_N6_smithy__N3_api__S7_Integer(value);
     }
-    public static int ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_pageSize(int value)
+    public static int ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M8_PageSize(int value)
     {
       return ToDafny_N6_smithy__N3_api__S7_Integer(value);
     }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_exclusiveStartKey(Dafny.ISequence<byte> value)
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_ExclusiveStartKey(Dafny.ISequence<byte> value)
     {
       return FromDafny_N6_smithy__N3_api__S4_Blob(value);
     }
-    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_exclusiveStartKey(System.IO.MemoryStream value)
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M17_ExclusiveStartKey(System.IO.MemoryStream value)
     {
       return ToDafny_N6_smithy__N3_api__S4_Blob(value);
     }
-    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_items(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> value)
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_Items(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_EncryptedHierarchicalKeys(value);
     }
-    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_items(System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> value)
+    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput__M5_Items(System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_EncryptedHierarchicalKeys(value);
     }
@@ -1160,51 +1160,51 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_active(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Active(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_active(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Active(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_oldActive(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_OldActive(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_oldActive(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M9_OldActive(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_version(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_Version(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_version(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M7_Version(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_beacon(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Beacon(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_beacon(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M6_Beacon(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_mutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_WriteInitializeMutationInput__M12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
-    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_items(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> value)
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_Items(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_EncryptedHierarchicalKeys(value);
     }
-    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_items(System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> value)
+    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_WriteMutatedVersionsInput__M5_Items(System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_EncryptedHierarchicalKeys(value);
     }
@@ -1280,11 +1280,11 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_oldActive(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
+    public static AWS.Cryptography.KeyStore.EncryptedHierarchicalKey FromDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_OldActive(software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_oldActive(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
+    public static software.amazon.cryptography.keystore.internaldafny.types._IEncryptedHierarchicalKey ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput__M9_OldActive(AWS.Cryptography.KeyStore.EncryptedHierarchicalKey value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey(value);
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
@@ -11,7 +11,7 @@ namespace AWS.Cryptography.KeyStore
     private string _identifier;
     private System.IO.MemoryStream _original;
     private System.IO.MemoryStream _terminal;
-    private bool? _completeMutation = false; // Manual edit to default false
+    private bool? _completeMutation;
     public System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> Items
     {
       get { return this._items; }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/ApplyMutationOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/ApplyMutationOutput.cs
@@ -7,16 +7,16 @@ namespace AWS.Cryptography.KeyStoreAdmin
 {
   public class ApplyMutationOutput
   {
-    private AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult _result;
+    private AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult _mutationResult;
     private System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> _mutatedBranchKeyItems;
-    public AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult Result
+    public AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult MutationResult
     {
-      get { return this._result; }
-      set { this._result = value; }
+      get { return this._mutationResult; }
+      set { this._mutationResult = value; }
     }
-    public bool IsSetResult()
+    public bool IsSetMutationResult()
     {
-      return this._result != null;
+      return this._mutationResult != null;
     }
     public System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> MutatedBranchKeyItems
     {
@@ -29,7 +29,7 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public void Validate()
     {
-      if (!IsSetResult()) throw new System.ArgumentException("Missing value for required property 'Result'");
+      if (!IsSetMutationResult()) throw new System.ArgumentException("Missing value for required property 'MutationResult'");
       if (!IsSetMutatedBranchKeyItems()) throw new System.ArgumentException("Missing value for required property 'MutatedBranchKeyItems'");
 
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/CreateKeyInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/CreateKeyInput.cs
@@ -7,18 +7,18 @@ namespace AWS.Cryptography.KeyStoreAdmin
 {
   public class CreateKeyInput
   {
-    private string _branchKeyIdentifier;
+    private string _identifier;
     private System.Collections.Generic.Dictionary<string, string> _encryptionContext;
     private AWS.Cryptography.KeyStoreAdmin.KMSIdentifier _kmsArn;
     private AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy _strategy;
-    public string BranchKeyIdentifier
+    public string Identifier
     {
-      get { return this._branchKeyIdentifier; }
-      set { this._branchKeyIdentifier = value; }
+      get { return this._identifier; }
+      set { this._identifier = value; }
     }
-    public bool IsSetBranchKeyIdentifier()
+    public bool IsSetIdentifier()
     {
-      return this._branchKeyIdentifier != null;
+      return this._identifier != null;
     }
     public System.Collections.Generic.Dictionary<string, string> EncryptionContext
     {

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/CreateKeyOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/CreateKeyOutput.cs
@@ -7,19 +7,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
 {
   public class CreateKeyOutput
   {
-    private string _branchKeyIdentifier;
-    public string BranchKeyIdentifier
+    private string _identifier;
+    public string Identifier
     {
-      get { return this._branchKeyIdentifier; }
-      set { this._branchKeyIdentifier = value; }
+      get { return this._identifier; }
+      set { this._identifier = value; }
     }
-    public bool IsSetBranchKeyIdentifier()
+    public bool IsSetIdentifier()
     {
-      return this._branchKeyIdentifier != null;
+      return this._identifier != null;
     }
     public void Validate()
     {
-      if (!IsSetBranchKeyIdentifier()) throw new System.ArgumentException("Missing value for required property 'BranchKeyIdentifier'");
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
 
     }
   }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/InitializeMutationInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/InitializeMutationInput.cs
@@ -7,17 +7,17 @@ namespace AWS.Cryptography.KeyStoreAdmin
 {
   public class InitializeMutationInput
   {
-    private string _branchKeyIdentifier;
+    private string _identifier;
     private AWS.Cryptography.KeyStoreAdmin.Mutations _mutations;
     private AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy _strategy;
-    public string BranchKeyIdentifier
+    public string Identifier
     {
-      get { return this._branchKeyIdentifier; }
-      set { this._branchKeyIdentifier = value; }
+      get { return this._identifier; }
+      set { this._identifier = value; }
     }
-    public bool IsSetBranchKeyIdentifier()
+    public bool IsSetIdentifier()
     {
-      return this._branchKeyIdentifier != null;
+      return this._identifier != null;
     }
     public AWS.Cryptography.KeyStoreAdmin.Mutations Mutations
     {
@@ -39,7 +39,7 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public void Validate()
     {
-      if (!IsSetBranchKeyIdentifier()) throw new System.ArgumentException("Missing value for required property 'BranchKeyIdentifier'");
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
       if (!IsSetMutations()) throw new System.ArgumentException("Missing value for required property 'Mutations'");
 
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationFromException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationFromException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationFromException : Exception
+  {
+    public MutationFromException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationToException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationToException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationToException : Exception
+  {
+    public MutationToException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationVerificationException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationVerificationException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationVerificationException : Exception
+  {
+    public MutationVerificationException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
@@ -192,6 +192,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
       ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException__M7_message(value.Message)
       );
     }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationFromException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationFromException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(AWS.Cryptography.KeyStoreAdmin.MutationFromException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(value.Message)
+      );
+    }
     public static AWS.Cryptography.KeyStoreAdmin.MutationInvalidException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException value)
     {
       return new AWS.Cryptography.KeyStoreAdmin.MutationInvalidException(
@@ -216,6 +229,32 @@ namespace AWS.Cryptography.KeyStoreAdmin
 
       return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException(
       ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationToException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationToException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(AWS.Cryptography.KeyStoreAdmin.MutationToException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationVerificationException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationVerificationException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(AWS.Cryptography.KeyStoreAdmin.MutationVerificationException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(value.Message)
       );
     }
     public static AWS.Cryptography.KeyStoreAdmin.UnexpectedStateException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException value)
@@ -445,6 +484,14 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
     public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException__M7_message(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
@@ -458,6 +505,22 @@ namespace AWS.Cryptography.KeyStoreAdmin
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
@@ -908,10 +971,16 @@ namespace AWS.Cryptography.KeyStoreAdmin
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S22_KeyStoreAdminException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_CollectionOfErrors dafnyVal:
@@ -945,10 +1014,16 @@ namespace AWS.Cryptography.KeyStoreAdmin
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S22_KeyStoreAdminException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationConflictException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationFromException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationInvalidException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationLockInvalidException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationToException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationVerificationException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(exception);
         case AWS.Cryptography.KeyStoreAdmin.UnexpectedStateException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(exception);
         case CollectionOfErrors collectionOfErrors:

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
@@ -13,39 +13,39 @@ namespace AWS.Cryptography.KeyStoreAdmin
 
     public static AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationInput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput)value; AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput(); converted.MutationToken = (AWS.Cryptography.KeyStoreAdmin.MutationToken)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_mutationToken(concrete._mutationToken);
-      if (concrete._pageSize.is_Some) converted.PageSize = (int)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_pageSize(concrete._pageSize);
-      if (concrete._strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_strategy(concrete._strategy); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput)value; AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput(); converted.MutationToken = (AWS.Cryptography.KeyStoreAdmin.MutationToken)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_MutationToken(concrete._MutationToken);
+      if (concrete._PageSize.is_Some) converted.PageSize = (int)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_PageSize(concrete._PageSize);
+      if (concrete._Strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_Strategy(concrete._Strategy); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationInput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput(AWS.Cryptography.KeyStoreAdmin.ApplyMutationInput value)
     {
       value.Validate();
       int? var_pageSize = value.IsSetPageSize() ? value.PageSize : (int?)null;
       AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy var_strategy = value.IsSetStrategy() ? value.Strategy : (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null;
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_mutationToken(value.MutationToken), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_pageSize(var_pageSize), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_strategy(var_strategy));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_MutationToken(value.MutationToken), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_PageSize(var_pageSize), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_Strategy(var_strategy));
     }
     public static AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationOutput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput)value; AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput(); converted.Result = (AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M6_result(concrete._result);
-      converted.MutatedBranchKeyItems = (System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_mutatedBranchKeyItems(concrete._mutatedBranchKeyItems); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput)value; AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput(); converted.MutationResult = (AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M14_MutationResult(concrete._MutationResult);
+      converted.MutatedBranchKeyItems = (System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_MutatedBranchKeyItems(concrete._MutatedBranchKeyItems); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationOutput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput(AWS.Cryptography.KeyStoreAdmin.ApplyMutationOutput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M6_result(value.Result), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_mutatedBranchKeyItems(value.MutatedBranchKeyItems));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M14_MutationResult(value.MutationResult), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_MutatedBranchKeyItems(value.MutatedBranchKeyItems));
     }
     public static AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult(software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationResult value)
     {
       software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult)value;
-      var converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult(); if (value.is_continueMutation)
+      var converted = new AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult(); if (value.is_ContinueMutation)
       {
-        converted.ContinueMutation = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_continueMutation(concrete.dtor_continueMutation);
+        converted.ContinueMutation = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_ContinueMutation(concrete.dtor_ContinueMutation);
         return converted;
       }
-      if (value.is_completeMutation)
+      if (value.is_CompleteMutation)
       {
-        converted.CompleteMutation = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_completeMutation(concrete.dtor_completeMutation);
+        converted.CompleteMutation = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_CompleteMutation(concrete.dtor_CompleteMutation);
         return converted;
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult state");
@@ -54,61 +54,61 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       value.Validate(); if (value.IsSetContinueMutation())
       {
-        return software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult.create_continueMutation(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_continueMutation(value.ContinueMutation));
+        return software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult.create_ContinueMutation(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_ContinueMutation(value.ContinueMutation));
       }
       if (value.IsSetCompleteMutation())
       {
-        return software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult.create_completeMutation(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_completeMutation(value.CompleteMutation));
+        return software.amazon.cryptography.keystoreadmin.internaldafny.types.ApplyMutationResult.create_CompleteMutation(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_CompleteMutation(value.CompleteMutation));
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult state");
     }
     public static AWS.Cryptography.KeyStoreAdmin.CreateKeyInput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput(software.amazon.cryptography.keystoreadmin.internaldafny.types._ICreateKeyInput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput)value; AWS.Cryptography.KeyStoreAdmin.CreateKeyInput converted = new AWS.Cryptography.KeyStoreAdmin.CreateKeyInput(); if (concrete._branchKeyIdentifier.is_Some) converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
-      if (concrete._encryptionContext.is_Some) converted.EncryptionContext = (System.Collections.Generic.Dictionary<string, string>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_encryptionContext(concrete._encryptionContext);
-      converted.KmsArn = (AWS.Cryptography.KeyStoreAdmin.KMSIdentifier)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_kmsArn(concrete._kmsArn);
-      if (concrete._strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_strategy(concrete._strategy); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput)value; AWS.Cryptography.KeyStoreAdmin.CreateKeyInput converted = new AWS.Cryptography.KeyStoreAdmin.CreateKeyInput(); if (concrete._Identifier.is_Some) converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M10_Identifier(concrete._Identifier);
+      if (concrete._EncryptionContext.is_Some) converted.EncryptionContext = (System.Collections.Generic.Dictionary<string, string>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_EncryptionContext(concrete._EncryptionContext);
+      converted.KmsArn = (AWS.Cryptography.KeyStoreAdmin.KMSIdentifier)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_KmsArn(concrete._KmsArn);
+      if (concrete._Strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_Strategy(concrete._Strategy); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._ICreateKeyInput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput(AWS.Cryptography.KeyStoreAdmin.CreateKeyInput value)
     {
       value.Validate();
-      string var_branchKeyIdentifier = value.IsSetBranchKeyIdentifier() ? value.BranchKeyIdentifier : (string)null;
+      string var_identifier = value.IsSetIdentifier() ? value.Identifier : (string)null;
       System.Collections.Generic.Dictionary<string, string> var_encryptionContext = value.IsSetEncryptionContext() ? value.EncryptionContext : (System.Collections.Generic.Dictionary<string, string>)null;
       AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy var_strategy = value.IsSetStrategy() ? value.Strategy : (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null;
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M19_branchKeyIdentifier(var_branchKeyIdentifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_encryptionContext(var_encryptionContext), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_kmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_strategy(var_strategy));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M10_Identifier(var_identifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_EncryptionContext(var_encryptionContext), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_KmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_Strategy(var_strategy));
     }
     public static AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput(software.amazon.cryptography.keystoreadmin.internaldafny.types._ICreateKeyOutput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput)value; AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput converted = new AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput(); converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput)value; AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput converted = new AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M10_Identifier(concrete._Identifier); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._ICreateKeyOutput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput(AWS.Cryptography.KeyStoreAdmin.CreateKeyOutput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M19_branchKeyIdentifier(value.BranchKeyIdentifier));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M10_Identifier(value.Identifier));
     }
     public static AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IInitializeMutationInput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput)value; AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput converted = new AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput(); converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
-      converted.Mutations = (AWS.Cryptography.KeyStoreAdmin.Mutations)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_mutations(concrete._mutations);
-      if (concrete._strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_strategy(concrete._strategy); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput)value; AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput converted = new AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M10_Identifier(concrete._Identifier);
+      converted.Mutations = (AWS.Cryptography.KeyStoreAdmin.Mutations)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_Mutations(concrete._Mutations);
+      if (concrete._Strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_Strategy(concrete._Strategy); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IInitializeMutationInput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput(AWS.Cryptography.KeyStoreAdmin.InitializeMutationInput value)
     {
       value.Validate();
       AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy var_strategy = value.IsSetStrategy() ? value.Strategy : (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null;
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M19_branchKeyIdentifier(value.BranchKeyIdentifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_mutations(value.Mutations), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_strategy(var_strategy));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_Mutations(value.Mutations), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_Strategy(var_strategy));
     }
     public static AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IInitializeMutationOutput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput)value; AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput converted = new AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput(); converted.MutationToken = (AWS.Cryptography.KeyStoreAdmin.MutationToken)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_mutationToken(concrete._mutationToken);
-      converted.MutatedBranchKeyItems = (System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_mutatedBranchKeyItems(concrete._mutatedBranchKeyItems); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput)value; AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput converted = new AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput(); converted.MutationToken = (AWS.Cryptography.KeyStoreAdmin.MutationToken)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_MutationToken(concrete._MutationToken);
+      converted.MutatedBranchKeyItems = (System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_MutatedBranchKeyItems(concrete._MutatedBranchKeyItems); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IInitializeMutationOutput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput(AWS.Cryptography.KeyStoreAdmin.InitializeMutationOutput value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_mutationToken(value.MutationToken), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_mutatedBranchKeyItems(value.MutatedBranchKeyItems));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationOutput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_MutationToken(value.MutationToken), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_MutatedBranchKeyItems(value.MutatedBranchKeyItems));
     }
     public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy value)
     {
@@ -155,14 +155,14 @@ namespace AWS.Cryptography.KeyStoreAdmin
     public static AWS.Cryptography.KeyStoreAdmin.KMSIdentifier FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier value)
     {
       software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier)value;
-      var converted = new AWS.Cryptography.KeyStoreAdmin.KMSIdentifier(); if (value.is_kmsKeyArn)
+      var converted = new AWS.Cryptography.KeyStoreAdmin.KMSIdentifier(); if (value.is_KmsKeyArn)
       {
-        converted.KmsKeyArn = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_kmsKeyArn(concrete.dtor_kmsKeyArn);
+        converted.KmsKeyArn = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_KmsKeyArn(concrete.dtor_KmsKeyArn);
         return converted;
       }
-      if (value.is_kmsMRKeyArn)
+      if (value.is_KmsMRKeyArn)
       {
-        converted.KmsMRKeyArn = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_kmsMRKeyArn(concrete.dtor_kmsMRKeyArn);
+        converted.KmsMRKeyArn = FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_KmsMRKeyArn(concrete.dtor_KmsMRKeyArn);
         return converted;
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStoreAdmin.KMSIdentifier state");
@@ -171,11 +171,11 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       value.Validate(); if (value.IsSetKmsKeyArn())
       {
-        return software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier.create_kmsKeyArn(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_kmsKeyArn(value.KmsKeyArn));
+        return software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier.create_KmsKeyArn(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_KmsKeyArn(value.KmsKeyArn));
       }
       if (value.IsSetKmsMRKeyArn())
       {
-        return software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier.create_kmsMRKeyArn(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_kmsMRKeyArn(value.KmsMRKeyArn));
+        return software.amazon.cryptography.keystoreadmin.internaldafny.types.KMSIdentifier.create_KmsMRKeyArn(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_KmsMRKeyArn(value.KmsMRKeyArn));
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStoreAdmin.KMSIdentifier state");
     }
@@ -272,15 +272,15 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public static AWS.Cryptography.KeyStoreAdmin.VersionKeyInput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IVersionKeyInput value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput)value; AWS.Cryptography.KeyStoreAdmin.VersionKeyInput converted = new AWS.Cryptography.KeyStoreAdmin.VersionKeyInput(); converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
-      converted.KmsArn = (AWS.Cryptography.KeyStoreAdmin.KMSIdentifier)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_kmsArn(concrete._kmsArn);
-      if (concrete._strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_strategy(concrete._strategy); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput)value; AWS.Cryptography.KeyStoreAdmin.VersionKeyInput converted = new AWS.Cryptography.KeyStoreAdmin.VersionKeyInput(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M10_Identifier(concrete._Identifier);
+      converted.KmsArn = (AWS.Cryptography.KeyStoreAdmin.KMSIdentifier)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_KmsArn(concrete._KmsArn);
+      if (concrete._Strategy.is_Some) converted.Strategy = (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_Strategy(concrete._Strategy); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IVersionKeyInput ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput(AWS.Cryptography.KeyStoreAdmin.VersionKeyInput value)
     {
       value.Validate();
       AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy var_strategy = value.IsSetStrategy() ? value.Strategy : (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null;
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M19_branchKeyIdentifier(value.BranchKeyIdentifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_kmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_strategy(var_strategy));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyInput(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_KmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_Strategy(var_strategy));
     }
     public static AWS.Cryptography.KeyStoreAdmin.VersionKeyOutput FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S16_VersionKeyOutput(software.amazon.cryptography.keystoreadmin.internaldafny.types._IVersionKeyOutput value)
     {
@@ -292,139 +292,139 @@ namespace AWS.Cryptography.KeyStoreAdmin
 
       return new software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKeyOutput();
     }
-    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_mutationToken(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
+    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_MutationToken(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_mutationToken(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M13_MutationToken(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static int? FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_pageSize(Wrappers_Compile._IOption<int> value)
+    public static int? FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_PageSize(Wrappers_Compile._IOption<int> value)
     {
       return value.is_None ? (int?)null : FromDafny_N6_smithy__N3_api__S7_Integer(value.Extract());
     }
-    public static Wrappers_Compile._IOption<int> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_pageSize(int? value)
+    public static Wrappers_Compile._IOption<int> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_PageSize(int? value)
     {
       return value == null ? Wrappers_Compile.Option<int>.create_None() : Wrappers_Compile.Option<int>.create_Some(ToDafny_N6_smithy__N3_api__S7_Integer((int)value));
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
+    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_Strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null : FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S18_ApplyMutationInput__M8_Strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_Some(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy((AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)value));
     }
-    public static AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M6_result(software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationResult value)
+    public static AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M14_MutationResult(software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationResult value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationResult ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M6_result(AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IApplyMutationResult ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M14_MutationResult(AWS.Cryptography.KeyStoreAdmin.ApplyMutationResult value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult(value);
     }
-    public static System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_mutatedBranchKeyItems(Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> value)
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_MutatedBranchKeyItems(Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutatedBranchKeyItems(value);
     }
-    public static Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_mutatedBranchKeyItems(System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> value)
+    public static Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationOutput__M21_MutatedBranchKeyItems(System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutatedBranchKeyItems(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_continueMutation(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
+    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_ContinueMutation(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_continueMutation(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_ContinueMutation(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.MutationComplete FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_completeMutation(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationComplete value)
+    public static AWS.Cryptography.KeyStoreAdmin.MutationComplete FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_CompleteMutation(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationComplete value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S16_MutationComplete(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationComplete ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_completeMutation(AWS.Cryptography.KeyStoreAdmin.MutationComplete value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationComplete ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_ApplyMutationResult__M16_CompleteMutation(AWS.Cryptography.KeyStoreAdmin.MutationComplete value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S16_MutationComplete(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M19_branchKeyIdentifier(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M10_Identifier(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
     {
       return value.is_None ? (string)null : FromDafny_N6_smithy__N3_api__S6_String(value.Extract());
     }
-    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M19_branchKeyIdentifier(string value)
+    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M10_Identifier(string value)
     {
       return value == null ? Wrappers_Compile.Option<Dafny.ISequence<char>>.create_None() : Wrappers_Compile.Option<Dafny.ISequence<char>>.create_Some(ToDafny_N6_smithy__N3_api__S6_String((string)value));
     }
-    public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_encryptionContext(Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>> value)
+    public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_EncryptionContext(Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>> value)
     {
       return value.is_None ? (System.Collections.Generic.Dictionary<string, string>)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext(value.Extract());
     }
-    public static Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_encryptionContext(System.Collections.Generic.Dictionary<string, string> value)
+    public static Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M17_EncryptionContext(System.Collections.Generic.Dictionary<string, string> value)
     {
       return value == null ? Wrappers_Compile.Option<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>>.create_None() : Wrappers_Compile.Option<Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>>>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext((System.Collections.Generic.Dictionary<string, string>)value));
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KMSIdentifier FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_kmsArn(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier value)
+    public static AWS.Cryptography.KeyStoreAdmin.KMSIdentifier FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_KmsArn(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_kmsArn(AWS.Cryptography.KeyStoreAdmin.KMSIdentifier value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M6_KmsArn(AWS.Cryptography.KeyStoreAdmin.KMSIdentifier value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
+    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_Strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null : FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S14_CreateKeyInput__M8_Strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_Some(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy((AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)value));
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M19_branchKeyIdentifier(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M10_Identifier(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M19_branchKeyIdentifier(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_CreateKeyOutput__M10_Identifier(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M19_branchKeyIdentifier(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M10_Identifier(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M19_branchKeyIdentifier(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M10_Identifier(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.Mutations FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_mutations(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations value)
+    public static AWS.Cryptography.KeyStoreAdmin.Mutations FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_Mutations(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_mutations(AWS.Cryptography.KeyStoreAdmin.Mutations value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M9_Mutations(AWS.Cryptography.KeyStoreAdmin.Mutations value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
+    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_Strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null : FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S23_InitializeMutationInput__M8_Strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_Some(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy((AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)value));
     }
-    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_mutationToken(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
+    public static AWS.Cryptography.KeyStoreAdmin.MutationToken FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_MutationToken(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_mutationToken(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutationToken ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M13_MutationToken(AWS.Cryptography.KeyStoreAdmin.MutationToken value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_MutationToken(value);
     }
-    public static System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_mutatedBranchKeyItems(Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> value)
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_MutatedBranchKeyItems(Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutatedBranchKeyItems(value);
     }
-    public static Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_mutatedBranchKeyItems(System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> value)
+    public static Dafny.ISequence<software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_InitializeMutationOutput__M21_MutatedBranchKeyItems(System.Collections.Generic.List<AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem> value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutatedBranchKeyItems(value);
     }
@@ -460,19 +460,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_kmsKeyArn(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_KmsKeyArn(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_kmsKeyArn(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M9_KmsKeyArn(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_kmsMRKeyArn(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_KmsMRKeyArn(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_kmsMRKeyArn(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier__M11_KmsMRKeyArn(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
@@ -532,27 +532,27 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M19_branchKeyIdentifier(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M10_Identifier(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M19_branchKeyIdentifier(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M10_Identifier(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KMSIdentifier FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_kmsArn(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier value)
+    public static AWS.Cryptography.KeyStoreAdmin.KMSIdentifier FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_KmsArn(software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier value)
     {
       return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier(value);
     }
-    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_kmsArn(AWS.Cryptography.KeyStoreAdmin.KMSIdentifier value)
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IKMSIdentifier ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M6_KmsArn(AWS.Cryptography.KeyStoreAdmin.KMSIdentifier value)
     {
       return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S13_KMSIdentifier(value);
     }
-    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
+    public static AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_Strategy(Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> value)
     {
       return value.is_None ? (AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)null : FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy(value.Extract());
     }
-    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S15_VersionKeyInput__M8_Strategy(AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy value)
     {
       return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystoreadmin.internaldafny.types._IKeyManagementStrategy>.create_Some(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_KeyManagementStrategy((AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy)value));
     }
@@ -618,15 +618,15 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public static AWS.Cryptography.KeyStoreAdmin.Mutations FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations)value; AWS.Cryptography.KeyStoreAdmin.Mutations converted = new AWS.Cryptography.KeyStoreAdmin.Mutations(); if (concrete._terminalKmsArn.is_Some) converted.TerminalKmsArn = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_terminalKmsArn(concrete._terminalKmsArn);
-      if (concrete._terminalEncryptionContext.is_Some) converted.TerminalEncryptionContext = (System.Collections.Generic.Dictionary<string, string>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_terminalEncryptionContext(concrete._terminalEncryptionContext); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations)value; AWS.Cryptography.KeyStoreAdmin.Mutations converted = new AWS.Cryptography.KeyStoreAdmin.Mutations(); if (concrete._TerminalKmsArn.is_Some) converted.TerminalKmsArn = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_TerminalKmsArn(concrete._TerminalKmsArn);
+      if (concrete._TerminalEncryptionContext.is_Some) converted.TerminalEncryptionContext = (System.Collections.Generic.Dictionary<string, string>)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_TerminalEncryptionContext(concrete._TerminalEncryptionContext); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutations ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations(AWS.Cryptography.KeyStoreAdmin.Mutations value)
     {
       value.Validate();
       string var_terminalKmsArn = value.IsSetTerminalKmsArn() ? value.TerminalKmsArn : (string)null;
       System.Collections.Generic.Dictionary<string, string> var_terminalEncryptionContext = value.IsSetTerminalEncryptionContext() ? value.TerminalEncryptionContext : (System.Collections.Generic.Dictionary<string, string>)null;
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_terminalKmsArn(var_terminalKmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_terminalEncryptionContext(var_terminalEncryptionContext));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Mutations(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_TerminalKmsArn(var_terminalKmsArn), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_TerminalEncryptionContext(var_terminalEncryptionContext));
     }
     public static AWS.Cryptography.KeyStore.AwsKms FromDafny_N3_aws__N12_cryptography__N8_keyStore__S6_AwsKms(software.amazon.cryptography.keystore.internaldafny.types._IAwsKms value)
     {
@@ -739,19 +739,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_terminalKmsArn(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_TerminalKmsArn(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
     {
       return value.is_None ? (string)null : FromDafny_N6_smithy__N3_api__S6_String(value.Extract());
     }
-    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_terminalKmsArn(string value)
+    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M14_TerminalKmsArn(string value)
     {
       return value == null ? Wrappers_Compile.Option<Dafny.ISequence<char>>.create_None() : Wrappers_Compile.Option<Dafny.ISequence<char>>.create_Some(ToDafny_N6_smithy__N3_api__S6_String((string)value));
     }
-    public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_terminalEncryptionContext(Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>> value)
+    public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_TerminalEncryptionContext(Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>> value)
     {
       return value.is_None ? (System.Collections.Generic.Dictionary<string, string>)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S23_EncryptionContextString(value.Extract());
     }
-    public static Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_terminalEncryptionContext(System.Collections.Generic.Dictionary<string, string> value)
+    public static Wrappers_Compile._IOption<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S9_Mutations__M25_TerminalEncryptionContext(System.Collections.Generic.Dictionary<string, string> value)
     {
       return value == null ? Wrappers_Compile.Option<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>>.create_None() : Wrappers_Compile.Option<Dafny.IMap<Dafny.ISequence<char>, Dafny.ISequence<char>>>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S23_EncryptionContextString((System.Collections.Generic.Dictionary<string, string>)value));
     }
@@ -802,14 +802,14 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public static AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem(software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem value)
     {
-      software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem)value; AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem converted = new AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem(); converted.ItemType = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_itemType(concrete._itemType);
-      converted.Description = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_description(concrete._description); return converted;
+      software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem concrete = (software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem)value; AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem converted = new AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem(); converted.ItemType = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_ItemType(concrete._ItemType);
+      converted.Description = (string)FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_Description(concrete._Description); return converted;
     }
     public static software.amazon.cryptography.keystoreadmin.internaldafny.types._IMutatedBranchKeyItem ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem(AWS.Cryptography.KeyStoreAdmin.MutatedBranchKeyItem value)
     {
       value.Validate();
 
-      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_itemType(value.ItemType), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_description(value.Description));
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.MutatedBranchKeyItem(ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_ItemType(value.ItemType), ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_Description(value.Description));
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(Dafny.ISequence<byte> value)
     {
@@ -874,19 +874,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
       // Therefore it defers to the dependant module for conversion
       return AWS.Cryptography.KeyStore.TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_KeyStorageInterfaceReference(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_itemType(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_ItemType(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_itemType(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M8_ItemType(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_description(Dafny.ISequence<char> value)
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_Description(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_description(string value)
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S20_MutatedBranchKeyItem__M11_Description(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/VersionKeyInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/VersionKeyInput.cs
@@ -7,17 +7,17 @@ namespace AWS.Cryptography.KeyStoreAdmin
 {
   public class VersionKeyInput
   {
-    private string _branchKeyIdentifier;
+    private string _identifier;
     private AWS.Cryptography.KeyStoreAdmin.KMSIdentifier _kmsArn;
     private AWS.Cryptography.KeyStoreAdmin.KeyManagementStrategy _strategy;
-    public string BranchKeyIdentifier
+    public string Identifier
     {
-      get { return this._branchKeyIdentifier; }
-      set { this._branchKeyIdentifier = value; }
+      get { return this._identifier; }
+      set { this._identifier = value; }
     }
-    public bool IsSetBranchKeyIdentifier()
+    public bool IsSetIdentifier()
     {
-      return this._branchKeyIdentifier != null;
+      return this._identifier != null;
     }
     public AWS.Cryptography.KeyStoreAdmin.KMSIdentifier KmsArn
     {
@@ -39,7 +39,7 @@ namespace AWS.Cryptography.KeyStoreAdmin
     }
     public void Validate()
     {
-      if (!IsSetBranchKeyIdentifier()) throw new System.ArgumentException("Missing value for required property 'BranchKeyIdentifier'");
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
       if (!IsSetKmsArn()) throw new System.ArgumentException("Missing value for required property 'KmsArn'");
 
     }

--- a/ComAmazonawsDynamodb/codegen-patches/dotnet/dafny-4.8.0.patch
+++ b/ComAmazonawsDynamodb/codegen-patches/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs a/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
-index e35ad3d2..9f375b21 100644
+index e35ad3d2d..9f375b21c 100644
 --- b/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
 +++ a/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
 @@ -5848,7 +5848,7 @@ namespace Com.Amazonaws.Dynamodb

--- a/ComAmazonawsKms/codegen-patches/dotnet/dafny-4.8.0.patch
+++ b/ComAmazonawsKms/codegen-patches/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs a/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
-index f479e07b..46aff0c7 100644
+index f479e07b9..46aff0c76 100644
 --- b/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
 +++ a/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
 @@ -5510,7 +5510,7 @@ namespace Com.Amazonaws.Kms


### PR DESCRIPTION
Give ourselves room to:
1. Improve the KMS errors during a KMS Key Transition or Mutation in general
2. Resume Mutations and Describe Mutation need some Storage Operations
3. The Storage Operations need to discern why a write failed.

More on (3.):
Write Operations can fail because something else 
modified or deleted an item since it was read,
OR 
Mutation writes can fail because 
the M-Lock and M-Token disagree.

The two conditions have different recovery methods.
i.e: If the Lock/Token is failing the request, 
do not retry with this Token, 
get a fresh one, 
or "criticize" the Lock.

Thus, we need to differentiate between them.

Since we cannot add or change operations on the Storage Model
after it has been released,
we MUST get these Storage changes in.

More on (1.):
KMS Access Denied errors are, 
unfortunately, not modeled in their Smithy Model,
and therefore represented in Dafny as Opaque Errors.

We will need to either benerate or 
implement additional logic in Smithy-Dafny to
fully handle Mutation errors from KMS.
(See https://github.com/smithy-lang/smithy-dafny/issues/609)

But for the immediate future,
we can consider returning the error shapes
introduced here when an opaque error is encountered.