### PR TITLE
fix(H-Keyring): if getCache returns Opaque Error, return Opaque

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -482,6 +482,11 @@ module AwsKmsHierarchicalKeyring {
       verifyValidStateCache(cache);
       var getCacheOutput := getEntry(cache, getCacheInput);
 
+      // If error is opaque, return Failure
+      if (getCacheOutput.Failure? && getCacheOutput.error.Opaque?) {
+        return Failure(getCacheOutput.error);
+      }
+
       var now := Time.GetCurrent();
 
       // //= aws-encryption-sdk-specification/framework/aws-kms/aws-kms-hierarchical-keyring.md#onencrypt
@@ -863,6 +868,11 @@ module AwsKmsHierarchicalKeyring {
       var getCacheInput := Types.GetCacheEntryInput(identifier := cacheId, bytesUsed := None);
       verifyValidStateCache(cache);
       var getCacheOutput := getEntry(cache, getCacheInput);
+
+      // If error is opaque, return Failure
+      if (getCacheOutput.Failure? && getCacheOutput.error.Opaque?) {
+        return Failure(getCacheOutput.error);
+      }
 
       var now := Time.GetCurrent();
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The Cache querying logic in the H-Keyring confuses a cache miss
with an opaque error.

i.e: `getCachOutput.Failure?` is not always `EntryDoesNotExist` but could be something like `Opaque(obj? := java.nio.BufferUnderflowException`.

Thus, I suggest we refactor the methods that call the cache to differentiate b/w Opaque and `EntryDoesNotExist`.

_Squash/merge commit message, if applicable:_
`fix(H-Keyring): if getCache returns Opaque Error, return Opaque`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
