### PR TITLE
fix(H-Keyring): if putCache throws EntryAlreadyExists, ignore

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -529,7 +529,10 @@ module AwsKmsHierarchicalKeyring {
         );
 
         verifyValidStateCache(cache);
-        var _ :- putEntry(cache, putCacheEntryInput);
+        var putResult := putEntry(cache, putCacheEntryInput);
+        if (putResult.Failure? && !putResult.error.EntryAlreadyExists?) {
+          return Failure(putResult.error);
+        }
 
         return Success(branchKeyMaterials);
       } else {
@@ -918,7 +921,10 @@ module AwsKmsHierarchicalKeyring {
         );
 
         verifyValidStateCache(cache);
-        var _ :- putEntry(cache, putCacheEntryInput);
+        var putResult := putEntry(cache, putCacheEntryInput);
+        if (putResult.Failure? && !putResult.error.EntryAlreadyExists?) {
+          return Failure(putResult.error);
+        }
 
         return Success(branchKeyMaterials);
       } else {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
The Model for the CMC is a little unclear,
but it could be interrupted to indicate that a 
put to the cache for an item that already exists can
throw an `EntryAlreadyExists` error.

The H-Keyring should ignore such an exception.

_Squash/merge commit message, if applicable:_
`fix(H-Keyring): if putCache throws EntryAlreadyExists, ignore`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
