### PR TITLE
feat(Mutations-TODO): Some Terminal KMS Exceptions

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -818,6 +818,9 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     | AlreadyExistsConditionFailed (
         nameonly message: string
       )
+    | KeyManagementException (
+        nameonly message: string
+      )
     | KeyStorageException (
         nameonly message: string
       )

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
@@ -433,8 +433,37 @@ structure KeyStoreException {
 // Can be thrown by InitializeMutation & VersionKey
 @error("client")
 @retryable
-@documentation("Operation was rejected due to a race with VersionKey. No items were changed. Retry operation when no other agent is Versioning this Branch Key ID.")
+@documentation(
+"Operation was rejected due to a race with VersionKey.
+No items were changed.
+Retry operation when no other agent is Versioning this Branch Key ID.")
 structure VersionRaceException {
   @required
   message: String,
 }
+
+// This should be used very carefully.
+// It is often better to simply return the KMS Exception,
+// rather than obscuring it with this.
+// However, in cases where the KMS response
+// is invalid due to Client Side Validation,
+// this MAY be a better error to throw than
+// the generic local service exception.
+// See https://github.com/smithy-lang/smithy-dafny/issues/614
+@error("client")
+@documentation("AWS KMS request was unsuccesful or response was invalid.")
+structure KeyManagementException {
+  @required
+  message: String
+}
+
+@error("client")
+@documentation("AWS KMS request was unsuccesful or response was invalid.")
+structure ComAmazonawsKms {
+  error: com.amazonaws.kms#Error
+}
+
+union com.amazonaws.kms#Error (
+  AlreadyExistsException: com.amazonaws.kms#AlreadyExistsException
+  CloudHsmClusterInUseException: com.amazonaws.kms#CloudHsmClusterInUseException
+)

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
@@ -456,14 +456,3 @@ structure KeyManagementException {
   @required
   message: String
 }
-
-@error("client")
-@documentation("AWS KMS request was unsuccesful or response was invalid.")
-structure ComAmazonawsKms {
-  error: com.amazonaws.kms#Error
-}
-
-union com.amazonaws.kms#Error (
-  AlreadyExistsException: com.amazonaws.kms#AlreadyExistsException
-  CloudHsmClusterInUseException: com.amazonaws.kms#CloudHsmClusterInUseException
-)

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestConfig.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestConfig.dfy
@@ -83,9 +83,9 @@ module TestConfig {
   }
 
 
-  method {:test} TestValidConfig() {
-    var kmsClient :- expect KMS.KMSClient();
-    var ddbClient :- expect DDB.DynamoDBClient();
+  method {:vcs_split_on_every_assert} {:test} TestValidConfig() {
+    var kmsClient :- expect ProvideKMSClient();
+    var ddbClient :- expect ProvideDDBClient();
     var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
 
     var keyStoreConfig := Types.KeyStoreConfig(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -217,28 +217,7 @@ module TestGetKeys {
 
   method {:test} TestGetBranchKeyVersion()
   {
-    var kmsClient :- expect KMS.KMSClient();
-    var ddbClient :- expect DDB.DynamoDBClient();
-    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-
-    var keyStoreConfig := Types.KeyStoreConfig(
-      id := None,
-      kmsConfiguration := kmsConfig,
-      logicalKeyStoreName := logicalKeyStoreName,
-      storage := Some(
-        Types.ddb(
-          Types.DynamoDBTable(
-            ddbTableName := branchKeyStoreName,
-            ddbClient := Some(ddbClient)
-          ))),
-      keyManagement := Some(
-        Types.kms(
-          Types.AwsKms(
-            kmsClient := Some(kmsClient)
-          )))
-    );
-
-    var keyStore :- expect KeyStore.KeyStore(keyStoreConfig);
+    var keyStore :- expect DefaultKeyStore();
 
     var versionResult :- expect keyStore.GetBranchKeyVersion(
       Types.GetBranchKeyVersionInput(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationErrorRefinement.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationErrorRefinement.dfy
@@ -1,0 +1,130 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+include "../Model/AwsCryptographyKeyStoreAdminTypes.dfy"
+
+module {:options "/functionSyntax:4" } MutationErrorRefinement {
+  import opened Wrappers
+  import Types = AwsCryptographyKeyStoreAdminTypes
+  import KeyStoreTypes = AwsCryptographyKeyStoreAdminTypes.AwsCryptographyKeyStoreTypes
+  import KMSKeystoreOperations
+  import KMS = Com.Amazonaws.Kms
+
+  function ExtractKmsOpaque(
+    error: KMSKeystoreOperations.KmsError
+  ): (opaqueError?: Option<KMS.Types.OpaqueError>)
+    ensures
+      && error.ComAmazonawsKms?
+      && error.ComAmazonawsKms.Opaque?
+      ==> opaqueError?.Some? && opaqueError?.value == error.ComAmazonawsKms
+  {
+    match error {
+      case Opaque(obj) => None
+      case KeyManagementException(s) => None
+      case ComAmazonawsKms(comAmazonawsKms: KMS.Types.Error) =>
+        match comAmazonawsKms {
+          case Opaque(obj) => Some(comAmazonawsKms)
+          case _ => None
+        }
+    }
+  }
+
+  function ExtractMessageFromKmsError(
+    error: KMSKeystoreOperations.KmsError
+  ): (errorMessage?: Option<string>)
+  {
+    match error {
+      case Opaque(obj) => None
+      case KeyManagementException(s) => Some(s)
+      case ComAmazonawsKms(comAmazonawsKms: KMS.Types.Error) =>
+        match comAmazonawsKms {
+          case Opaque(obj) => None
+          case _ => comAmazonawsKms.message
+        }
+    }
+  }
+
+  function DefaultKmsErrorMessage(
+    nameonly localOperation: string,
+    nameonly kmsOperation: string,
+    nameonly identifier: string,
+    nameonly kmsArn: string,
+    nameonly while?: Option<string> := None,
+    nameonly errorMessage?: Option<string> := None
+  ): (message: string)
+  {
+    "KMS through an exception for "
+    + localOperation + "'s " + kmsOperation
+    + (if while?.Some? then " while " + while?.value else ".")
+    + " KMS ARN: " + kmsArn
+    + "\tBranch Key ID: " + identifier
+    + "\nKMS Message: " + errorMessage?.UnwrapOr("")
+  }
+
+  function VerifyActiveException(
+    branchKeyItem: KeyStoreTypes.EncryptedHierarchicalKey,
+    error: KMSKeystoreOperations.KmsError
+  ): (output: Types.Error)
+    requires branchKeyItem.Type.ActiveHierarchicalSymmetricVersion?
+  {
+    var message := DefaultKmsErrorMessage(
+                     localOperation := "InitializeMutation",
+                     kmsOperation := "ReEncrypt",
+                     identifier := branchKeyItem.Identifier,
+                     kmsArn := branchKeyItem.KmsArn,
+                     while? := Some("verifying the Active Branch Key. Do you have permission for the original KMS ARN?"),
+                     errorMessage? := ExtractMessageFromKmsError(error));
+    Types.MutationFromException(message := message)
+  }
+
+  function VerifyTerminalException(
+    branchKeyItem: KeyStoreTypes.EncryptedHierarchicalKey,
+    error: KMSKeystoreOperations.KmsError
+  ): (output: Types.Error)
+    requires branchKeyItem.Type.HierarchicalSymmetricVersion?
+  {
+    var message := DefaultKmsErrorMessage(
+                     localOperation := "ApplyMutation",
+                     kmsOperation := "ReEncrypt",
+                     identifier := branchKeyItem.Identifier,
+                     kmsArn := branchKeyItem.KmsArn,
+                     while? := Some("verifying a Version with terminal properities."
+                                    + " Do you have permission for the terminal KMS ARN?"
+                                    + " Version (Decrypt Only): " + branchKeyItem.Type.HierarchicalSymmetricVersion.Version),
+                     errorMessage? := ExtractMessageFromKmsError(error));
+    Types.MutationToException(message := message)
+  }
+
+  // https://github.com/smithy-lang/smithy-dafny/issues/609
+  // TODO-Mutations-GA :: Once we can get a string from KMS Oapque,
+  // we can check it for ReEncryptTo or ReEncryptFrom.
+  // Than, this function can return
+  // MutationToException or MutationFromException
+  function MutateException(
+    branchKeyItem: KeyStoreTypes.EncryptedHierarchicalKey,
+    error: KMSKeystoreOperations.KmsError,
+    terminalKmsArn: string
+  ): (output: Types.Error)
+    requires branchKeyItem.Type.HierarchicalSymmetricVersion? || branchKeyItem.Type.ActiveHierarchicalSymmetricBeacon?
+  {
+    var while? :=
+      if branchKeyItem.Type.HierarchicalSymmetricVersion?
+      then Some("mutating a Version."
+                + " Do you have permission for the original and terminal KMS ARN?"
+                + " Version (Decrypt Only): " + branchKeyItem.Type.HierarchicalSymmetricVersion.Version)
+      else Some("mutating the Beacon Key."
+                + " Do you have permission for the the original and terminal KMS ARN?");
+    // https://github.com/smithy-lang/smithy-dafny/issues/609
+    // If opaqueKmsError?.Some?, parse for ReEncryptTo or ReEncrytFrom
+    var opaqueKmsError? := ExtractKmsOpaque(error);
+    var message := DefaultKmsErrorMessage(
+                     localOperation := "ApplyMutation",
+                     kmsOperation := "ReEncrypt",
+                     identifier := branchKeyItem.Identifier,
+                     kmsArn := "original: " + branchKeyItem.KmsArn + "\tterminal: " + terminalKmsArn,
+                     while? := while?,
+                     errorMessage? := ExtractMessageFromKmsError(error));
+    if opaqueKmsError?.Some?
+    then Types.ComAmazonawsKms(ComAmazonawsKms := opaqueKmsError?.value)
+    else Types.KeyStoreAdminException(message := message)
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -34,6 +34,7 @@ import software.amazon.cryptography.keystore.internaldafny.types.DynamoDBTable;
 import software.amazon.cryptography.keystore.internaldafny.types.EncryptedHierarchicalKey;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
@@ -82,6 +83,7 @@ import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncrypt
 import software.amazon.cryptography.keystore.internaldafny.types.WriteNewEncryptedBranchKeyVersionOutput;
 import software.amazon.cryptography.keystore.model.AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.model.CollectionOfErrors;
+import software.amazon.cryptography.keystore.model.KeyManagementException;
 import software.amazon.cryptography.keystore.model.KeyStorageException;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
 import software.amazon.cryptography.keystore.model.MutationLockConditionFailed;
@@ -97,6 +99,9 @@ public class ToDafny {
   public static Error Error(RuntimeException nativeValue) {
     if (nativeValue instanceof AlreadyExistsConditionFailed) {
       return ToDafny.Error((AlreadyExistsConditionFailed) nativeValue);
+    }
+    if (nativeValue instanceof KeyManagementException) {
+      return ToDafny.Error((KeyManagementException) nativeValue);
     }
     if (nativeValue instanceof KeyStorageException) {
       return ToDafny.Error((KeyStorageException) nativeValue);
@@ -989,6 +994,15 @@ public class ToDafny {
         nativeValue.message()
       );
     return new Error_AlreadyExistsConditionFailed(message);
+  }
+
+  public static Error Error(KeyManagementException nativeValue) {
+    DafnySequence<? extends Character> message;
+    message =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.message()
+      );
+    return new Error_KeyManagementException(message);
   }
 
   public static Error Error(KeyStorageException nativeValue) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import software.amazon.cryptography.keystore.internaldafny.types.Error;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_CollectionOfErrors;
+import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException;
 import software.amazon.cryptography.keystore.internaldafny.types.Error_MutationLockConditionFailed;
@@ -62,6 +63,7 @@ import software.amazon.cryptography.keystore.model.HierarchicalKeyType;
 import software.amazon.cryptography.keystore.model.HierarchicalSymmetric;
 import software.amazon.cryptography.keystore.model.KMSConfiguration;
 import software.amazon.cryptography.keystore.model.KeyManagement;
+import software.amazon.cryptography.keystore.model.KeyManagementException;
 import software.amazon.cryptography.keystore.model.KeyStorageException;
 import software.amazon.cryptography.keystore.model.KeyStoreConfig;
 import software.amazon.cryptography.keystore.model.KeyStoreException;
@@ -115,6 +117,19 @@ public class ToNative {
   ) {
     AlreadyExistsConditionFailed.Builder nativeBuilder =
       AlreadyExistsConditionFailed.builder();
+    nativeBuilder.message(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_message()
+      )
+    );
+    return nativeBuilder.build();
+  }
+
+  public static KeyManagementException Error(
+    Error_KeyManagementException dafnyValue
+  ) {
+    KeyManagementException.Builder nativeBuilder =
+      KeyManagementException.builder();
     nativeBuilder.message(
       software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
         dafnyValue.dtor_message()
@@ -199,6 +214,9 @@ public class ToNative {
   public static RuntimeException Error(Error dafnyValue) {
     if (dafnyValue.is_AlreadyExistsConditionFailed()) {
       return ToNative.Error((Error_AlreadyExistsConditionFailed) dafnyValue);
+    }
+    if (dafnyValue.is_KeyManagementException()) {
+      return ToNative.Error((Error_KeyManagementException) dafnyValue);
     }
     if (dafnyValue.is_KeyStorageException()) {
       return ToNative.Error((Error_KeyStorageException) dafnyValue);

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyManagementException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyManagementException.java
@@ -6,7 +6,7 @@ package software.amazon.cryptography.keystore.model;
 import java.util.Objects;
 
 /**
- * AWS KMS returned an invalid response.
+ * AWS KMS request was unsuccesful or response was invalid.
  */
 public class KeyManagementException extends RuntimeException {
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyManagementException.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/KeyManagementException.java
@@ -6,13 +6,11 @@ package software.amazon.cryptography.keystore.model;
 import java.util.Objects;
 
 /**
- * Operation was rejected due to a race with VersionKey.
- * No items were changed.
- * Retry operation when no other agent is Versioning this Branch Key ID.
+ * AWS KMS returned an invalid response.
  */
-public class VersionRaceException extends RuntimeException {
+public class KeyManagementException extends RuntimeException {
 
-  protected VersionRaceException(BuilderImpl builder) {
+  protected KeyManagementException(BuilderImpl builder) {
     super(messageFromBuilder(builder), builder.cause());
   }
 
@@ -69,7 +67,7 @@ public class VersionRaceException extends RuntimeException {
      */
     Throwable cause();
 
-    VersionRaceException build();
+    KeyManagementException build();
   }
 
   static class BuilderImpl implements Builder {
@@ -80,7 +78,7 @@ public class VersionRaceException extends RuntimeException {
 
     protected BuilderImpl() {}
 
-    protected BuilderImpl(VersionRaceException model) {
+    protected BuilderImpl(KeyManagementException model) {
       this.message = model.message();
       this.cause = model.cause();
     }
@@ -103,13 +101,13 @@ public class VersionRaceException extends RuntimeException {
       return this.cause;
     }
 
-    public VersionRaceException build() {
+    public KeyManagementException build() {
       if (Objects.isNull(this.message())) {
         throw new IllegalArgumentException(
           "Missing value for required field `message`"
         );
       }
-      return new VersionRaceException(this);
+      return new KeyManagementException(this);
     }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyManagementException.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyManagementException.cs
@@ -1,0 +1,13 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class KeyManagementException : Exception
+  {
+    public KeyManagementException(string message) : base(message) { }
+    public string getMessage() { return this.Message; }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -339,6 +339,19 @@ namespace AWS.Cryptography.KeyStore
       }
       throw new System.ArgumentException("Invalid AWS.Cryptography.KeyStore.KeyManagement state");
     }
+    public static AWS.Cryptography.KeyStore.KeyManagementException FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException(software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException value)
+    {
+      return new AWS.Cryptography.KeyStore.KeyManagementException(
+      FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException__M7_message(value._message)
+      );
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException(AWS.Cryptography.KeyStore.KeyManagementException value)
+    {
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException(
+      ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException__M7_message(value.Message)
+      );
+    }
     public static AWS.Cryptography.KeyStore.KeyStorageException FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException value)
     {
       return new AWS.Cryptography.KeyStore.KeyStorageException(
@@ -943,6 +956,14 @@ namespace AWS.Cryptography.KeyStore
     public static software.amazon.cryptography.keystore.internaldafny.types._IAwsKms ToDafny_N3_aws__N12_cryptography__N8_keyStore__S13_KeyManagement__M3_kms(AWS.Cryptography.KeyStore.AwsKms value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S6_AwsKms(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException__M7_message(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException__M7_message(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
     }
     public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException__M7_message(Dafny.ISequence<char> value)
     {
@@ -1880,6 +1901,8 @@ namespace AWS.Cryptography.KeyStore
           );
         case software.amazon.cryptography.keystore.internaldafny.types.Error_AlreadyExistsConditionFailed dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(dafnyVal);
+        case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyManagementException dafnyVal:
+          return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStorageException dafnyVal:
           return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(dafnyVal);
         case software.amazon.cryptography.keystore.internaldafny.types.Error_KeyStoreException dafnyVal:
@@ -1921,6 +1944,8 @@ namespace AWS.Cryptography.KeyStore
       {
         case AWS.Cryptography.KeyStore.AlreadyExistsConditionFailed exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S28_AlreadyExistsConditionFailed(exception);
+        case AWS.Cryptography.KeyStore.KeyManagementException exception:
+          return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_KeyManagementException(exception);
         case AWS.Cryptography.KeyStore.KeyStorageException exception:
           return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S19_KeyStorageException(exception);
         case AWS.Cryptography.KeyStore.KeyStoreException exception:


### PR DESCRIPTION
If the KMS Call, for mutating the Beacon, fails,
it MAY indicate the MPL Consumer does not have access to the terminal KMS Key.

If the KMS call for verifying a terminal version fails, it MAY indicate the MPL Consumer does not have access to the terminal KMS Key.

_Squash/merge commit message, if applicable:_
`feat(Mutations-TODO): Some Terminal KMS Exceptions`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
