### PR TITLE
fix: variable name collision fix for Go

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
@@ -350,7 +350,7 @@ module DDBKeystoreOperations {
   function method CreateTransactWritePutItem(
     item: DDB.AttributeMap,
     tableName: DDB.TableName,
-    ConditionExpression: ConditionExpression
+    conditionExpression: ConditionExpression
   ): (output: DDB.TransactWriteItem)
   {
 
@@ -361,7 +361,7 @@ module DDBKeystoreOperations {
           Item := item,
           TableName := tableName,
           ConditionExpression := Some(
-            match ConditionExpression
+            match conditionExpression
             case BRANCH_KEY_NOT_EXIST() => BRANCH_KEY_NOT_EXIST_CONDITION
             case BRANCH_KEY_EXISTS() => BRANCH_KEY_EXISTS_CONDITION
           ),


### PR DESCRIPTION
_Issue #, if available:_
https://t.corp.amazon.com/V1528740765

_Description of changes:_

The variable name `ConditionExpression` and the type `ConditionExpression` ends up colliding in Go. This PR uses cameCase for the variable name to avoid collision.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
