### PR TITLE
chore(Python): Pin releases to patch version

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -160,7 +160,7 @@ module.exports = {
           {
             files: Object.keys(Runtimes.python),
             from: "{path =.*",
-            to: '"~${nextRelease.version}"',
+            to: '"${nextRelease.version}"',
             results: Object.keys(Runtimes.python).map(
               CheckDependencyReplacementResults,
             ),


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Before, Python releases would pin to minor versions.
This is not in parity with Java/.NET, which pin to patch versions.
Let's bias for keeping language release behavior in parity.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
