### PR TITLE
chore(Python): Fetch tags as part of release

### DIFF
--- a/AwsCryptographicMaterialProviders/codebuild/release-python/prod-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/prod-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml)
       - |

--- a/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml)
       - |

--- a/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
@@ -25,7 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
-      - git fetch --tags
+      - git fetch --tags 
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml)
       - |

--- a/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
@@ -25,7 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
-      - git fetch --tags 
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml)
       - |

--- a/AwsCryptographyPrimitives/codebuild/release-python/prod-release.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/prod-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographyPrimitives/runtimes/python/pyproject.toml)
       - |

--- a/AwsCryptographyPrimitives/codebuild/release-python/test-release.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/test-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' AwsCryptographyPrimitives/runtimes/python/pyproject.toml)
       - |

--- a/ComAmazonawsDynamodb/codebuild/release-python/prod-release.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/prod-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' ComAmazonawsDynamodb/runtimes/python/pyproject.toml)
       - |

--- a/ComAmazonawsDynamodb/codebuild/release-python/test-release.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/test-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' ComAmazonawsDynamodb/runtimes/python/pyproject.toml)
       - |

--- a/ComAmazonawsKms/codebuild/release-python/prod-release.yml
+++ b/ComAmazonawsKms/codebuild/release-python/prod-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' ComAmazonawsKms/runtimes/python/pyproject.toml)
       - |

--- a/ComAmazonawsKms/codebuild/release-python/test-release.yml
+++ b/ComAmazonawsKms/codebuild/release-python/test-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' ComAmazonawsKms/runtimes/python/pyproject.toml)
       - |

--- a/StandardLibrary/codebuild/release-python/prod-release.yml
+++ b/StandardLibrary/codebuild/release-python/prod-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' StandardLibrary/runtimes/python/pyproject.toml)
       - |

--- a/StandardLibrary/codebuild/release-python/test-release.yml
+++ b/StandardLibrary/codebuild/release-python/test-release.yml
@@ -25,6 +25,7 @@ phases:
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
       # Assert that project version is the expected released version
+      - git fetch --tags
       - git checkout $COMMIT_ID
       - FOUND_VERSION=$(sed -n 's/version = "\(.*\)"/\1/p' StandardLibrary/runtimes/python/pyproject.toml)
       - |


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Python fetches source code from within the buildspec.
For the MPL, `$COMMIT_ID` will often be a git tag.
Python will need to fetch the tags.

This isn't needed for Java/NET.
Both use `--source-version XX` in their CodeBuild config, which accepts a git tag by default.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
