### PR TITLE
chore: Merge main

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
@@ -261,8 +261,8 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
   method CreateAwsKmsHierarchicalKeyring (config: InternalConfig, input: CreateAwsKmsHierarchicalKeyringInput)
     returns (output: Result<IKeyring, Error>)
   {
-    //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#initialization
-    //= type=implication
+    // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#initialization
+    // //= type=implication
     //# If the Hierarchical Keyring does NOT get a `Shared` cache on initialization,
     //# it MUST initialize a [cryptographic-materials-cache](../local-cryptographic-materials-cache.md)
     //# with the user provided cache limit TTL and the entry capacity.
@@ -291,8 +291,8 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
       );
     }
 
-    //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#partition-id
-    //= type=implication
+    // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#partition-id
+    // //= type=implication
     //# PartitionId can be a string provided by the user. If provided, it MUST be interpreted as UTF8 bytes.
     //# If the PartitionId is NOT provided by the user, it MUST be set to the 16 byte representation of a v4 UUID.
     var partitionIdBytes : seq<uint8>;
@@ -314,8 +314,8 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
       .MapFailure(e => Types.AwsCryptographicMaterialProvidersException(message := e));
     }
 
-    //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#logical-key-store-name
-    //= type=implication
+    // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#logical-key-store-name
+    // //= type=implication
     //# Logical Key Store Name is set by the user when configuring the Key Store for
     //# the Hierarchical Keyring. This is a logical name for the key store.
     //# Logical Key Store Name MUST be converted to UTF8 Bytes to be used in

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -423,7 +423,7 @@ module AwsKmsHierarchicalKeyring {
         && 0 <= |branchKeyId| < UINT32_LIMIT,
         E("Invalid Branch Key ID Length")
       );
-      //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#encryption-materials
+      // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#encryption-materials
       //# When the hierarchical keyring receives an OnEncrypt request,
       //# the cache entry identifier MUST be calculated as the
       //# SHA-384 hash of the following byte strings, in the order listed:
@@ -484,7 +484,7 @@ module AwsKmsHierarchicalKeyring {
 
       var now := Time.GetCurrent();
 
-      //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#onencrypt
+      // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#onencrypt
       //# If using a `Shared` cache across multiple Hierarchical Keyrings,
       //# different keyrings having the same `branchKey` can have different TTLs.
       //# In such a case, the expiry time in the cache is set according to the Keyring that populated the cache.
@@ -796,7 +796,7 @@ module AwsKmsHierarchicalKeyring {
         && 0 <= |branchKeyId| < UINT32_LIMIT,
         E("Invalid Branch Key ID Length")
       );
-      //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#decryption-materials
+      // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#decryption-materials
       //# When the hierarchical keyring receives an OnDecrypt request,
       //# it MUST calculate the cache entry identifier as the
       //# SHA-384 hash of the following byte strings, in the order listed:
@@ -866,7 +866,7 @@ module AwsKmsHierarchicalKeyring {
 
       var now := Time.GetCurrent();
 
-      //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#ondecrypt
+      // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#ondecrypt
       //# If using a `Shared` cache across multiple Hierarchical Keyrings,
       //# different keyrings having the same `branchKey` can have different TTLs.
       //# In such a case, the expiry time in the cache is set according to the Keyring that populated the cache.

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.6.0-SNAPSHOT"
+version = "1.7.0-SNAPSHOT"
 description = "AWS Cryptographic Material Providers Library"
 
 sourceSets {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.6.0</Version>
+      <Version>1.7.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# [1.7.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.6.0...v1.7.0) (2024-09-23)
+
+### Features
+
+- **HierarchyKeyring; CMC:** Shared cache across Hierarchy Keyrings ([#747](https://github.com/aws/aws-cryptographic-material-providers-library/issues/747)) ([d4709e9](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d4709e91fe05180ea13712cf657373515493a3f1))
+
 # [1.6.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.5.1...v1.6.0) (2024-09-10)
 
 ### Bug Fixes

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.6.0")]
+[assembly: AssemblyVersion("1.7.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.6.0-SNAPSHOT"
+version = "1.7.0-SNAPSHOT"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {
@@ -68,7 +68,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.6.0-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.7.0-SNAPSHOT")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.8.0
 dafnyVerifyVersion=4.8.0
-mplVersion=1.6.0-SNAPSHOT
+mplVersion=1.7.0-SNAPSHOT


### PR DESCRIPTION
### Description
This is a merge from main.

```
git checkout rc-1.7.0 --recurse-submodules
git merge main --no-commit
git checkout -b tony/rc-1.7.0-merge-main
# resolve merge conflicts
git commit 
```

### CI
CI Failure on Mac OS .NET 6.0 ([dd6fea5](https://github.com/aws/aws-cryptographic-material-providers-library/pull/786/commits/dd6fea5c83d8931a42cbff34589ca5049c8a9fd3)):
```
 TestGetItemsForInitializeMutation.TestHappyCase: FAILED
	dafny/AwsCryptographyKeyStore/test/Storage/TestGetItemsForInitializeMutation.dfy(30,18): Wrappers.Result.Failure(AwsCryptographyKeyStoreTypes.Error.KeyStorageException(DDB through an exception for GetItemsForInitializeMutation's TransactGetItems. Table Name: KeyStoreDdbTable	Branch Key ID: 75789115-1deb-4fe3-a2ec-be9e885d1945	DDB Message: Transaction cancelled, please refer cancellation reasons for specific reasons [None, TransactionConflict, TransactionConflict]))
```

This is interesting,
and highlights the discussion between @seebees and I
about using Query instead of Transact Get Items.

For every CI execution testing the MPL,
a request to `TransactGetItem` is made.

These requests can conflict,
resulting in a Transaction Cancelled event.

Do a certain degree, this is a benefit.

At least in the context of fetching items for initializing mutations,
this would prevent two mutations from starting on the same Branch Key
before the Mutation Lock was even created.

i.e: This is a bug as a potentially cost saving feature,
since the failed read prevents the KMS operations 
that would have been thrown away anyhow.

Pretty interesting,
but upsetting that this will cause our CI to be flaky.

I can implement a re-try behavior for the test...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
