### PR TITLE
ci: fix missing getVersion in nightly Dafny CI

### DIFF
--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -11,6 +11,10 @@ on:
     - cron: "30 16 * * *"
 
 jobs:
+  getVersion:
+    # Don't run the cron builds on forks
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
+    uses: ./.github/workflows/dafny_version.yaml
   dafny-nightly-format:
     # Don't run the cron builds on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
@@ -39,6 +43,7 @@ jobs:
       regenerate-code: true
   dafny-nightly-python:
     needs: getVersion
+    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/library_python_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}


### PR DESCRIPTION
Fixes startup failures like https://github.com/aws/aws-cryptographic-material-providers-library/actions/runs/11389253918

The `getVersion` job definition is copied from https://github.com/aws/aws-cryptographic-material-providers-library/blob/787f63a4cae67d9079b28c190a7c3d70854f9d67/.github/workflows/daily_ci.yml#L9-L12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
