### PR TITLE
fix: python time externs should return integers

### DIFF
--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/extern/Time.py
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/extern/Time.py
@@ -8,10 +8,10 @@ import smithy_dafny_standard_library.internaldafny.generated.Wrappers as Wrapper
 # Extend generated class with our externs
 class default__(smithy_dafny_standard_library.internaldafny.generated.Time.default__):
     def CurrentRelativeTimeMilli():
-        return datetime.datetime.now(tz = pytz.UTC).timestamp() * 1000
+        return round(datetime.datetime.now(tz = pytz.UTC).timestamp() * 1000)
 
     def CurrentRelativeTime():
-        return datetime.datetime.now(tz = pytz.UTC).timestamp()
+        return round(datetime.datetime.now(tz = pytz.UTC).timestamp())
 
     def GetCurrentTimeStamp():
         try:


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
