### PR TITLE
fix: Move Java helper methods out of extern class

### DIFF
--- a/AwsCryptographyPrimitives/runtimes/java/src/main/java/HMAC/HMac.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/java/HMAC/HMac.java
@@ -12,7 +12,7 @@ import software.amazon.cryptography.primitives.internaldafny.types.DigestAlgorit
 import software.amazon.cryptography.primitives.internaldafny.types.Error;
 import software.amazon.cryptography.primitives.model.AwsCryptographicPrimitivesError;
 
-public class HMac extends _ExternBase_HMac {
+public class HMac extends _ExternBase___default {
 
   private String algorithm;
   private Mac hmac;

--- a/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/extern/HMAC.py
+++ b/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/extern/HMAC.py
@@ -27,8 +27,7 @@ class default__(aws_cryptography_primitives.internaldafny.generated.HMAC.default
       output = hmac.GetResult()
       return Wrappers.Result_Success(_dafny.Seq(output))
 
-# Extend generated class
-class HMac(aws_cryptography_primitives.internaldafny.generated.HMAC.HMac):
+class HMac:
 
     @staticmethod
     def Build(digest):

--- a/AwsCryptographyPrimitives/src/HKDF/HMAC.dfy
+++ b/AwsCryptographyPrimitives/src/HKDF/HMAC.dfy
@@ -63,13 +63,7 @@ module {:options "-functionSyntax:4"} {:extern "HMAC"} HMAC {
     // since their calling pattern is different between different versions of Dafny
     // (i.e. after 4.2, explicit type descriptors are required).
 
-    static function CreateHMacSuccess(hmac: HMac): Result<HMac, Types.Error> {
-      Success(hmac)
-    }
 
-    static function CreateHMacFailure(error: Types.Error): Result<HMac, Types.Error> {
-      Failure(error)
-    }
   }
 
   // HMAC Digest is safe to make a Dafny function
@@ -78,10 +72,18 @@ module {:options "-functionSyntax:4"} {:extern "HMAC"} HMAC {
     : ( output: Result<seq<uint8>, Types.Error> )
     ensures output.Success? ==> |output.value| == HashDigest.Length(input.digestAlgorithm)
 
-  // The next two functions are for the benefit of the extern implementation to call,
+  // The following functions are for the benefit of the extern implementation to call,
   // avoiding direct references to generic datatype constructors
   // since their calling pattern is different between different versions of Dafny
   // (i.e. after 4.2, explicit type descriptors are required).
+
+  function CreateHMacSuccess(hmac: HMac): Result<HMac, Types.Error> {
+    Success(hmac)
+  }
+
+  function CreateHMacFailure(error: Types.Error): Result<HMac, Types.Error> {
+    Failure(error)
+  }
 
   function CreateDigestSuccess(bytes: seq<uint8>): Result<seq<uint8>, Types.Error> {
     Success(bytes)


### PR DESCRIPTION
_Description of changes:_

I added these as a migration workaround for upgrading the Dafny version, but as a side effect it made `HMac` a mixed Dafny/native class when it wasn't intended to be, and this isn't supported on all target languages (e.g. Go). Easy fix to move them out of the class to the surrounding module instead.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
