### PR TITLE
chore(release-canidate): Key Store Admin

### DIFF
--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
-index 0b153802..56aef9ec 100644
+index 0b153802b..56aef9ec6 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
 @@ -3903,7 +3903,9 @@ namespace AWS.Cryptography.MaterialProviders

--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/dotnet/dafny-4.8.0.patch
@@ -1,8 +1,8 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
-index cc3dc4cd..63100b40 100644
+index 2804c8f21..868d600b3 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
-@@ -1727,7 +1727,7 @@ namespace AWS.Cryptography.KeyStore
+@@ -1875,7 +1875,7 @@ namespace AWS.Cryptography.KeyStore
              dafnyVal._ComAmazonawsDynamodb
            );
          case software.amazon.cryptography.keystore.internaldafny.types.Error_ComAmazonawsKms dafnyVal:
@@ -10,8 +10,8 @@ index cc3dc4cd..63100b40 100644
 +          return Com.Amazonaws.Kms.TypeConversion.FromDafny_CommonError( // Manual edit KMS. -> Kms.
              dafnyVal._ComAmazonawsKms
            );
-         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException dafnyVal:
-@@ -1754,7 +1754,7 @@ namespace AWS.Cryptography.KeyStore
+         case software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed dafnyVal:
+@@ -1910,7 +1910,7 @@ namespace AWS.Cryptography.KeyStore
        {
          case "Com.Amazonaws.KMS":
            return software.amazon.cryptography.keystore.internaldafny.types.Error.create_ComAmazonawsKms(
@@ -20,16 +20,3 @@ index cc3dc4cd..63100b40 100644
            );
          case "Com.Amazonaws.Dynamodb":
            return software.amazon.cryptography.keystore.internaldafny.types.Error.create_ComAmazonawsDynamodb(
-diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-index 16da0962..9607f4a4 100644
---- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-+++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
-@@ -11,7 +11,7 @@ namespace AWS.Cryptography.KeyStore
-     private string _identifier;
-     private System.IO.MemoryStream _original;
-     private System.IO.MemoryStream _terminal;
--    private bool? _completeMutation;
-+    private bool? _completeMutation = false; // Manual edit to default false
-     public System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> Items
-     {
-       get { return this._items; }

--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStoreAdmin/dotnet/dafny-4.8.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStoreAdmin/dotnet/dafny-4.8.0.patch
@@ -1,8 +1,8 @@
 diff --git b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
-index b8ad30a5..4904d73b 100644
+index fa79a35cd..97802ad43 100644
 --- b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
 +++ a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
-@@ -1056,7 +1056,8 @@ namespace AWS.Cryptography.KeyStoreAdmin
+@@ -963,7 +963,8 @@ namespace AWS.Cryptography.KeyStoreAdmin
              dafnyVal._ComAmazonawsDynamodb
            );
          case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_ComAmazonawsKms dafnyVal:

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -38,6 +38,12 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly encryptionContext: EncryptionContext ,
     nameonly branchKey: Secret
   )
+  datatype ClobberMutationLockInput = | ClobberMutationLockInput (
+    nameonly mutationLock: MutationLock
+  )
+  datatype ClobberMutationLockOutput = | ClobberMutationLockOutput (
+
+                                       )
   datatype CreateKeyInput = | CreateKeyInput (
     nameonly branchKeyIdentifier: Option<string> := Option.None ,
     nameonly encryptionContext: Option<EncryptionContext> := Option.None
@@ -129,6 +135,12 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly grantTokens: GrantTokenList ,
     nameonly kmsConfiguration: KMSConfiguration
   )
+  datatype GetMutationLockInput = | GetMutationLockInput (
+    nameonly Identifier: string
+  )
+  datatype GetMutationLockOutput = | GetMutationLockOutput (
+    nameonly mutationLock: Option<MutationLock> := Option.None
+  )
   type GrantTokenList = seq<string>
   datatype HierarchicalKeyType =
     | ActiveHierarchicalSymmetricVersion(ActiveHierarchicalSymmetricVersion: ActiveHierarchicalSymmetric)
@@ -147,8 +159,10 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       WriteNewEncryptedBranchKey := [];
       WriteInitializeMutation := [];
       GetItemsForInitializeMutation := [];
+      GetMutationLock := [];
       WriteNewEncryptedBranchKeyVersion := [];
       QueryForVersions := [];
+      ClobberMutationLock := [];
       GetKeyStorageInfo := [];
       GetEncryptedBranchKeyVersion := [];
       GetEncryptedBeaconKey := [];
@@ -158,8 +172,10 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     ghost var WriteNewEncryptedBranchKey: seq<DafnyCallEvent<WriteNewEncryptedBranchKeyInput, Result<WriteNewEncryptedBranchKeyOutput, Error>>>
     ghost var WriteInitializeMutation: seq<DafnyCallEvent<WriteInitializeMutationInput, Result<WriteInitializeMutationOutput, Error>>>
     ghost var GetItemsForInitializeMutation: seq<DafnyCallEvent<GetItemsForInitializeMutationInput, Result<GetItemsForInitializeMutationOutput, Error>>>
+    ghost var GetMutationLock: seq<DafnyCallEvent<GetMutationLockInput, Result<GetMutationLockOutput, Error>>>
     ghost var WriteNewEncryptedBranchKeyVersion: seq<DafnyCallEvent<WriteNewEncryptedBranchKeyVersionInput, Result<WriteNewEncryptedBranchKeyVersionOutput, Error>>>
     ghost var QueryForVersions: seq<DafnyCallEvent<QueryForVersionsInput, Result<QueryForVersionsOutput, Error>>>
+    ghost var ClobberMutationLock: seq<DafnyCallEvent<ClobberMutationLockInput, Result<ClobberMutationLockOutput, Error>>>
     ghost var GetKeyStorageInfo: seq<DafnyCallEvent<GetKeyStorageInfoInput, Result<GetKeyStorageInfoOutput, Error>>>
     ghost var GetEncryptedBranchKeyVersion: seq<DafnyCallEvent<GetEncryptedBranchKeyVersionInput, Result<GetEncryptedBranchKeyVersionOutput, Error>>>
     ghost var GetEncryptedBeaconKey: seq<DafnyCallEvent<GetEncryptedBeaconKeyInput, Result<GetEncryptedBeaconKeyOutput, Error>>>
@@ -346,6 +362,37 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       ensures GetItemsForInitializeMutationEnsuresPublicly(input, output)
       ensures unchanged(History)
 
+    predicate GetMutationLockEnsuresPublicly(input: GetMutationLockInput , output: Result<GetMutationLockOutput, Error>)
+    // The public method to be called by library consumers
+    method GetMutationLock ( input: GetMutationLockInput )
+      returns (output: Result<GetMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetMutationLock
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetMutationLockEnsuresPublicly(input, output)
+      ensures History.GetMutationLock == old(History.GetMutationLock) + [DafnyCallEvent(input, output)]
+    {
+      output := GetMutationLock' (input);
+      History.GetMutationLock := History.GetMutationLock + [DafnyCallEvent(input, output)];
+    }
+    // The method to implement in the concrete class.
+    method GetMutationLock' ( input: GetMutationLockInput )
+      returns (output: Result<GetMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History}
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetMutationLockEnsuresPublicly(input, output)
+      ensures unchanged(History)
+
     predicate WriteNewEncryptedBranchKeyVersionEnsuresPublicly(input: WriteNewEncryptedBranchKeyVersionInput , output: Result<WriteNewEncryptedBranchKeyVersionOutput, Error>)
     // The public method to be called by library consumers
     method WriteNewEncryptedBranchKeyVersion ( input: WriteNewEncryptedBranchKeyVersionInput )
@@ -406,6 +453,37 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       ensures
         && ValidState()
       ensures QueryForVersionsEnsuresPublicly(input, output)
+      ensures unchanged(History)
+
+    predicate ClobberMutationLockEnsuresPublicly(input: ClobberMutationLockInput , output: Result<ClobberMutationLockOutput, Error>)
+    // The public method to be called by library consumers
+    method ClobberMutationLock ( input: ClobberMutationLockInput )
+      returns (output: Result<ClobberMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`ClobberMutationLock
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures ClobberMutationLockEnsuresPublicly(input, output)
+      ensures History.ClobberMutationLock == old(History.ClobberMutationLock) + [DafnyCallEvent(input, output)]
+    {
+      output := ClobberMutationLock' (input);
+      History.ClobberMutationLock := History.ClobberMutationLock + [DafnyCallEvent(input, output)];
+    }
+    // The method to implement in the concrete class.
+    method ClobberMutationLock' ( input: ClobberMutationLockInput )
+      returns (output: Result<ClobberMutationLockOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History}
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures ClobberMutationLockEnsuresPublicly(input, output)
       ensures unchanged(History)
 
     predicate GetKeyStorageInfoEnsuresPublicly(input: GetKeyStorageInfoInput , output: Result<GetKeyStorageInfoOutput, Error>)
@@ -737,10 +815,22 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
                                                      )
   datatype Error =
       // Local Error structures are listed here
+    | AlreadyExistsConditionFailed (
+        nameonly message: string
+      )
     | KeyStorageException (
         nameonly message: string
       )
     | KeyStoreException (
+        nameonly message: string
+      )
+    | MutationLockConditionFailed (
+        nameonly message: string
+      )
+    | NoLongerExistsConditionFailed (
+        nameonly message: string
+      )
+    | OldEncConditionFailed (
         nameonly message: string
       )
     | VersionRaceException (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -171,9 +171,11 @@ module DefaultKeyStorageInterface {
             && output.value.activeItem.Identifier == input.Identifier
             && Structure.ActiveHierarchicalSymmetricKey?(output.value.activeItem)
             && output.value.activeItem.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+            && KmsArn.ValidKmsArn?(output.value.activeItem.KmsArn)
             && output.value.beaconItem.Identifier == input.Identifier
             && Structure.ActiveHierarchicalSymmetricBeaconKey?(output.value.beaconItem)
             && output.value.beaconItem.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+            && KmsArn.ValidKmsArn?(output.value.beaconItem.KmsArn)
       )
     }
 
@@ -194,6 +196,7 @@ module DefaultKeyStorageInterface {
               && Structure.DecryptOnlyHierarchicalSymmetricKey?(item)
               && item.Type.HierarchicalSymmetricVersion?
               && item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+              && KmsArn.ValidKmsArn?(item.KmsArn)
       )
     }
 
@@ -963,6 +966,7 @@ module DefaultKeyStorageInterface {
                 && Structure.EncryptedHierarchicalKey?(output.value)
                 && output.value.Identifier == identifier
                 && output.value.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+                && KmsArn.ValidKmsArn?(output.value.KmsArn)
     {
       :- Need(
            Structure.BranchKeyItem?(item),
@@ -970,17 +974,18 @@ module DefaultKeyStorageInterface {
              message:="Malformed Branch Key Store Item encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      var item := ToEncryptedHierarchicalKey(item, logicalKeyStoreName);
+      var branchKey := ToEncryptedHierarchicalKey(branchKey, logicalKeyStoreName);
 
-      assert item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
+      assert branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
       :- Need(
-           && item.Identifier == identifier
-           && item.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName,
+           && branchKey.Identifier == identifier
+           && branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+           && KmsArn.ValidKmsArn?(branchKey.KmsArn),
            Types.KeyStorageException(
-             message:="Malformed Branch Key Store Item encountered. TableName: "
+             message:="Malformed Branch Key Store BranchKey encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      Success(item)
+      Success(branchKey)
     }
 
     /** A transaction write for 4 items, conditioned on No Mutation Lock exsisting for Identifier.*/

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -974,7 +974,7 @@ module DefaultKeyStorageInterface {
              message:="Malformed Branch Key Store Item encountered. TableName: "
              + ddbTableName + "\tBranch Key ID: " + identifier)
          );
-      var branchKey := ToEncryptedHierarchicalKey(branchKey, logicalKeyStoreName);
+      var branchKey := ToEncryptedHierarchicalKey(item, logicalKeyStoreName);
 
       assert branchKey.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName;
       :- Need(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
@@ -363,8 +363,8 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
       GrantTokens := Some(grantTokens)
     );
 
-    var maybeReEncryptResponse := kmsClient.ReEncrypt(reEncryptRequest);
-    var reEncryptResponse :- maybeReEncryptResponse
+    var reEncryptResponse? := kmsClient.ReEncrypt(reEncryptRequest);
+    var reEncryptResponse :- reEncryptResponse?
     .MapFailure(e => Types.ComAmazonawsKms(ComAmazonawsKms := e));
 
     :- Need(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/Structure.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/Structure.dfy
@@ -23,7 +23,8 @@ module {:options "/functionSyntax:4" } Structure {
   const M_LOCK_TERMINAL := "terminal" // The DDB Attribute name for the terminal state, which is AttributeValue.B
   const M_LOCK_UUID := "uuid" // The DDB Attribute name for the uuid, which is AttributeValue.S
 
-  const ENCRYPTION_CONTEXT_PREFIX := "aws-crypto-ec:"
+  const AWS_CRYPTO_EC := "aws-crypto-ec"
+  const ENCRYPTION_CONTEXT_PREFIX := AWS_CRYPTO_EC + ":"
 
   const BRANCH_KEY_RESTRICTED_FIELD_NAMES := {
     BRANCH_KEY_IDENTIFIER_FIELD,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
@@ -23,18 +23,7 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
 
   method {:test} TestHappyCase()
   {
-    // var underTest :- expect Fixtures.DefaultStorage();
-    var ddbClient :- expect DDB.DynamoDBClient();
-    // The next two assumes are tragic
-    assume {:axiom} UTF8.Encode(physicalName).Success? && UTF8.EncodeAscii(physicalName) == UTF8.Encode(physicalName).value;
-    assume {:axiom} UTF8.Encode(logicalName).Success? && UTF8.EncodeAscii(logicalName) == UTF8.Encode(logicalName).value;
-    var underTest := new DefaultKeyStorageInterface.DynamoDBKeyStorageInterface(
-      ddbTableName := physicalName,
-      ddbClient := ddbClient,
-      logicalKeyStoreName := logicalName,
-      ddbTableNameUtf8 := UTF8.EncodeAscii(physicalName),
-      logicalKeyStoreNameUtf8 := UTF8.EncodeAscii(logicalName)
-    );
+    var underTest :- expect Fixtures.DefaultStorage();
     var input := Types.GetItemsForInitializeMutationInput(
       Identifier := Fixtures.branchKeyId
     );
@@ -52,18 +41,7 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
 
   method {:test} TestHappyCaseMLocked()
   {
-    // var underTest :- expect Fixtures.DefaultStorage();
-    // The next two assumes are tragic
-    assume {:axiom} UTF8.Encode(physicalName).Success? && UTF8.EncodeAscii(physicalName) == UTF8.Encode(physicalName).value;
-    assume {:axiom} UTF8.Encode(logicalName).Success? && UTF8.EncodeAscii(logicalName) == UTF8.Encode(logicalName).value;
-    var ddbClient :- expect DDB.DynamoDBClient();
-    var underTest := new DefaultKeyStorageInterface.DynamoDBKeyStorageInterface(
-      ddbTableName := physicalName,
-      ddbClient := ddbClient,
-      logicalKeyStoreName := logicalName,
-      ddbTableNameUtf8 := UTF8.EncodeAscii(physicalName),
-      logicalKeyStoreNameUtf8 := UTF8.EncodeAscii(logicalName)
-    );
+    var underTest :- expect Fixtures.DefaultStorage();
     var input := Types.GetItemsForInitializeMutationInput(
       Identifier := mLockedId
     );

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy
@@ -28,9 +28,13 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := Fixtures.branchKeyId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
+    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+                                   "`type` missing from activeItem!";
     expect
       output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
       "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+                                   "`type` missing from beaconItem!";
     expect
       output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
       "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];
@@ -46,10 +50,13 @@ module {:options "/functionSyntax:4"} TestGetItemsForInitializeMutation {
       Identifier := mLockedId
     );
     var output :- expect underTest.GetItemsForInitializeMutation(input);
-
+    expect Structure.TYPE_FIELD in output.activeItem.EncryptionContext,
+                                   "`type` missing from activeItem!";
     expect
       output.activeItem.Type.ActiveHierarchicalSymmetricVersion?,
       "activeItem was not Active? 'type': " + output.activeItem.EncryptionContext[Structure.TYPE_FIELD];
+    expect Structure.TYPE_FIELD in output.beaconItem.EncryptionContext,
+                                   "`type` missing from beaconItem!";
     expect
       output.beaconItem.Type.ActiveHierarchicalSymmetricBeacon?,
       "beaconItem was not Beacon? 'type': " + output.beaconItem.EncryptionContext[Structure.TYPE_FIELD];

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/AwsCryptographyKeyStoreAdminTypes.dfy
@@ -193,10 +193,19 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny.types"
     | MutationConflictException (
         nameonly message: string
       )
+    | MutationFromException (
+        nameonly message: string
+      )
     | MutationInvalidException (
         nameonly message: string
       )
     | MutationLockInvalidException (
+        nameonly message: string
+      )
+    | MutationToException (
+        nameonly message: string
+      )
+    | MutationVerificationException (
         nameonly message: string
       )
     | UnexpectedStateException (

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/Model/KeyStoreAdmin.smithy
@@ -453,23 +453,68 @@ structure MutationConflictException {
 }
 
 @error("client")
-@documentation("Key Management Authorization failed while Initializing the Mutation. No Mutation Lock was created; no items were changed.")
+@documentation(
+"Branch Key Authorization failed while Initializing the Mutation.
+No Mutation Lock was created; no items were changed.")
 structure MutationInvalidException {
   @required
   message: String,
 }
 
-// Mutation Lock's Digest is incorrect; TODO: If we trust the backing table, should we remove this error?
 @error("client")
-@documentation("Mutation Lock is failing authentication. Mutation Lock still exists but Mutation cannot proceed. No items were changed. Recommend identifying latest author of Mutation Lock and validating their access.")
+@documentation(
+"Mutation Lock disagrees with provided Mutation Token.
+Mutation Lock still exists but Mutation cannot proceed.
+No items were changed.
+Recommend identifying latest author of Mutation Lock
+and validating their access;
+or checking the integrity of Mutation Token.")
 structure MutationLockInvalidException {
   @required
   message: String,
 }
 
 @error("client")
-@documentation("An Item was encountered that is not in an expected state. Mutation Lock is still present; no items were changed by this request. Recommend audting backing table access; an Item of a Branch Key MUST only be in one of two states during a Mutation; this item is in a third state.")
+@documentation(
+"An Item was encountered that is not
+in an expected state.
+Mutation Lock is still present;
+no items were changed by this request.
+Recommend audting backing table access;
+an Item of a Branch Key MUST be in
+either the original or terminal states during a Mutation;
+encountered item(s) in other states.")
 structure UnexpectedStateException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while authenticating
+an item already in the terminal state.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationVerificationException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while mutating
+an item from original to terminal.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationToException {
+  @required
+  message: String,
+}
+
+@error("client")
+@documentation(
+"Key Management generic error encountered while mutating
+an item from original to terminal.
+Possibly, access to the terminal KMS Key was withdrawn.")
+structure MutationFromException {
   @required
   message: String,
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Index.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Index.dfy
@@ -128,7 +128,6 @@ module {:extern "software.amazon.cryptography.keystoreadmin.internaldafny"}
     } else {
       ddbClient := ddbClient?.value;
     }
-    // assume {:axiom} ddbClient.Modifies < FixturesLie(); // Tony thinks we don't need this
     // If the customer gave us the DDB Client, it is fresh
     // If we create the DDB Client, it is fresh
     assume {:axiom} fresh(ddbClient) && fresh(ddbClient.Modifies);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
@@ -81,11 +81,13 @@ module {:options "/functionSyntax:4" } AdminFixtures {
     key: string := "Robbie",
     value: string := "Is a dog.")
 
+  /** Adds an "un-modeled Attribute" to the Active & Decrypt. */
+  /** If alsoViolateBeacion?, also add to Beacon.*/
   method AddAttributeWithoutLibrary(
     nameonly id: string,
     nameonly physicalName: string := Fixtures.branchKeyStoreName,
     nameonly logicalName: string := Fixtures.logicalKeyStoreName,
-    nameonly keyValue: KeyValue := KeyValue(key:="Robbie", value:="Is a dog."),
+    nameonly keyValue: KeyValue := KeyValue(),
     nameonly alsoViolateBeacon?: bool := false,
     nameonly ddbClient?: Option<DDB.Types.IDynamoDBClient> := None,
     nameonly kmsClient?: Option<KMS.Types.IKMSClient> := None
@@ -100,13 +102,10 @@ module {:options "/functionSyntax:4" } AdminFixtures {
              + (if kmsClient?.Some? then kmsClient?.value.Modifies else {})
   {
     var ddbClient :- expect Fixtures.ProvideDDBClient(ddbClient?);
-    assume {:axiom} fresh(ddbClient) && fresh(ddbClient.Modifies);
     var kmsClient :- expect Fixtures.ProvideKMSClient(None);
-    assume {:axiom} fresh(kmsClient) && fresh(kmsClient.Modifies);
-
     var storage :- expect Fixtures.DefaultStorage(
       physicalName := physicalName, logicalName := logicalName, ddbClient? := Some(ddbClient));
-    assume {:axiom} fresh(storage) && fresh(storage.Modifies);
+
     var allThree :- expect Fixtures.getItems(id:=id, underTest:=storage);
     var activeDDB :- expect ViolateItem(
       item := allThree.active, keyValue:=keyValue, kmsClient:=kmsClient, physicalName:=physicalName);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
@@ -87,7 +87,7 @@ module {:options "/functionSyntax:4" } AdminFixtures {
     nameonly id: string,
     nameonly physicalName: string := Fixtures.branchKeyStoreName,
     nameonly logicalName: string := Fixtures.logicalKeyStoreName,
-    nameonly keyValue: KeyValue := KeyValue(),
+    nameonly keyValue: KeyValue := KeyValue(key:="Robbie", value:="Is a dog."),
     nameonly alsoViolateBeacon?: bool := false,
     nameonly ddbClient?: Option<DDB.Types.IDynamoDBClient> := None,
     nameonly kmsClient?: Option<KMS.Types.IKMSClient> := None

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsEncryptionContextUnModeledAttribute.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsEncryptionContextUnModeledAttribute.dfy
@@ -8,11 +8,13 @@ include "../../../AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
 include "../AdminFixtures.dfy"
 
 // Tests that an Encryption Context only change:
-// - Completes if there is no paging
+// - Completes, without paging, since it is annoying to violate the items
 // - Changes the Custom Encryption Context for all items
 // - All items can be decrypted by KMS
+// - maintains un-modeled attributes in exsisting items
+// - projects un-modeled attributes to new items
 
-module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
+module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAttribute {
   import Types = AwsCryptographyKeyStoreAdminTypes
   import KeyStoreAdmin
   import KeyStore
@@ -36,14 +38,12 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
   const kmsId: string := Fixtures.keyArn
   const physicalName: string := Fixtures.branchKeyStoreName
   const logicalName: string := Fixtures.logicalKeyStoreName
-  const testLogPrefix := "\nTestMutationsEncryptionContextAddValue :: TestProofMutationsOverWritesUnModeldedAttributesCase :: "
+  const testLogPrefix := "\nTestMutationsEncryptionContextUnModeledAttribute :: TestHappyCase :: "
 
-  // This is evidence that the code behaves in the manner we DO NOT WANT
-  method {:test} {:vcs_split_on_every_assert} TestProofMutationsOverWritesUnModeldedAttributesCase()
+  method {:test} {:vcs_split_on_every_assert} TestHappyCase()
   {
     print " running";
 
-    // expect false; // disable test till other investigation is done
     var ddbClient :- expect DDB.DynamoDBClient();
     var kmsClient :- expect KMS.KMSClient();
 
@@ -55,15 +55,18 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var uuid :- expect UUID.GenerateUUID();
     var testId := happyCaseId + "-" + uuid;
 
-    // var robbieBytes :- expect UTF8.Encode("Robbie");
     var kodaBytes :- expect UTF8.Encode("Koda");
     var isADogBytes :- expect UTF8.Encode("is a dog.");
     var originalEC := map[kodaBytes := isADogBytes];
     Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0, customEC:=originalEC);
 
     print testLogPrefix + " Created the legit test items with 1 versions! testId: " + testId + "\n";
-
-    var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(id:=testId, alsoViolateBeacon? := true, ddbClient? := Some(ddbClient));
+    var unModeledAttri := AdminFixtures.KeyValue();
+    var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
+      id:=testId,
+      alsoViolateBeacon? := true,
+      ddbClient? := Some(ddbClient),
+      keyValue := unModeledAttri);
 
     print testLogPrefix + " Violated all three. testId: " + testId + "\n";
 
@@ -102,19 +105,9 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     {
       var item := items[itemIndex];
       expect
-        customEC in item.EncryptionContext,
-                    "Koda should be a Key in the Custom Encryption Context of all items for this test.";
-      expect
-        item.EncryptionContext[customEC] == timestamp,
-        "Koda's value should be the test timestamp for all decrypt items for this test.";
-      expect "type" in item.EncryptionContext, "Decrypt Only item is missing 'type' from EC!!";
-      expect
         item.Type.HierarchicalSymmetricVersion?,
         "Query for Decrypt Only returned a non-Decrypt Only!";
-
-      if ("Robbie" in item.EncryptionContext) {
-        print testLogPrefix + "Robbie in " + item.EncryptionContext["type"] + "\n";
-      }
+      var _ := itemExpectations(item, timestamp, unModeledAttri);
       var versionUUID := item.Type.HierarchicalSymmetricVersion.Version;
       inputV := KeyStoreTypes.GetBranchKeyVersionInput(
         branchKeyIdentifier := testId,
@@ -123,8 +116,10 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
       var _ :- expect keyStore.GetBranchKeyVersion(inputV);
 
       // This is a best effort
-      var _ := CleanupItems.DeleteTypeWithFailure(testId, item.EncryptionContext["type"], ddbClient);
-      print testLogPrefix + " Validated Decrypt Only and tried to clean it up: " + item.EncryptionContext["type"] + "\n";
+      var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BRANCH_KEY_TYPE_PREFIX + versionUUID, ddbClient);
+      print testLogPrefix
+            + " Validated Decrypt Only and tried to clean it up: "
+            + Structure.BRANCH_KEY_TYPE_PREFIX + versionUUID + "\n";
       itemIndex := 1 + itemIndex;
     }
 
@@ -132,12 +127,7 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var lastActive? :- expect storage.GetEncryptedActiveBranchKey(lastActiveInput);
     expect lastActive?.Item.Type.ActiveHierarchicalSymmetricVersion?;
     var lastActive := lastActive?.Item.Type.ActiveHierarchicalSymmetricVersion;
-    expect
-      customEC in lastActive?.Item.EncryptionContext,
-                  "Koda should be a Key in the Custom Encryption Context for the ACTIVE.";
-    expect
-      lastActive?.Item.EncryptionContext[customEC] == timestamp,
-      "Koda's value should be the test timestamp for the ACTIVE.";
+    var _ := itemExpectations(lastActive?.Item, timestamp, unModeledAttri);
     var _ :- expect keyStore.GetActiveBranchKey(KeyStoreTypes.GetActiveBranchKeyInput(branchKeyIdentifier := testId));
     print testLogPrefix + " Active Validated with KMS/KeyStore: " + testId + "\n";
     var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BRANCH_KEY_ACTIVE_TYPE, ddbClient);
@@ -145,15 +135,32 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextAddValue {
     var beaconInput := KeyStoreTypes.GetEncryptedBeaconKeyInput(Identifier:=testId);
     var beacon? :- expect storage.GetEncryptedBeaconKey(beaconInput);
     expect beacon?.Item.Type.ActiveHierarchicalSymmetricBeacon?;
-    expect
-      customEC in beacon?.Item.EncryptionContext,
-                  "Koda should be a Key in the Custom Encryption Context for the Beacon.";
-    expect
-      beacon?.Item.EncryptionContext[customEC] == timestamp,
-      "Koda's value should be the test timestamp for the Beacon.";
+    var _ := itemExpectations(beacon?.Item, timestamp, unModeledAttri);
     var _ :- expect keyStore.GetBeaconKey(KeyStoreTypes.GetBeaconKeyInput(branchKeyIdentifier := testId));
     print testLogPrefix + " Beacon Validated with KMS/KeyStore: " + testId + "\n";
     var _ := CleanupItems.DeleteTypeWithFailure(testId, Structure.BEACON_KEY_TYPE_VALUE, ddbClient);
+  }
+
+  method itemExpectations(
+    item: KeyStoreTypes.EncryptedHierarchicalKey,
+    timestamp : string,
+    unModeledAttri : AdminFixtures.KeyValue
+  )
+    returns (output: bool)
+    ensures output ==> "type" in item.EncryptionContext
+  {
+    expect
+      customEC in item.EncryptionContext,
+                  "Koda should be a Key in the Custom Encryption Context of all items for this test.";
+    expect
+      item.EncryptionContext[customEC] == timestamp,
+      "Koda's value should be the test timestamp for all items for this test.";
+    expect "type" in item.EncryptionContext, "item is missing 'type' from EC!!";
+    expect unModeledAttri.key in item.EncryptionContext,
+                                 "un-modeled attribute was dropped!";
+    expect item.EncryptionContext[unModeledAttri.key] == unModeledAttri.value,
+      "un-modeled attribute value is incorrect";
+    return true;
   }
 }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationsUnModeledAttribute.dfy
@@ -14,7 +14,7 @@ include "../AdminFixtures.dfy"
 // - maintains un-modeled attributes in exsisting items
 // - projects un-modeled attributes to new items
 
-module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAttribute {
+module {:options "/functionSyntax:4" } TestMutationsUnModeledAttribute {
   import Types = AwsCryptographyKeyStoreAdminTypes
   import KeyStoreAdmin
   import KeyStore
@@ -38,9 +38,9 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAt
   const kmsId: string := Fixtures.keyArn
   const physicalName: string := Fixtures.branchKeyStoreName
   const logicalName: string := Fixtures.logicalKeyStoreName
-  const testLogPrefix := "\nTestMutationsEncryptionContextUnModeledAttribute :: TestHappyCase :: "
+  const testLogPrefix := "\nTestMutationsUnModeledAttribute :: TestHappyCase :: "
 
-  method {:test} {:vcs_split_on_every_assert} TestHappyCase()
+  method {:test} TestHappyCase()
   {
     print " running";
 
@@ -61,7 +61,7 @@ module {:options "/functionSyntax:4" } TestMutationsEncryptionContextUnModeledAt
     Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0, customEC:=originalEC);
 
     print testLogPrefix + " Created the legit test items with 1 versions! testId: " + testId + "\n";
-    var unModeledAttri := AdminFixtures.KeyValue();
+    var unModeledAttri := AdminFixtures.KeyValue(key:="Robbie", value:="Is a dog.");
     var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
       id:=testId,
       alsoViolateBeacon? := true,

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.6.0-SNAPSHOT"
+version = props.getProperty("mplVersion")
 description = "AWS Cryptographic Material Providers Library"
 
 sourceSets {

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -31,12 +31,18 @@ sourceSets {
         runtimeClasspath += sourceSets.test.get().output + sourceSets["examples"].output + sourceSets.main.get().output
     }
 }
-val examplesImplementation by configurations.getting{
+val examplesImplementation: Configuration by configurations.getting{
     extendsFrom(configurations.testImplementation.get())
 }
-val testExamplesImplementation by configurations.getting{
-    extendsFrom(configurations.testImplementation.get())
+configurations.add(examplesImplementation)
+val examplesAnnotationProcessor: Configuration by configurations.getting{
+    extendsFrom(configurations.testAnnotationProcessor.get())
 }
+configurations.add(examplesAnnotationProcessor)
+val testExamplesImplementation: Configuration by configurations.getting{
+    extendsFrom(configurations["examplesImplementation"])
+}
+configurations.add(testExamplesImplementation)
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))
@@ -107,13 +113,14 @@ dependencies {
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")
 
-    // Example Dependencies are marked as testImplementation
-    testImplementation("software.amazon.awssdk:arns")
-    testImplementation("software.amazon.awssdk:auth")
-    testImplementation("software.amazon.awssdk:sts")
-    testImplementation("software.amazon.awssdk:apache-client:2.19.0")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
-    testImplementation("com.google.code.findbugs:jsr305:3.0.2")
+    // Example Dependencies
+    examplesImplementation("software.amazon.awssdk:arns")
+    examplesImplementation("software.amazon.awssdk:auth")
+    examplesImplementation("software.amazon.awssdk:sts")
+    examplesImplementation("software.amazon.awssdk:utils")
+    examplesImplementation("software.amazon.awssdk:apache-client:2.19.0")
+    examplesAnnotationProcessor("org.projectlombok:lombok:1.18.30")
+    examplesImplementation("com.google.code.findbugs:jsr305:3.0.2")
 
 }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -3,7 +3,6 @@
 package software.amazon.cryptography.example;
 
 import javax.annotation.Nonnull;
-
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.regions.Region;

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/CredentialUtils.java
@@ -1,0 +1,50 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example;
+
+import javax.annotation.Nonnull;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+
+public class CredentialUtils {
+
+  public static StsAssumeRoleCredentialsProvider credsForRole(
+    @Nonnull String roleArn,
+    @Nonnull String roleSessionName,
+    @Nonnull Region region,
+    @Nonnull SdkHttpClient httpClient,
+    @Nonnull AwsCredentialsProvider creds
+  ) {
+    StsAssumeRoleCredentialsProvider provider = StsAssumeRoleCredentialsProvider
+      .builder()
+      .stsClient(
+        StsClient
+          .builder()
+          .httpClient(httpClient)
+          .region(region)
+          .credentialsProvider(creds)
+          .build()
+      )
+      .refreshRequest(
+        AssumeRoleRequest
+          .builder()
+          .roleArn(roleArn)
+          .roleSessionName(roleSessionName)
+          .durationSeconds(900) // 15 minutes by 60 seconds
+          .build()
+      )
+      .build();
+    // Force credential resolution.
+    // If the host does not have permission to use these credentials,
+    // we want to fail early.
+    // This may not be appropriate in a production environment,
+    // as it is "greedy initialization".
+    provider.resolveCredentials();
+    return provider;
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/AdminProvider.java
@@ -71,6 +71,6 @@ public class AdminProvider {
       .stream()
       .map(item -> String.format("%s : %s", item.itemType(), item.description())
       )
-      .collect(Collectors.joining(",\n "));
+      .collect(Collectors.joining(",\n"));
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/CreateKeyExample.java
@@ -4,8 +4,10 @@ package software.amazon.cryptography.example.hierarchy;
 
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.utils.StringUtils;
 import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
 import software.amazon.cryptography.keystoreadmin.model.CreateKeyInput;
 import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
@@ -25,9 +27,10 @@ import software.amazon.cryptography.keystoreadmin.model.KMSIdentifier;
 public class CreateKeyExample {
 
   public static String CreateKey(
-    String keyStoreTableName,
-    String logicalKeyStoreName,
-    String kmsKeyArn,
+    @Nonnull String keyStoreTableName,
+    @Nonnull String logicalKeyStoreName,
+    @Nonnull String kmsKeyArn,
+    @Nullable String branchKeyId,
     @Nullable DynamoDbClient dynamoDbClient
   ) {
     // 1. Configure your Key Store Admin resource.
@@ -42,8 +45,10 @@ public class CreateKeyExample {
     // If an Identifier is not provided, a v4 UUID will be generated and used.
     // This example provides a combination of a fixed string and a v4 UUID;
     // this makes it easy for Crypto Tools to clean up these Example Branch Keys.
-    final String branchKeyId =
-      "mpl-java-example-" + java.util.UUID.randomUUID().toString();
+    branchKeyId =
+      StringUtils.isBlank(branchKeyId)
+        ? "mpl-java-example-" + java.util.UUID.randomUUID().toString()
+        : branchKeyId;
 
     // 3. Create a custom encryption context for the Branch Key.
     // Most encrypted data should have an associated encryption context
@@ -90,6 +95,6 @@ public class CreateKeyExample {
     final String keyStoreTableName = args[0];
     final String logicalKeyStoreName = args[1];
     final String kmsKeyArn = args[2];
-    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null);
+    CreateKey(keyStoreTableName, logicalKeyStoreName, kmsKeyArn, null, null);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/IKeyStorageInterface.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/IKeyStorageInterface.java
@@ -3,6 +3,8 @@
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 package software.amazon.cryptography.keystore;
 
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedBeaconKeyInput;
@@ -13,6 +15,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutationOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 import software.amazon.cryptography.keystore.model.WriteInitializeMutationInput;
@@ -25,6 +29,12 @@ import software.amazon.cryptography.keystore.model.WriteNewEncryptedBranchKeyVer
 import software.amazon.cryptography.keystore.model.WriteNewEncryptedBranchKeyVersionOutput;
 
 public interface IKeyStorageInterface {
+  /**
+   * Overwrite an existing Mutation Lock.
+   *
+   */
+  ClobberMutationLockOutput ClobberMutationLock(ClobberMutationLockInput input);
+
   /**
    * Get the ACTIVE branch key for encryption for an existing branch key.
    *
@@ -72,6 +82,14 @@ public interface IKeyStorageInterface {
    * @return Output containing information about the underlying storage.
    */
   GetKeyStorageInfoOutput GetKeyStorageInfo(GetKeyStorageInfoInput input);
+
+  /**
+   * Check for Mutation Lock on a Branch Key ID.
+   * If one exists, returns the Mutation Lock.
+   * Otherwise, returns nothing.
+   *
+   */
+  GetMutationLockOutput GetMutationLock(GetMutationLockInput input);
 
   /**
    * Query Storage for a page of version (decrypt only) items

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStorageInterface.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStorageInterface.java
@@ -8,6 +8,8 @@ import java.lang.IllegalArgumentException;
 import java.lang.RuntimeException;
 import java.util.Objects;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.model.GetEncryptedActiveBranchKeyOutput;
 import software.amazon.cryptography.keystore.model.GetEncryptedBeaconKeyInput;
@@ -18,6 +20,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutationOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 import software.amazon.cryptography.keystore.model.WriteInitializeMutationInput;
@@ -67,6 +71,25 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
 
   public software.amazon.cryptography.keystore.internaldafny.types.IKeyStorageInterface impl() {
     return this._impl;
+  }
+
+  /**
+   * Overwrite an existing Mutation Lock.
+   *
+   */
+  public ClobberMutationLockOutput ClobberMutationLock(
+    ClobberMutationLockInput input
+  ) {
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyValue =
+      ToDafny.ClobberMutationLockInput(input);
+    Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > result = this._impl.ClobberMutationLock(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.ClobberMutationLockOutput(result.dtor_value());
   }
 
   /**
@@ -172,6 +195,25 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
       throw ToNative.Error(result.dtor_error());
     }
     return ToNative.GetKeyStorageInfoOutput(result.dtor_value());
+  }
+
+  /**
+   * Check for Mutation Lock on a Branch Key ID.
+   * If one exists, returns the Mutation Lock.
+   * Otherwise, returns nothing.
+   *
+   */
+  public GetMutationLockOutput GetMutationLock(GetMutationLockInput input) {
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyValue =
+      ToDafny.GetMutationLockInput(input);
+    Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > result = this._impl.GetMutationLock(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.GetMutationLockOutput(result.dtor_value());
   }
 
   /**
@@ -305,6 +347,42 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
         );
       }
       this._impl = nativeImpl;
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > ClobberMutationLock(
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyInput
+    ) {
+      try {
+        ClobberMutationLockInput nativeInput =
+          ToNative.ClobberMutationLockInput(dafnyInput);
+        ClobberMutationLockOutput nativeOutput =
+          this._impl.ClobberMutationLock(nativeInput);
+        software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput dafnyOutput =
+          ToDafny.ClobberMutationLockOutput(nativeOutput);
+        return Result.create_Success(
+          software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          dafnyOutput
+        );
+      } catch (RuntimeException ex) {
+        return Result.create_Failure(
+          software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          ToDafny.Error(ex)
+        );
+      }
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput,
+      Error
+    > ClobberMutationLock_k(
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyInput
+    ) {
+      throw new RuntimeException("Not supported at this time.");
     }
 
     public Result<
@@ -484,6 +562,43 @@ public final class KeyStorageInterface implements IKeyStorageInterface {
       Error
     > GetKeyStorageInfo_k(
       software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoInput dafnyInput
+    ) {
+      throw new RuntimeException("Not supported at this time.");
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > GetMutationLock(
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyInput
+    ) {
+      try {
+        GetMutationLockInput nativeInput = ToNative.GetMutationLockInput(
+          dafnyInput
+        );
+        GetMutationLockOutput nativeOutput =
+          this._impl.GetMutationLock(nativeInput);
+        software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput dafnyOutput =
+          ToDafny.GetMutationLockOutput(nativeOutput);
+        return Result.create_Success(
+          software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          dafnyOutput
+        );
+      } catch (RuntimeException ex) {
+        return Result.create_Failure(
+          software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput._typeDescriptor(),
+          Error._typeDescriptor(),
+          ToDafny.Error(ex)
+        );
+      }
+    }
+
+    public Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput,
+      Error
+    > GetMutationLock_k(
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyInput
     ) {
       throw new RuntimeException("Not supported at this time.");
     }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -23,6 +23,8 @@ import software.amazon.cryptography.keystore.internaldafny.types.ActiveHierarchi
 import software.amazon.cryptography.keystore.internaldafny.types.AwsKms;
 import software.amazon.cryptography.keystore.internaldafny.types.BeaconKeyMaterials;
 import software.amazon.cryptography.keystore.internaldafny.types.BranchKeyMaterials;
+import software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.CreateKeyStoreInput;
@@ -31,8 +33,12 @@ import software.amazon.cryptography.keystore.internaldafny.types.Discovery;
 import software.amazon.cryptography.keystore.internaldafny.types.DynamoDBTable;
 import software.amazon.cryptography.keystore.internaldafny.types.EncryptedHierarchicalKey;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException;
 import software.amazon.cryptography.keystore.internaldafny.types.GetActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetActiveBranchKeyOutput;
@@ -51,6 +57,8 @@ import software.amazon.cryptography.keystore.internaldafny.types.GetItemsForInit
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStorageInfoOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType;
 import software.amazon.cryptography.keystore.internaldafny.types.HierarchicalSymmetric;
 import software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient;
@@ -72,9 +80,13 @@ import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncrypt
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionInput;
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionOutput;
+import software.amazon.cryptography.keystore.model.AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.model.CollectionOfErrors;
 import software.amazon.cryptography.keystore.model.KeyStorageException;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
+import software.amazon.cryptography.keystore.model.MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.model.NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.model.OldEncConditionFailed;
 import software.amazon.cryptography.keystore.model.OpaqueError;
 import software.amazon.cryptography.keystore.model.VersionRaceException;
 import software.amazon.cryptography.services.dynamodb.internaldafny.types.IDynamoDBClient;
@@ -83,11 +95,23 @@ import software.amazon.cryptography.services.kms.internaldafny.types.IKMSClient;
 public class ToDafny {
 
   public static Error Error(RuntimeException nativeValue) {
+    if (nativeValue instanceof AlreadyExistsConditionFailed) {
+      return ToDafny.Error((AlreadyExistsConditionFailed) nativeValue);
+    }
     if (nativeValue instanceof KeyStorageException) {
       return ToDafny.Error((KeyStorageException) nativeValue);
     }
     if (nativeValue instanceof KeyStoreException) {
       return ToDafny.Error((KeyStoreException) nativeValue);
+    }
+    if (nativeValue instanceof MutationLockConditionFailed) {
+      return ToDafny.Error((MutationLockConditionFailed) nativeValue);
+    }
+    if (nativeValue instanceof NoLongerExistsConditionFailed) {
+      return ToDafny.Error((NoLongerExistsConditionFailed) nativeValue);
+    }
+    if (nativeValue instanceof OldEncConditionFailed) {
+      return ToDafny.Error((OldEncConditionFailed) nativeValue);
     }
     if (nativeValue instanceof VersionRaceException) {
       return ToDafny.Error((VersionRaceException) nativeValue);
@@ -255,6 +279,20 @@ public class ToDafny {
       encryptionContext,
       branchKey
     );
+  }
+
+  public static ClobberMutationLockInput ClobberMutationLockInput(
+    software.amazon.cryptography.keystore.model.ClobberMutationLockInput nativeValue
+  ) {
+    MutationLock mutationLock;
+    mutationLock = ToDafny.MutationLock(nativeValue.mutationLock());
+    return new ClobberMutationLockInput(mutationLock);
+  }
+
+  public static ClobberMutationLockOutput ClobberMutationLockOutput(
+    software.amazon.cryptography.keystore.model.ClobberMutationLockOutput nativeValue
+  ) {
+    return new ClobberMutationLockOutput();
   }
 
   public static CreateKeyInput CreateKeyInput(
@@ -606,6 +644,31 @@ public class ToDafny {
     );
   }
 
+  public static GetMutationLockInput GetMutationLockInput(
+    software.amazon.cryptography.keystore.model.GetMutationLockInput nativeValue
+  ) {
+    DafnySequence<? extends Character> identifier;
+    identifier =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.Identifier()
+      );
+    return new GetMutationLockInput(identifier);
+  }
+
+  public static GetMutationLockOutput GetMutationLockOutput(
+    software.amazon.cryptography.keystore.model.GetMutationLockOutput nativeValue
+  ) {
+    Option<MutationLock> mutationLock;
+    mutationLock =
+      Objects.nonNull(nativeValue.mutationLock())
+        ? Option.create_Some(
+          MutationLock._typeDescriptor(),
+          ToDafny.MutationLock(nativeValue.mutationLock())
+        )
+        : Option.create_None(MutationLock._typeDescriptor());
+    return new GetMutationLockOutput(mutationLock);
+  }
+
   public static HierarchicalSymmetric HierarchicalSymmetric(
     software.amazon.cryptography.keystore.model.HierarchicalSymmetric nativeValue
   ) {
@@ -919,6 +982,15 @@ public class ToDafny {
     return new WriteNewEncryptedBranchKeyVersionOutput();
   }
 
+  public static Error Error(AlreadyExistsConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_AlreadyExistsConditionFailed(message);
+  }
+
   public static Error Error(KeyStorageException nativeValue) {
     DafnySequence<? extends Character> message;
     message =
@@ -935,6 +1007,33 @@ public class ToDafny {
         nativeValue.message()
       );
     return new Error_KeyStoreException(message);
+  }
+
+  public static Error Error(MutationLockConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationLockConditionFailed(message);
+  }
+
+  public static Error Error(NoLongerExistsConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_NoLongerExistsConditionFailed(message);
+  }
+
+  public static Error Error(OldEncConditionFailed nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_OldEncConditionFailed(message);
   }
 
   public static Error Error(VersionRaceException nativeValue) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -13,17 +13,24 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_CollectionOfErrors;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_Opaque;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException;
 import software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient;
 import software.amazon.cryptography.keystore.model.ActiveHierarchicalSymmetric;
 import software.amazon.cryptography.keystore.model.ActiveHierarchicalSymmetricBeacon;
+import software.amazon.cryptography.keystore.model.AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.model.AwsKms;
 import software.amazon.cryptography.keystore.model.BeaconKeyMaterials;
 import software.amazon.cryptography.keystore.model.BranchKeyMaterials;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockInput;
+import software.amazon.cryptography.keystore.model.ClobberMutationLockOutput;
 import software.amazon.cryptography.keystore.model.CollectionOfErrors;
 import software.amazon.cryptography.keystore.model.CreateKeyInput;
 import software.amazon.cryptography.keystore.model.CreateKeyOutput;
@@ -49,6 +56,8 @@ import software.amazon.cryptography.keystore.model.GetItemsForInitializeMutation
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
 import software.amazon.cryptography.keystore.model.GetKeyStorageInfoOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStoreInfoOutput;
+import software.amazon.cryptography.keystore.model.GetMutationLockInput;
+import software.amazon.cryptography.keystore.model.GetMutationLockOutput;
 import software.amazon.cryptography.keystore.model.HierarchicalKeyType;
 import software.amazon.cryptography.keystore.model.HierarchicalSymmetric;
 import software.amazon.cryptography.keystore.model.KMSConfiguration;
@@ -58,6 +67,9 @@ import software.amazon.cryptography.keystore.model.KeyStoreConfig;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
 import software.amazon.cryptography.keystore.model.MRDiscovery;
 import software.amazon.cryptography.keystore.model.MutationLock;
+import software.amazon.cryptography.keystore.model.MutationLockConditionFailed;
+import software.amazon.cryptography.keystore.model.NoLongerExistsConditionFailed;
+import software.amazon.cryptography.keystore.model.OldEncConditionFailed;
 import software.amazon.cryptography.keystore.model.OpaqueError;
 import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
 import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
@@ -98,6 +110,19 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static AlreadyExistsConditionFailed Error(
+    Error_AlreadyExistsConditionFailed dafnyValue
+  ) {
+    AlreadyExistsConditionFailed.Builder nativeBuilder =
+      AlreadyExistsConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static KeyStorageException Error(
     Error_KeyStorageException dafnyValue
   ) {
@@ -120,6 +145,45 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static MutationLockConditionFailed Error(
+    Error_MutationLockConditionFailed dafnyValue
+  ) {
+    MutationLockConditionFailed.Builder nativeBuilder =
+      MutationLockConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static NoLongerExistsConditionFailed Error(
+    Error_NoLongerExistsConditionFailed dafnyValue
+  ) {
+    NoLongerExistsConditionFailed.Builder nativeBuilder =
+      NoLongerExistsConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static OldEncConditionFailed Error(
+    Error_OldEncConditionFailed dafnyValue
+  ) {
+    OldEncConditionFailed.Builder nativeBuilder =
+      OldEncConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static VersionRaceException Error(
     Error_VersionRaceException dafnyValue
   ) {
@@ -133,11 +197,23 @@ public class ToNative {
   }
 
   public static RuntimeException Error(Error dafnyValue) {
+    if (dafnyValue.is_AlreadyExistsConditionFailed()) {
+      return ToNative.Error((Error_AlreadyExistsConditionFailed) dafnyValue);
+    }
     if (dafnyValue.is_KeyStorageException()) {
       return ToNative.Error((Error_KeyStorageException) dafnyValue);
     }
     if (dafnyValue.is_KeyStoreException()) {
       return ToNative.Error((Error_KeyStoreException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationLockConditionFailed()) {
+      return ToNative.Error((Error_MutationLockConditionFailed) dafnyValue);
+    }
+    if (dafnyValue.is_NoLongerExistsConditionFailed()) {
+      return ToNative.Error((Error_NoLongerExistsConditionFailed) dafnyValue);
+    }
+    if (dafnyValue.is_OldEncConditionFailed()) {
+      return ToNative.Error((Error_OldEncConditionFailed) dafnyValue);
     }
     if (dafnyValue.is_VersionRaceException()) {
       return ToNative.Error((Error_VersionRaceException) dafnyValue);
@@ -252,6 +328,25 @@ public class ToNative {
         dafnyValue.dtor_branchKey()
       )
     );
+    return nativeBuilder.build();
+  }
+
+  public static ClobberMutationLockInput ClobberMutationLockInput(
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput dafnyValue
+  ) {
+    ClobberMutationLockInput.Builder nativeBuilder =
+      ClobberMutationLockInput.builder();
+    nativeBuilder.mutationLock(
+      ToNative.MutationLock(dafnyValue.dtor_mutationLock())
+    );
+    return nativeBuilder.build();
+  }
+
+  public static ClobberMutationLockOutput ClobberMutationLockOutput(
+    software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput dafnyValue
+  ) {
+    ClobberMutationLockOutput.Builder nativeBuilder =
+      ClobberMutationLockOutput.builder();
     return nativeBuilder.build();
   }
 
@@ -601,6 +696,31 @@ public class ToNative {
     nativeBuilder.kmsConfiguration(
       ToNative.KMSConfiguration(dafnyValue.dtor_kmsConfiguration())
     );
+    return nativeBuilder.build();
+  }
+
+  public static GetMutationLockInput GetMutationLockInput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput dafnyValue
+  ) {
+    GetMutationLockInput.Builder nativeBuilder = GetMutationLockInput.builder();
+    nativeBuilder.Identifier(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_Identifier()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static GetMutationLockOutput GetMutationLockOutput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput dafnyValue
+  ) {
+    GetMutationLockOutput.Builder nativeBuilder =
+      GetMutationLockOutput.builder();
+    if (dafnyValue.dtor_mutationLock().is_Some()) {
+      nativeBuilder.mutationLock(
+        ToNative.MutationLock(dafnyValue.dtor_mutationLock().dtor_value())
+      );
+    }
     return nativeBuilder.build();
   }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/AlreadyExistsConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/AlreadyExistsConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed. An item already exists for this Branch Key ID & Type.
  */
-public class MutationInvalidException extends RuntimeException {
+public class AlreadyExistsConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected AlreadyExistsConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    AlreadyExistsConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(AlreadyExistsConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public AlreadyExistsConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new AlreadyExistsConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockInput.java
@@ -1,0 +1,88 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.Objects;
+
+public class ClobberMutationLockInput {
+
+  /**
+   * Information an in-flight Mutation of a Branch Key.
+   * This ensures:
+   * - only one Mutation affects a Branch Key at a time
+   * - all items of a Branch Key are mutated consistently
+   */
+  private final MutationLock mutationLock;
+
+  protected ClobberMutationLockInput(BuilderImpl builder) {
+    this.mutationLock = builder.mutationLock();
+  }
+
+  /**
+   * @return Information an in-flight Mutation of a Branch Key.
+   * This ensures:
+   * - only one Mutation affects a Branch Key at a time
+   * - all items of a Branch Key are mutated consistently
+   */
+  public MutationLock mutationLock() {
+    return this.mutationLock;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param mutationLock Information an in-flight Mutation of a Branch Key.
+     * This ensures:
+     * - only one Mutation affects a Branch Key at a time
+     * - all items of a Branch Key are mutated consistently
+     */
+    Builder mutationLock(MutationLock mutationLock);
+
+    /**
+     * @return Information an in-flight Mutation of a Branch Key.
+     * This ensures:
+     * - only one Mutation affects a Branch Key at a time
+     * - all items of a Branch Key are mutated consistently
+     */
+    MutationLock mutationLock();
+
+    ClobberMutationLockInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected MutationLock mutationLock;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(ClobberMutationLockInput model) {
+      this.mutationLock = model.mutationLock();
+    }
+
+    public Builder mutationLock(MutationLock mutationLock) {
+      this.mutationLock = mutationLock;
+      return this;
+    }
+
+    public MutationLock mutationLock() {
+      return this.mutationLock;
+    }
+
+    public ClobberMutationLockInput build() {
+      if (Objects.isNull(this.mutationLock())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `mutationLock`"
+        );
+      }
+      return new ClobberMutationLockInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/ClobberMutationLockOutput.java
@@ -1,0 +1,32 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+public class ClobberMutationLockOutput {
+
+  protected ClobberMutationLockOutput(BuilderImpl builder) {}
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    ClobberMutationLockOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(ClobberMutationLockOutput model) {}
+
+    public ClobberMutationLockOutput build() {
+      return new ClobberMutationLockOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockInput.java
@@ -1,0 +1,76 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.Objects;
+
+public class GetMutationLockInput {
+
+  /**
+   * The Branch Key to check for a Mutation Lock.
+   */
+  private final String Identifier;
+
+  protected GetMutationLockInput(BuilderImpl builder) {
+    this.Identifier = builder.Identifier();
+  }
+
+  /**
+   * @return The Branch Key to check for a Mutation Lock.
+   */
+  public String Identifier() {
+    return this.Identifier;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param Identifier The Branch Key to check for a Mutation Lock.
+     */
+    Builder Identifier(String Identifier);
+
+    /**
+     * @return The Branch Key to check for a Mutation Lock.
+     */
+    String Identifier();
+
+    GetMutationLockInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected String Identifier;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetMutationLockInput model) {
+      this.Identifier = model.Identifier();
+    }
+
+    public Builder Identifier(String Identifier) {
+      this.Identifier = Identifier;
+      return this;
+    }
+
+    public String Identifier() {
+      return this.Identifier;
+    }
+
+    public GetMutationLockInput build() {
+      if (Objects.isNull(this.Identifier())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `Identifier`"
+        );
+      }
+      return new GetMutationLockInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetMutationLockOutput.java
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+public class GetMutationLockOutput {
+
+  /**
+   * If not present, there is no Mutation Lock.
+   */
+  private final MutationLock mutationLock;
+
+  protected GetMutationLockOutput(BuilderImpl builder) {
+    this.mutationLock = builder.mutationLock();
+  }
+
+  /**
+   * @return If not present, there is no Mutation Lock.
+   */
+  public MutationLock mutationLock() {
+    return this.mutationLock;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param mutationLock If not present, there is no Mutation Lock.
+     */
+    Builder mutationLock(MutationLock mutationLock);
+
+    /**
+     * @return If not present, there is no Mutation Lock.
+     */
+    MutationLock mutationLock();
+
+    GetMutationLockOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected MutationLock mutationLock;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetMutationLockOutput model) {
+      this.mutationLock = model.mutationLock();
+    }
+
+    public Builder mutationLock(MutationLock mutationLock) {
+      this.mutationLock = mutationLock;
+      return this;
+    }
+
+    public MutationLock mutationLock() {
+      return this.mutationLock;
+    }
+
+    public GetMutationLockOutput build() {
+      return new GetMutationLockOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/MutationLockConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/MutationLockConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed due to Mutation Lock condition failure.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationLockConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationLockConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationLockConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationLockConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationLockConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationLockConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/NoLongerExistsConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/NoLongerExistsConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed. Item was deleted since it was read.
  */
-public class MutationInvalidException extends RuntimeException {
+public class NoLongerExistsConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected NoLongerExistsConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    NoLongerExistsConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(NoLongerExistsConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public NoLongerExistsConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new NoLongerExistsConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/OldEncConditionFailed.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/OldEncConditionFailed.java
@@ -1,17 +1,16 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 // Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
-package software.amazon.cryptography.keystoreadmin.model;
+package software.amazon.cryptography.keystore.model;
 
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Write to Storage failed; cipher-text attribute of an item was updated since it was read.
  */
-public class MutationInvalidException extends RuntimeException {
+public class OldEncConditionFailed extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected OldEncConditionFailed(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +67,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    OldEncConditionFailed build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +78,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(OldEncConditionFailed model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +101,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public OldEncConditionFailed build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new OldEncConditionFailed(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/WriteMutatedVersionsInput.java
@@ -30,7 +30,7 @@ public class WriteMutatedVersionsInput {
   private final ByteBuffer Terminal;
 
   /**
-   * If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+   * If set to True, the Mutation Lock will be deleted.
    */
   private final Boolean CompleteMutation;
 
@@ -71,7 +71,7 @@ public class WriteMutatedVersionsInput {
   }
 
   /**
-   * @return If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+   * @return If set to True, the Mutation Lock will be deleted.
    */
   public Boolean CompleteMutation() {
     return this.CompleteMutation;
@@ -127,12 +127,12 @@ public class WriteMutatedVersionsInput {
     ByteBuffer Terminal();
 
     /**
-     * @param CompleteMutation If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+     * @param CompleteMutation If set to True, the Mutation Lock will be deleted.
      */
     Builder CompleteMutation(Boolean CompleteMutation);
 
     /**
-     * @return If set to True, the Mutation Lock will be deleted. Effectively defaults to false
+     * @return If set to True, the Mutation Lock will be deleted.
      */
     Boolean CompleteMutation();
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToDafny.java
@@ -23,8 +23,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.CreateKeyO
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.IKeyStoreAdminClient;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.InitializeMutationInput;
@@ -41,8 +44,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.VersionKey
 import software.amazon.cryptography.keystoreadmin.model.CollectionOfErrors;
 import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.model.MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.model.MutationFromException;
 import software.amazon.cryptography.keystoreadmin.model.MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.model.MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.model.MutationToException;
+import software.amazon.cryptography.keystoreadmin.model.MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.model.OpaqueError;
 import software.amazon.cryptography.keystoreadmin.model.UnexpectedStateException;
 
@@ -55,11 +61,20 @@ public class ToDafny {
     if (nativeValue instanceof MutationConflictException) {
       return ToDafny.Error((MutationConflictException) nativeValue);
     }
+    if (nativeValue instanceof MutationFromException) {
+      return ToDafny.Error((MutationFromException) nativeValue);
+    }
     if (nativeValue instanceof MutationInvalidException) {
       return ToDafny.Error((MutationInvalidException) nativeValue);
     }
     if (nativeValue instanceof MutationLockInvalidException) {
       return ToDafny.Error((MutationLockInvalidException) nativeValue);
+    }
+    if (nativeValue instanceof MutationToException) {
+      return ToDafny.Error((MutationToException) nativeValue);
+    }
+    if (nativeValue instanceof MutationVerificationException) {
+      return ToDafny.Error((MutationVerificationException) nativeValue);
     }
     if (nativeValue instanceof UnexpectedStateException) {
       return ToDafny.Error((UnexpectedStateException) nativeValue);
@@ -409,6 +424,15 @@ public class ToDafny {
     return new Error_MutationConflictException(message);
   }
 
+  public static Error Error(MutationFromException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationFromException(message);
+  }
+
   public static Error Error(MutationInvalidException nativeValue) {
     DafnySequence<? extends Character> message;
     message =
@@ -425,6 +449,24 @@ public class ToDafny {
         nativeValue.message()
       );
     return new Error_MutationLockInvalidException(message);
+  }
+
+  public static Error Error(MutationToException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationToException(message);
+  }
+
+  public static Error Error(MutationVerificationException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_MutationVerificationException(message);
   }
 
   public static Error Error(UnexpectedStateException nativeValue) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/ToNative.java
@@ -10,8 +10,11 @@ import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_CollectionOfErrors;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException;
+import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_Opaque;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException;
 import software.amazon.cryptography.keystoreadmin.internaldafny.types.IKeyStoreAdminClient;
@@ -30,9 +33,12 @@ import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
 import software.amazon.cryptography.keystoreadmin.model.MutatedBranchKeyItem;
 import software.amazon.cryptography.keystoreadmin.model.MutationComplete;
 import software.amazon.cryptography.keystoreadmin.model.MutationConflictException;
+import software.amazon.cryptography.keystoreadmin.model.MutationFromException;
 import software.amazon.cryptography.keystoreadmin.model.MutationInvalidException;
 import software.amazon.cryptography.keystoreadmin.model.MutationLockInvalidException;
+import software.amazon.cryptography.keystoreadmin.model.MutationToException;
 import software.amazon.cryptography.keystoreadmin.model.MutationToken;
+import software.amazon.cryptography.keystoreadmin.model.MutationVerificationException;
 import software.amazon.cryptography.keystoreadmin.model.Mutations;
 import software.amazon.cryptography.keystoreadmin.model.OpaqueError;
 import software.amazon.cryptography.keystoreadmin.model.UnexpectedStateException;
@@ -89,6 +95,19 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static MutationFromException Error(
+    Error_MutationFromException dafnyValue
+  ) {
+    MutationFromException.Builder nativeBuilder =
+      MutationFromException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
   public static MutationInvalidException Error(
     Error_MutationInvalidException dafnyValue
   ) {
@@ -107,6 +126,31 @@ public class ToNative {
   ) {
     MutationLockInvalidException.Builder nativeBuilder =
       MutationLockInvalidException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static MutationToException Error(
+    Error_MutationToException dafnyValue
+  ) {
+    MutationToException.Builder nativeBuilder = MutationToException.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static MutationVerificationException Error(
+    Error_MutationVerificationException dafnyValue
+  ) {
+    MutationVerificationException.Builder nativeBuilder =
+      MutationVerificationException.builder();
     nativeBuilder.message(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
         dafnyValue.dtor_message()
@@ -135,11 +179,20 @@ public class ToNative {
     if (dafnyValue.is_MutationConflictException()) {
       return ToNative.Error((Error_MutationConflictException) dafnyValue);
     }
+    if (dafnyValue.is_MutationFromException()) {
+      return ToNative.Error((Error_MutationFromException) dafnyValue);
+    }
     if (dafnyValue.is_MutationInvalidException()) {
       return ToNative.Error((Error_MutationInvalidException) dafnyValue);
     }
     if (dafnyValue.is_MutationLockInvalidException()) {
       return ToNative.Error((Error_MutationLockInvalidException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationToException()) {
+      return ToNative.Error((Error_MutationToException) dafnyValue);
+    }
+    if (dafnyValue.is_MutationVerificationException()) {
+      return ToNative.Error((Error_MutationVerificationException) dafnyValue);
     }
     if (dafnyValue.is_UnexpectedStateException()) {
       return ToNative.Error((Error_UnexpectedStateException) dafnyValue);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationFromException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationFromException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while mutating
+ * an item from original to terminal.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationFromException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationFromException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationFromException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationFromException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationFromException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationFromException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationLockInvalidException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationLockInvalidException.java
@@ -6,7 +6,12 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Mutation Lock is failing authentication. Mutation Lock still exists but Mutation cannot proceed. No items were changed. Recommend identifying latest author of Mutation Lock and validating their access.
+ * Mutation Lock disagrees with provided Mutation Token.
+ * Mutation Lock still exists but Mutation cannot proceed.
+ * No items were changed.
+ * Recommend identifying latest author of Mutation Lock
+ * and validating their access;
+ * or checking the integrity of Mutation Token.
  */
 public class MutationLockInvalidException extends RuntimeException {
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationToException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationToException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while mutating
+ * an item from original to terminal.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationToException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationToException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationToException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationToException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationToException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationToException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationVerificationException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/MutationVerificationException.java
@@ -6,12 +6,13 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * Branch Key Authorization failed while Initializing the Mutation.
- * No Mutation Lock was created; no items were changed.
+ * Key Management generic error encountered while authenticating
+ * an item already in the terminal state.
+ * Possibly, access to the terminal KMS Key was withdrawn.
  */
-public class MutationInvalidException extends RuntimeException {
+public class MutationVerificationException extends RuntimeException {
 
-  protected MutationInvalidException(BuilderImpl builder) {
+  protected MutationVerificationException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -68,7 +69,7 @@ public class MutationInvalidException extends RuntimeException {
      */
     Throwable cause();
 
-    MutationInvalidException build();
+    MutationVerificationException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -79,7 +80,7 @@ public class MutationInvalidException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(MutationInvalidException model) {
+    protected BuilderImpl(MutationVerificationException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -102,13 +103,13 @@ public class MutationInvalidException extends RuntimeException {
       return this.cause;
     }
 
-    public MutationInvalidException build() {
+    public MutationVerificationException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new MutationInvalidException(this);
+      return new MutationVerificationException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/UnexpectedStateException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystoreadmin/model/UnexpectedStateException.java
@@ -6,7 +6,14 @@ package software.amazon.cryptography.keystoreadmin.model;
 import java.util.Objects;
 
 /**
- * An Item was encountered that is not in an expected state. Mutation Lock is still present; no items were changed by this request. Recommend audting backing table access; an Item of a Branch Key MUST only be in one of two states during a Mutation; this item is in a third state.
+ * An Item was encountered that is not
+ * in an expected state.
+ * Mutation Lock is still present;
+ * no items were changed by this request.
+ * Recommend audting backing table access;
+ * an Item of a Branch Key MUST be in
+ * either the original or terminal states during a Mutation;
+ * encountered item(s) in other states.
  */
 public class UnexpectedStateException extends RuntimeException {
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/Fixtures.java
@@ -10,11 +10,16 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.GetKeyStorageInfoInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class Fixtures {
 
@@ -25,6 +30,17 @@ public class Fixtures {
     "arn:aws:kms:us-west-2:370957321024:key/bc127593-f7da-452c-a1f3-cd34c46f81f8";
   public static final String KEYSTORE_KMS_ARN =
     "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126";
+  public static final String MRK_ARN_EAST =
+    "arn:aws:kms:us-east-1:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String MRK_ARN_WEST =
+    "arn:aws:kms:us-west-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  // Key MUST NOT exist in ap-south-2
+  public static final String MRK_ARN_AP =
+    "arn:aws:kms:ap-south-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String LIMITED_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-Limited-KMS-us-west-2";
+  public static final String NO_KMS_ACCESS_IAM_ROLE =
+    "arn:aws:iam::370957321024:role/GitHub-CI-MPL-No-KMS-us-west-2";
 
   public static final AwsCredentialsProvider defaultCreds =
     DefaultCredentialsProvider.create();
@@ -32,15 +48,23 @@ public class Fixtures {
     .builder()
     .connectionTimeToLive(Duration.ofSeconds(5))
     .build();
-  public static final DynamoDbClient dynamoDbClient = DynamoDbClient
+  public static final DynamoDbClient ddbClientWest2 = DynamoDbClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
     .build();
-  public static final KmsClient kmsClient = KmsClient
+  public static final KmsClient kmsClientWest2 = KmsClient
     .builder()
     .httpClient(httpClient)
     .credentialsProvider(defaultCreds)
+    .region(Region.US_WEST_2)
+    .build();
+  public static final KmsClient kmsClientEast1 = KmsClient
+    .builder()
+    .httpClient(httpClient)
+    .credentialsProvider(defaultCreds)
+    .region(Region.US_EAST_1)
     .build();
 
   public static void deleteKeyStoreDdbItem(
@@ -76,6 +100,45 @@ public class Fixtures {
     dynamoDbClient = AdminProvider.dynamoDB(dynamoDbClient);
     return dynamoDbClient.getItem(builder ->
       builder.tableName(physicalName).key(ddbKey)
+    );
+  }
+
+  public static void cleanUpBranchKeyId(
+    KeyStorageInterface storage,
+    String branchKeyId
+  ) {
+    QueryForVersionsOutput versions = storage.QueryForVersions(
+      QueryForVersionsInput
+        .builder()
+        .Identifier(branchKeyId)
+        .pageSize(99)
+        .build()
+    );
+    String physicalName = storage
+      .GetKeyStorageInfo(GetKeyStorageInfoInput.builder().build())
+      .Name();
+    versions
+      .items()
+      .forEach(item ->
+        deleteKeyStoreDdbItem(
+          item.Identifier(),
+          item.EncryptionContext().get("type"),
+          physicalName,
+          ddbClientWest2
+        )
+      );
+
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "branch:ACTIVE",
+      physicalName,
+      ddbClientWest2
+    );
+    deleteKeyStoreDdbItem(
+      branchKeyId,
+      "beacon:ACTIVE",
+      physicalName,
+      ddbClientWest2
     );
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
@@ -5,8 +5,6 @@ package software.amazon.cryptography.example.hierarchy;
 import org.testng.annotations.Test;
 import software.amazon.cryptography.example.Fixtures;
 import software.amazon.cryptography.keystore.KeyStorageInterface;
-import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
-import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
 
 public class ExampleTests {
 
@@ -16,7 +14,8 @@ public class ExampleTests {
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
       Fixtures.KEYSTORE_KMS_ARN,
-      Fixtures.dynamoDbClient
+      null,
+      Fixtures.ddbClientWest2
     );
     branchKeyId =
       MutationExample.End2End(
@@ -24,8 +23,8 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient,
-        Fixtures.kmsClient
+        Fixtures.ddbClientWest2,
+        Fixtures.kmsClientWest2
       );
     branchKeyId =
       VersionKeyExample.VersionKey(
@@ -33,42 +32,13 @@ public class ExampleTests {
         Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
         Fixtures.POSTAL_HORN_KEY_ARN,
         branchKeyId,
-        Fixtures.dynamoDbClient
+        Fixtures.ddbClientWest2
       );
     KeyStorageInterface storage = StorageCheater.create(
-      Fixtures.dynamoDbClient,
+      Fixtures.ddbClientWest2,
       Fixtures.TEST_KEYSTORE_NAME,
       Fixtures.TEST_LOGICAL_KEYSTORE_NAME
     );
-    QueryForVersionsOutput versions = storage.QueryForVersions(
-      QueryForVersionsInput
-        .builder()
-        .Identifier(branchKeyId)
-        .pageSize(10)
-        .build()
-    );
-    versions
-      .items()
-      .forEach(item ->
-        Fixtures.deleteKeyStoreDdbItem(
-          item.Identifier(),
-          item.Type().HierarchicalSymmetricVersion().Version(),
-          Fixtures.TEST_KEYSTORE_NAME,
-          Fixtures.dynamoDbClient
-        )
-      );
-
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "branch:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
-    Fixtures.deleteKeyStoreDdbItem(
-      branchKeyId,
-      "beacon:ACTIVE",
-      Fixtures.TEST_KEYSTORE_NAME,
-      Fixtures.dynamoDbClient
-    );
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -1,0 +1,160 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.cryptography.example.CredentialUtils;
+import software.amazon.cryptography.keystore.KeyStorageInterface;
+import software.amazon.cryptography.keystore.model.QueryForVersionsInput;
+import software.amazon.cryptography.keystore.model.QueryForVersionsOutput;
+import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.ApplyMutationResult;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationInput;
+import software.amazon.cryptography.keystoreadmin.model.InitializeMutationOutput;
+import software.amazon.cryptography.keystoreadmin.model.KeyManagementStrategy;
+import software.amazon.cryptography.keystoreadmin.model.MutationToken;
+import software.amazon.cryptography.keystoreadmin.model.Mutations;
+import software.amazon.cryptography.example.Fixtures;
+
+import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;
+import static software.amazon.cryptography.example.Fixtures.POSTAL_HORN_KEY_ARN;
+
+public class MutationKmsAccessInFlightTest {
+  static final String testPrefix = "mutation-kms-access-in-flight-test-";
+  @Test
+  public void test() {
+    KeyStorageInterface storage = StorageCheater.create(
+      Fixtures.ddbClientWest2,
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME
+    );
+    final String branchKeyId = testPrefix + java.util.UUID.randomUUID().toString();
+    CreateKeyExample.CreateKey(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      POSTAL_HORN_KEY_ARN,
+      branchKeyId,
+      Fixtures.ddbClientWest2
+    );
+    KeyManagementStrategy strategyWest2 = AdminProvider.strategy(Fixtures.kmsClientWest2);
+    KmsClient denyMrk = KmsClient.builder()
+        .credentialsProvider(
+          CredentialUtils.credsForRole(
+            Fixtures.LIMITED_KMS_ACCESS_IAM_ROLE,
+            "java-mpl-examples",
+            Region.US_WEST_2,
+            Fixtures.httpClient,
+            Fixtures.defaultCreds))
+      .region(Region.US_WEST_2)
+      .httpClient(Fixtures.httpClient)
+      .build();
+
+    KeyManagementStrategy strategyDenyMrk = AdminProvider.strategy(denyMrk);
+    KeyStoreAdmin admin = AdminProvider.admin(
+      Fixtures.TEST_KEYSTORE_NAME,
+      Fixtures.TEST_LOGICAL_KEYSTORE_NAME,
+      Fixtures.ddbClientWest2
+    );
+
+    System.out.println("BranchKey ID to mutate: " + branchKeyId);
+    HashMap<String, String> terminalEC = new HashMap<>();
+    terminalEC.put("Robbie", "is a dog.");
+
+    Mutations mutations = Mutations
+      .builder()
+      .terminalEncryptionContext(terminalEC)
+      .terminalKmsArn(MRK_ARN_WEST)
+      .build();
+
+    InitializeMutationInput initInput = InitializeMutationInput
+      .builder()
+      .mutations(mutations)
+      .branchKeyIdentifier(branchKeyId)
+      .strategy(strategyWest2)
+      .build();
+
+    InitializeMutationOutput initOutput = admin.InitializeMutation(initInput);
+    MutationToken token = initOutput.mutationToken();
+    System.out.println(
+      "InitLogs: " +
+      branchKeyId +
+      " items: \n" +
+      AdminProvider.mutatedItemsToString(initOutput.mutatedBranchKeyItems())
+    );
+    boolean done = false;
+    List<KmsException> kmsExceptions = new ArrayList<>();
+    boolean isFromThrown = false;
+    boolean isToThrown = false;
+    int limitLoop = 5;
+
+    while (!done) {
+      try {
+        limitLoop--;
+        if (limitLoop == 0) done = true;
+        ApplyMutationInput applyInput = ApplyMutationInput
+          .builder()
+          .mutationToken(token)
+          .pageSize(1)
+          .strategy(strategyDenyMrk)
+          .build();
+        ApplyMutationOutput applyOutput = admin.ApplyMutation(applyInput);
+        ApplyMutationResult result = applyOutput.result();
+        System.out.println(
+          "ApplyLogs: " +
+          branchKeyId +
+          " items: \n" +
+          AdminProvider.mutatedItemsToString(applyOutput.mutatedBranchKeyItems())
+        );
+
+        if (result.continueMutation() != null) token = result.continueMutation();
+        if (result.completeMutation() != null) done = true;
+
+      } catch (KmsException accessDenied) {
+        boolean isFrom = accessDenied.getMessage().contains("ReEncryptFrom");
+        isFromThrown = isFromThrown || isFrom;
+        boolean isTo = accessDenied.getMessage().contains("ReEncryptTo");
+        isToThrown = isToThrown || isTo;
+        Assert.assertTrue((isTo || isFrom),
+          "KMS Exception does not meet expectations. testId: " + branchKeyId + ". KMS Exception: " + accessDenied);
+        kmsExceptions.add(accessDenied);
+        // An exception was thrown, let's delete the item
+        QueryForVersionsOutput versions = storage.QueryForVersions(
+          QueryForVersionsInput
+            .builder()
+            .Identifier(branchKeyId)
+            .pageSize(1)
+            .build()
+        );
+        versions
+          .items()
+          .forEach(item ->
+            Fixtures.deleteKeyStoreDdbItem(
+              item.Identifier(),
+              item.EncryptionContext().get("type"),
+              Fixtures.TEST_KEYSTORE_NAME,
+              Fixtures.ddbClientWest2
+            )
+          );
+      }
+    }
+
+    // Clean Up
+    Fixtures.cleanUpBranchKeyId(storage, branchKeyId);
+    Assert.assertTrue((kmsExceptions.size() == 2),
+      "More KMS Exceptions thrown than expected. kmsExceptions: " + kmsExceptions);
+    Assert.assertTrue(isFromThrown, "Apply never verified the new decrypt.");
+    Assert.assertTrue(isToThrown, "Apply never mutated the old decrypt.");
+  }
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/MutationKmsAccessInFlightTest.java
@@ -151,14 +151,21 @@ public class MutationKmsAccessInFlightTest {
         );
         versions
           .items()
-          .forEach(item ->
+          .forEach(item -> {
+            String typStr = item.EncryptionContext().get("type");
             Fixtures.deleteKeyStoreDdbItem(
               item.Identifier(),
-              item.EncryptionContext().get("type"),
+              typStr,
               Fixtures.TEST_KEYSTORE_NAME,
               Fixtures.ddbClientWest2
-            )
-          );
+            );
+            System.out.println(
+              "\nItem: " +
+              typStr +
+              " \tKMS Exception: " +
+              accessDenied.getMessage()
+            );
+          });
       }
     }
 

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/AlreadyExistsConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/AlreadyExistsConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class AlreadyExistsConditionFailed : Exception
+  {
+    public AlreadyExistsConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockInput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class ClobberMutationLockInput
+  {
+    private AWS.Cryptography.KeyStore.MutationLock _mutationLock;
+    public AWS.Cryptography.KeyStore.MutationLock MutationLock
+    {
+      get { return this._mutationLock; }
+      set { this._mutationLock = value; }
+    }
+    public bool IsSetMutationLock()
+    {
+      return this._mutationLock != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetMutationLock()) throw new System.ArgumentException("Missing value for required property 'MutationLock'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/ClobberMutationLockOutput.cs
@@ -1,0 +1,17 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class ClobberMutationLockOutput
+  {
+
+
+    public void Validate()
+    {
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockInput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetMutationLockInput
+  {
+    private string _identifier;
+    public string Identifier
+    {
+      get { return this._identifier; }
+      set { this._identifier = value; }
+    }
+    public bool IsSetIdentifier()
+    {
+      return this._identifier != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetMutationLockOutput.cs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetMutationLockOutput
+  {
+    private AWS.Cryptography.KeyStore.MutationLock _mutationLock;
+    public AWS.Cryptography.KeyStore.MutationLock MutationLock
+    {
+      get { return this._mutationLock; }
+      set { this._mutationLock = value; }
+    }
+    public bool IsSetMutationLock()
+    {
+      return this._mutationLock != null;
+    }
+    public void Validate()
+    {
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/IKeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/IKeyStorageInterface.cs
@@ -17,5 +17,7 @@ namespace AWS.Cryptography.KeyStore
     AWS.Cryptography.KeyStore.WriteInitializeMutationOutput WriteInitializeMutation(AWS.Cryptography.KeyStore.WriteInitializeMutationInput input);
     AWS.Cryptography.KeyStore.QueryForVersionsOutput QueryForVersions(AWS.Cryptography.KeyStore.QueryForVersionsInput input);
     AWS.Cryptography.KeyStore.WriteMutatedVersionsOutput WriteMutatedVersions(AWS.Cryptography.KeyStore.WriteMutatedVersionsInput input);
+    AWS.Cryptography.KeyStore.GetMutationLockOutput GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input);
+    AWS.Cryptography.KeyStore.ClobberMutationLockOutput ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterface.cs
@@ -47,6 +47,13 @@ namespace AWS.Cryptography.KeyStore
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
       return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S35_GetItemsForInitializeMutationOutput(result.dtor_value);
     }
+    protected override AWS.Cryptography.KeyStore.GetMutationLockOutput _GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.GetMutationLock(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(result.dtor_value);
+    }
     protected override AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionOutput _WriteNewEncryptedBranchKeyVersion(AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionInput input)
     {
       software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S38_WriteNewEncryptedBranchKeyVersionInput(input);
@@ -60,6 +67,13 @@ namespace AWS.Cryptography.KeyStore
       Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.QueryForVersions(internalInput);
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
       return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_QueryForVersionsOutput(result.dtor_value);
+    }
+    protected override AWS.Cryptography.KeyStore.ClobberMutationLockOutput _ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = this._impl.ClobberMutationLock(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(result.dtor_value);
     }
     protected override AWS.Cryptography.KeyStore.GetKeyStorageInfoOutput _GetKeyStorageInfo(AWS.Cryptography.KeyStore.GetKeyStorageInfoInput input)
     {

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterfaceBase.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStorageInterfaceBase.cs
@@ -57,5 +57,15 @@ namespace AWS.Cryptography.KeyStore
       input.Validate(); return _WriteMutatedVersions(input);
     }
     protected abstract AWS.Cryptography.KeyStore.WriteMutatedVersionsOutput _WriteMutatedVersions(AWS.Cryptography.KeyStore.WriteMutatedVersionsInput input);
+    public AWS.Cryptography.KeyStore.GetMutationLockOutput GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input)
+    {
+      input.Validate(); return _GetMutationLock(input);
+    }
+    protected abstract AWS.Cryptography.KeyStore.GetMutationLockOutput _GetMutationLock(AWS.Cryptography.KeyStore.GetMutationLockInput input);
+    public AWS.Cryptography.KeyStore.ClobberMutationLockOutput ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input)
+    {
+      input.Validate(); return _ClobberMutationLock(input);
+    }
+    protected abstract AWS.Cryptography.KeyStore.ClobberMutationLockOutput _ClobberMutationLock(AWS.Cryptography.KeyStore.ClobberMutationLockInput input);
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/MutationLockConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/MutationLockConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class MutationLockConditionFailed : Exception
+  {
+    public MutationLockConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NativeWrapper_KeyStorageInterface.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NativeWrapper_KeyStorageInterface.cs
@@ -157,6 +157,34 @@ namespace AWS.Cryptography.KeyStore
     {
       throw new KeyStoreException("Not supported at this time.");
     }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> GetMutationLock(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput input)
+    {
+      void validateOutput(AWS.Cryptography.KeyStore.GetMutationLockOutput nativeOutput)
+      {
+        try { nativeOutput.Validate(); }
+        catch (ArgumentException e)
+        {
+          var message = $"Output of {_impl}._GetMutationLock is invalid. {e.Message}";
+          throw new KeyStoreException(message);
+        }
+      }
+      AWS.Cryptography.KeyStore.GetMutationLockInput nativeInput = TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(input);
+      try
+      {
+        AWS.Cryptography.KeyStore.GetMutationLockOutput nativeOutput = _impl.GetMutationLock(nativeInput);
+        _ = nativeOutput ?? throw new KeyStoreException($"{_impl}._GetMutationLock returned null, should be {typeof(AWS.Cryptography.KeyStore.GetMutationLockOutput)}");
+        validateOutput(nativeOutput);
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Success(TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(nativeOutput));
+      }
+      catch (Exception e)
+      {
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Failure(TypeConversion.ToDafny_CommonError(e));
+      }
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> GetMutationLock_k(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput input)
+    {
+      throw new KeyStoreException("Not supported at this time.");
+    }
     public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> WriteNewEncryptedBranchKeyVersion(software.amazon.cryptography.keystore.internaldafny.types._IWriteNewEncryptedBranchKeyVersionInput input)
     {
       void validateOutput(AWS.Cryptography.KeyStore.WriteNewEncryptedBranchKeyVersionOutput nativeOutput)
@@ -210,6 +238,34 @@ namespace AWS.Cryptography.KeyStore
       }
     }
     public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> QueryForVersions_k(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput input)
+    {
+      throw new KeyStoreException("Not supported at this time.");
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> ClobberMutationLock(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput input)
+    {
+      void validateOutput(AWS.Cryptography.KeyStore.ClobberMutationLockOutput nativeOutput)
+      {
+        try { nativeOutput.Validate(); }
+        catch (ArgumentException e)
+        {
+          var message = $"Output of {_impl}._ClobberMutationLock is invalid. {e.Message}";
+          throw new KeyStoreException(message);
+        }
+      }
+      AWS.Cryptography.KeyStore.ClobberMutationLockInput nativeInput = TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(input);
+      try
+      {
+        AWS.Cryptography.KeyStore.ClobberMutationLockOutput nativeOutput = _impl.ClobberMutationLock(nativeInput);
+        _ = nativeOutput ?? throw new KeyStoreException($"{_impl}._ClobberMutationLock returned null, should be {typeof(AWS.Cryptography.KeyStore.ClobberMutationLockOutput)}");
+        validateOutput(nativeOutput);
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Success(TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(nativeOutput));
+      }
+      catch (Exception e)
+      {
+        return Wrappers_Compile.Result<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError>.create_Failure(TypeConversion.ToDafny_CommonError(e));
+      }
+    }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> ClobberMutationLock_k(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput input)
     {
       throw new KeyStoreException("Not supported at this time.");
     }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NoLongerExistsConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/NoLongerExistsConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class NoLongerExistsConditionFailed : Exception
+  {
+    public NoLongerExistsConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/OldEncConditionFailed.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/OldEncConditionFailed.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class OldEncConditionFailed : Exception
+  {
+    public OldEncConditionFailed(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -11,6 +11,39 @@ namespace AWS.Cryptography.KeyStore
 
     private const string ISO8601DateFormatNoMS = "yyyy-MM-dd\\THH:mm:ss\\Z";
 
+    public static AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.ClobberMutationLockInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput)value; AWS.Cryptography.KeyStore.ClobberMutationLockInput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockInput(); converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(concrete._mutationLock); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput(AWS.Cryptography.KeyStore.ClobberMutationLockInput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(value.MutationLock));
+    }
+    public static AWS.Cryptography.KeyStore.ClobberMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput)value; AWS.Cryptography.KeyStore.ClobberMutationLockOutput converted = new AWS.Cryptography.KeyStore.ClobberMutationLockOutput(); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IClobberMutationLockOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_ClobberMutationLockOutput(AWS.Cryptography.KeyStore.ClobberMutationLockOutput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.ClobberMutationLockOutput();
+    }
     public static AWS.Cryptography.KeyStore.CreateKeyInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput(software.amazon.cryptography.keystore.internaldafny.types._ICreateKeyInput value)
     {
       software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput)value; AWS.Cryptography.KeyStore.CreateKeyInput converted = new AWS.Cryptography.KeyStore.CreateKeyInput(); if (concrete._branchKeyIdentifier.is_Some) converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
@@ -232,6 +265,26 @@ namespace AWS.Cryptography.KeyStore
 
       return new software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M10_keyStoreId(value.KeyStoreId), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M12_keyStoreName(value.KeyStoreName), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M19_logicalKeyStoreName(value.LogicalKeyStoreName), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M11_grantTokens(value.GrantTokens), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput__M16_kmsConfiguration(value.KmsConfiguration));
     }
+    public static AWS.Cryptography.KeyStore.GetMutationLockInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput)value; AWS.Cryptography.KeyStore.GetMutationLockInput converted = new AWS.Cryptography.KeyStore.GetMutationLockInput(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(concrete._Identifier); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput(AWS.Cryptography.KeyStore.GetMutationLockInput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(value.Identifier));
+    }
+    public static AWS.Cryptography.KeyStore.GetMutationLockOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput)value; AWS.Cryptography.KeyStore.GetMutationLockOutput converted = new AWS.Cryptography.KeyStore.GetMutationLockOutput(); if (concrete._mutationLock.is_Some) converted.MutationLock = (AWS.Cryptography.KeyStore.MutationLock)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(concrete._mutationLock); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetMutationLockOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput(AWS.Cryptography.KeyStore.GetMutationLockOutput value)
+    {
+      value.Validate();
+      AWS.Cryptography.KeyStore.MutationLock var_mutationLock = value.IsSetMutationLock() ? value.MutationLock : (AWS.Cryptography.KeyStore.MutationLock)null;
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetMutationLockOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(var_mutationLock));
+    }
     public static AWS.Cryptography.KeyStore.HierarchicalKeyType FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_HierarchicalKeyType(software.amazon.cryptography.keystore.internaldafny.types._IHierarchicalKeyType value)
     {
       software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType concrete = (software.amazon.cryptography.keystore.internaldafny.types.HierarchicalKeyType)value;
@@ -380,6 +433,45 @@ namespace AWS.Cryptography.KeyStore
         return software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration.create_mrDiscovery(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_mrDiscovery(value.MrDiscovery));
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStore.KMSConfiguration state");
+    }
+    public static AWS.Cryptography.KeyStore.MutationLockConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.MutationLockConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(AWS.Cryptography.KeyStore.MutationLockConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStore.OldEncConditionFailed FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed value)
+    {
+      return new AWS.Cryptography.KeyStore.OldEncConditionFailed(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(AWS.Cryptography.KeyStore.OldEncConditionFailed value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(value.Message)
+      );
     }
     public static AWS.Cryptography.KeyStore.QueryForVersionsInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput(software.amazon.cryptography.keystore.internaldafny.types._IQueryForVersionsInput value)
     {
@@ -555,6 +647,22 @@ namespace AWS.Cryptography.KeyStore
       value.Validate();
 
       return new software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionOutput();
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_ClobberMutationLockInput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value);
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput__M19_branchKeyIdentifier(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
     {
@@ -788,6 +896,22 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration(value);
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_GetMutationLockInput__M10_Identifier(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> value)
+    {
+      return value.is_None ? (AWS.Cryptography.KeyStore.MutationLock)null : FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(value.Extract());
+    }
+    public static Wrappers_Compile._IOption<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetMutationLockOutput__M12_mutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      return value == null ? Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_None() : Wrappers_Compile.Option<software.amazon.cryptography.keystore.internaldafny.types._IMutationLock>.create_Some(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock((AWS.Cryptography.KeyStore.MutationLock)value));
+    }
     public static AWS.Cryptography.KeyStore.ActiveHierarchicalSymmetric FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_HierarchicalKeyType__M34_ActiveHierarchicalSymmetricVersion(software.amazon.cryptography.keystore.internaldafny.types._IActiveHierarchicalSymmetric value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_ActiveHierarchicalSymmetric(value);
@@ -939,6 +1063,30 @@ namespace AWS.Cryptography.KeyStore
     public static software.amazon.cryptography.keystore.internaldafny.types._IMRDiscovery ToDafny_N3_aws__N12_cryptography__N8_keyStore__S16_KMSConfiguration__M11_mrDiscovery(AWS.Cryptography.KeyStore.MRDiscovery value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S11_MRDiscovery(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_QueryForVersionsInput__M17_exclusiveStartKey(Wrappers_Compile._IOption<Dafny.ISequence<byte>> value)
     {
@@ -1148,6 +1296,20 @@ namespace AWS.Cryptography.KeyStore
     {
       return Dafny.Sequence<char>.FromString(value);
     }
+    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.MutationLock concrete = (software.amazon.cryptography.keystore.internaldafny.types.MutationLock)value; AWS.Cryptography.KeyStore.MutationLock converted = new AWS.Cryptography.KeyStore.MutationLock(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(concrete._Identifier);
+      converted.CreateTime = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(concrete._CreateTime);
+      converted.UUID = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(concrete._UUID);
+      converted.Original = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(concrete._Original);
+      converted.Terminal = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(concrete._Terminal); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.MutationLock(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(value.UUID), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(value.Terminal));
+    }
     public static System.Collections.Generic.Dictionary<string, string> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext(Dafny.IMap<Dafny.ISequence<byte>, Dafny.ISequence<byte>> value)
     {
       return value.ItemEnumerable.ToDictionary(pair => FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M3_key(pair.Car), pair => FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M5_value(pair.Cdr));
@@ -1207,20 +1369,6 @@ namespace AWS.Cryptography.KeyStore
       value.Validate();
 
       return new software.amazon.cryptography.keystore.internaldafny.types.EncryptedHierarchicalKey(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M4_Type(value.Type), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M6_KmsArn(value.KmsArn), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M17_EncryptionContext(value.EncryptionContext), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M14_CiphertextBlob(value.CiphertextBlob));
-    }
-    public static AWS.Cryptography.KeyStore.MutationLock FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(software.amazon.cryptography.keystore.internaldafny.types._IMutationLock value)
-    {
-      software.amazon.cryptography.keystore.internaldafny.types.MutationLock concrete = (software.amazon.cryptography.keystore.internaldafny.types.MutationLock)value; AWS.Cryptography.KeyStore.MutationLock converted = new AWS.Cryptography.KeyStore.MutationLock(); converted.Identifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(concrete._Identifier);
-      converted.CreateTime = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(concrete._CreateTime);
-      converted.UUID = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(concrete._UUID);
-      converted.Original = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(concrete._Original);
-      converted.Terminal = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(concrete._Terminal); return converted;
-    }
-    public static software.amazon.cryptography.keystore.internaldafny.types._IMutationLock ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock(AWS.Cryptography.KeyStore.MutationLock value)
-    {
-      value.Validate();
-
-      return new software.amazon.cryptography.keystore.internaldafny.types.MutationLock(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(value.Identifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(value.CreateTime), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(value.UUID), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(value.Original), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(value.Terminal));
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(Dafny.ISequence<byte> value)
     {
@@ -1405,6 +1553,46 @@ namespace AWS.Cryptography.KeyStore
     {
       return value;
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext__M3_key(Dafny.ISequence<byte> value)
     {
       return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S9_Utf8Bytes(value);
@@ -1530,46 +1718,6 @@ namespace AWS.Cryptography.KeyStore
       return FromDafny_N6_smithy__N3_api__S4_Blob(value);
     }
     public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S24_EncryptedHierarchicalKey__M14_CiphertextBlob(System.IO.MemoryStream value)
-    {
-      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_Identifier(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M10_CreateTime(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(Dafny.ISequence<char> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M4_UUID(string value)
-    {
-      return ToDafny_N6_smithy__N3_api__S6_String(value);
-    }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(Dafny.ISequence<byte> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Original(System.IO.MemoryStream value)
-    {
-      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(Dafny.ISequence<byte> value)
-    {
-      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
-    }
-    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S12_MutationLock__M8_Terminal(System.IO.MemoryStream value)
     {
       return ToDafny_N6_smithy__N3_api__S4_Blob(value);
     }
@@ -1730,10 +1878,18 @@ namespace AWS.Cryptography.KeyStore
           return Com.Amazonaws.Kms.TypeConversion.FromDafny_CommonError( // Manual edit KMS. -> Kms.
             dafnyVal._ComAmazonawsKms
           );
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S17_KeyStoreException(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_NoLongerExistsConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_OldEncConditionFailed dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_VersionRaceException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S20_VersionRaceException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_CollectionOfErrors dafnyVal:
@@ -1763,10 +1919,18 @@ namespace AWS.Cryptography.KeyStore
       }
       switch (value)
       {
+        case AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(exception);
         case AWS.Cryptography.KeyStore.KeyStorageException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(exception);
         case AWS.Cryptography.KeyStore.KeyStoreException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S17_KeyStoreException(exception);
+        case AWS.Cryptography.KeyStore.MutationLockConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S27_MutationLockConditionFailed(exception);
+        case AWS.Cryptography.KeyStore.NoLongerExistsConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S29_NoLongerExistsConditionFailed(exception);
+        case AWS.Cryptography.KeyStore.OldEncConditionFailed exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S21_OldEncConditionFailed(exception);
         case AWS.Cryptography.KeyStore.VersionRaceException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S20_VersionRaceException(exception);
         case CollectionOfErrors collectionOfErrors:

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/WriteMutatedVersionsInput.cs
@@ -11,7 +11,7 @@ namespace AWS.Cryptography.KeyStore
     private string _identifier;
     private System.IO.MemoryStream _original;
     private System.IO.MemoryStream _terminal;
-    private bool? _completeMutation = false; // Manual edit to default false
+    private bool? _completeMutation;
     public System.Collections.Generic.List<AWS.Cryptography.KeyStore.EncryptedHierarchicalKey> Items
     {
       get { return this._items; }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationFromException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationFromException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationFromException : Exception
+  {
+    public MutationFromException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationToException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationToException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationToException : Exception
+  {
+    public MutationToException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationVerificationException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/MutationVerificationException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStoreAdmin;
+namespace AWS.Cryptography.KeyStoreAdmin
+{
+  public class MutationVerificationException : Exception
+  {
+    public MutationVerificationException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStoreAdmin/TypeConversion.cs
@@ -192,6 +192,19 @@ namespace AWS.Cryptography.KeyStoreAdmin
       ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException__M7_message(value.Message)
       );
     }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationFromException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationFromException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(AWS.Cryptography.KeyStoreAdmin.MutationFromException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(value.Message)
+      );
+    }
     public static AWS.Cryptography.KeyStoreAdmin.MutationInvalidException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException value)
     {
       return new AWS.Cryptography.KeyStoreAdmin.MutationInvalidException(
@@ -216,6 +229,32 @@ namespace AWS.Cryptography.KeyStoreAdmin
 
       return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException(
       ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationToException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationToException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(AWS.Cryptography.KeyStoreAdmin.MutationToException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(value.Message)
+      );
+    }
+    public static AWS.Cryptography.KeyStoreAdmin.MutationVerificationException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException value)
+    {
+      return new AWS.Cryptography.KeyStoreAdmin.MutationVerificationException(
+      FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(AWS.Cryptography.KeyStoreAdmin.MutationVerificationException value)
+    {
+
+      return new software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException(
+      ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(value.Message)
       );
     }
     public static AWS.Cryptography.KeyStoreAdmin.UnexpectedStateException FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException value)
@@ -445,6 +484,14 @@ namespace AWS.Cryptography.KeyStoreAdmin
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
     public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException__M7_message(Dafny.ISequence<char> value)
     {
       return FromDafny_N6_smithy__N3_api__S6_String(value);
@@ -458,6 +505,22 @@ namespace AWS.Cryptography.KeyStoreAdmin
       return FromDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException__M7_message(string value)
     {
       return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
@@ -908,10 +971,16 @@ namespace AWS.Cryptography.KeyStoreAdmin
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S22_KeyStoreAdminException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationConflictException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationFromException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationInvalidException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationLockInvalidException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationToException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(dafnyVal);
+        case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_MutationVerificationException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_UnexpectedStateException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(dafnyVal);
         case software.amazon.cryptography.keystoreadmin.internaldafny.types.Error_CollectionOfErrors dafnyVal:
@@ -945,10 +1014,16 @@ namespace AWS.Cryptography.KeyStoreAdmin
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S22_KeyStoreAdminException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationConflictException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S25_MutationConflictException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationFromException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S21_MutationFromException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationInvalidException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_MutationInvalidException(exception);
         case AWS.Cryptography.KeyStoreAdmin.MutationLockInvalidException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S28_MutationLockInvalidException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationToException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S19_MutationToException(exception);
+        case AWS.Cryptography.KeyStoreAdmin.MutationVerificationException exception:
+          return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S29_MutationVerificationException(exception);
         case AWS.Cryptography.KeyStoreAdmin.UnexpectedStateException exception:
           return ToDafny_N3_aws__N12_cryptography__N13_keyStoreAdmin__S24_UnexpectedStateException(exception);
         case CollectionOfErrors collectionOfErrors:

--- a/ComAmazonawsDynamodb/codegen-patches/dotnet/dafny-4.8.0.patch
+++ b/ComAmazonawsDynamodb/codegen-patches/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs a/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
-index e35ad3d2..9f375b21 100644
+index e35ad3d2d..9f375b21c 100644
 --- b/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
 +++ a/ComAmazonawsDynamodb/runtimes/net/Generated/TypeConversion.cs
 @@ -5848,7 +5848,7 @@ namespace Com.Amazonaws.Dynamodb

--- a/ComAmazonawsKms/codegen-patches/dotnet/dafny-4.8.0.patch
+++ b/ComAmazonawsKms/codegen-patches/dotnet/dafny-4.8.0.patch
@@ -1,5 +1,5 @@
 diff --git b/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs a/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
-index f479e07b..46aff0c7 100644
+index f479e07b9..46aff0c76 100644
 --- b/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
 +++ a/ComAmazonawsKms/runtimes/net/Generated/TypeConversion.cs
 @@ -5510,7 +5510,7 @@ namespace Com.Amazonaws.Kms

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.6.0-SNAPSHOT"
+version = props.getProperty("mplVersion")
 description = "TestAwsCryptographicMaterialProviders"
 
 java {
@@ -68,7 +68,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.6.0-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${version}")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.8.0
 dafnyVerifyVersion=4.8.0
-mplVersion=1.6.0-SNAPSHOT
+mplVersion=1.8.0-rc


### PR DESCRIPTION
The Key Store Admin client exposes administrative
operations for the Branch Keys used by the
AWS KMS Hierarchical Keyring.

These Operations are:
- Create Key
- Version Key
- Initialize Mutation
- Apply Mutation

See the Java Examples directory for the
AWS Cryptographic Materials Provider for details:
`AwsCryptographicMaterialProviders/runtimes/java/src/examples`

### Changes from rc-1.7.0

- Initialize Mutation now uses `ddb:TransactGetItems` instead of `ddb:BatchGetItems`.
- To better facilitate DDB Queries,
  we changed the type string (sort key in key store table)
  of the mutation lock from `MUTATION_LOCK` to `branch:MUTATION_LOCK`.
  This is a breaking change that will corrupt any in-flight mutations.
  As Branch Key Mutations is only present in release-candidate branches,
  no customers are impacted by this breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
