### PR TITLE
chore(STD-Dafny): HasSubString

### DIFF
--- a/StandardLibrary/src/Sequence.dfy
+++ b/StandardLibrary/src/Sequence.dfy
@@ -7,35 +7,35 @@ module StandardLibrary.Sequence {
   // export provides SequenceEqual, StandardLibrary
   import opened UInt
 
-predicate method SequenceEqualNat<T(==)>(seq1: seq<T>, seq2: seq<T>, start1: nat, start2: nat, size: nat) : (ret : bool)
-  requires start1 + size <= |seq1|
-  requires start2 + size <= |seq2|
-  ensures ret ==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
-{
-  if |seq1| > INT64_MAX_LIMIT || |seq2| > INT64_MAX_LIMIT then
-    false
-  else
-    SequenceEqual(seq1, seq2, start1 as uint64, start2 as uint64, size as uint64)
-}
-
-predicate SequenceEqual<T(==)>(seq1: seq64<T>, seq2: seq64<T>, start1: uint64, start2: uint64, size: uint64) : (ret : bool)
-  requires start1 as nat + size as nat <= |seq1| 
-  requires start2 as nat + size as nat <= |seq2|
-  ensures ret <==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
-{
-  seq1[start1..start1 + size] == seq2[start2..start2 + size]
-} by method {
-  var j := start2 as uint64;
-  for i := start1 as uint64 to (start1 + size) as uint64
-    invariant j == i - start1 + start2
-    invariant forall k : uint64 | start1 <= k < i :: seq1[k] == seq2[k - start1 + start2]
+  predicate method SequenceEqualNat<T(==)>(seq1: seq<T>, seq2: seq<T>, start1: nat, start2: nat, size: nat) : (ret : bool)
+    requires start1 + size <= |seq1|
+    requires start2 + size <= |seq2|
+    ensures ret ==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
   {
-    if seq1[i] != seq2[j] {
-      return false;
-    }
-    j := j + 1;
+    if |seq1| > INT64_MAX_LIMIT || |seq2| > INT64_MAX_LIMIT then
+      false
+    else
+      SequenceEqual(seq1, seq2, start1 as uint64, start2 as uint64, size as uint64)
   }
-  return true;
-}
+
+  predicate SequenceEqual<T(==)>(seq1: seq64<T>, seq2: seq64<T>, start1: uint64, start2: uint64, size: uint64) : (ret : bool)
+    requires start1 as nat + size as nat <= |seq1|
+    requires start2 as nat + size as nat <= |seq2|
+    ensures ret <==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
+  {
+    seq1[start1..start1 + size] == seq2[start2..start2 + size]
+  } by method {
+    var j := start2 as uint64;
+    for i := start1 as uint64 to (start1 + size) as uint64
+      invariant j == i - start1 + start2
+      invariant forall k : uint64 | start1 <= k < i :: seq1[k] == seq2[k - start1 + start2]
+    {
+      if seq1[i] != seq2[j] {
+        return false;
+      }
+      j := j + 1;
+    }
+    return true;
+  }
 
 }

--- a/StandardLibrary/src/Sequence.dfy
+++ b/StandardLibrary/src/Sequence.dfy
@@ -12,7 +12,7 @@ module StandardLibrary.Sequence {
     requires start2 + size <= |seq2|
     ensures ret ==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
   {
-    if |seq1| > INT64_MAX_LIMIT || |seq2| > UINT64_MAX_LIMIT then
+    if |seq1| > UINT64_MAX_LIMIT || |seq2| > UINT64_MAX_LIMIT then
       // This line of code will never be executed, but is included for correctness
       seq1[start1..start1 + size] == seq2[start2..start2 + size]
     else

--- a/StandardLibrary/src/Sequence.dfy
+++ b/StandardLibrary/src/Sequence.dfy
@@ -12,8 +12,9 @@ module StandardLibrary.Sequence {
     requires start2 + size <= |seq2|
     ensures ret ==> seq1[start1..start1 + size] == seq2[start2..start2 + size]
   {
-    if |seq1| > INT64_MAX_LIMIT || |seq2| > INT64_MAX_LIMIT then
-      false
+    if |seq1| > INT64_MAX_LIMIT || |seq2| > UINT64_MAX_LIMIT then
+      // This line of code will never be executed, but is included for correctness
+      seq1[start1..start1 + size] == seq2[start2..start2 + size]
     else
       SequenceEqual(seq1, seq2, start1 as uint64, start2 as uint64, size as uint64)
   }

--- a/StandardLibrary/src/Sequence.dfy
+++ b/StandardLibrary/src/Sequence.dfy
@@ -1,0 +1,28 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+module StandardLibrary.Sequence {
+  export provides SequenceEqual
+
+  /* No Allocation Comparison of two Sequences. Author: ajewellamz */
+  predicate method SequenceEqual<T(==)>(
+    nameonly seq1 : seq<T>,
+    nameonly seq2 : seq<T>,
+    nameonly start1 : nat,
+    nameonly start2 : nat,
+    nameonly size : nat
+  ): (ret: bool) // returns (ret : bool)
+
+    requires start1 + size <= |seq1|
+    requires start2 + size <= |seq2|
+    ensures ret ==> seq1[start1 .. start1 + size] == seq2[start2 .. start2+size]
+  {
+    // for i : nat := 0 to size {
+    //   if seq1[start1+i] != seq2[start2+i] {
+    //     return false;
+    //   }
+    // }
+    // return true;
+    forall i | 0 <= i < size :: seq1[start1+i] == seq2[start2+i]
+  }
+}

--- a/StandardLibrary/src/String.dfy
+++ b/StandardLibrary/src/String.dfy
@@ -1,8 +1,10 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+include "../../libraries/src/Wrappers.dfy"
 
 module StandardLibrary.String {
-  export provides Int2String, Base10Int2String
+  import Wrappers
+  export provides Int2String, Base10Int2String, HasSubString, Wrappers
 
   const Base10: seq<char> := ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
@@ -47,5 +49,27 @@ module StandardLibrary.String {
   function method Base10Int2String(n: int) : string
   {
     Int2String(n, Base10)
+  }
+
+  /* Returns the index of a substraing or None, if the substring is not in the string */
+  method HasSubString(xs: string, ss: string)
+    returns (o: Wrappers.Option<nat>)
+    requires |ss| <= |xs|
+    ensures o.Some? ==>
+              o.value <= |xs| - |ss| && xs[o.value..(o.value + |ss|)] == ss
+    // TODO: ensures o.None? ==> no such index exists
+  {
+    var index: nat := 0;
+    var limit: nat := |xs| - |ss|;
+    while index <= limit
+      decreases limit - index
+    {
+      if (xs[index .. index + |ss|] == ss) {
+        return Wrappers.Some(index);
+      } else {
+        index := index + 1;
+      }
+    }
+    return Wrappers.None;
   }
 }

--- a/StandardLibrary/src/String.dfy
+++ b/StandardLibrary/src/String.dfy
@@ -54,7 +54,6 @@ module StandardLibrary.String {
     Int2String(n, Base10)
   }
 
-
   /* Returns the index of a substring or None, if the substring is not in the string */
   method HasSubString(haystack: string, needle: string)
     returns (o: Wrappers.Option<nat>)
@@ -63,17 +62,17 @@ module StandardLibrary.String {
               && o.value <= |haystack| - |needle| && haystack[o.value..(o.value + |needle|)] == needle
               && (forall i | 0 <= i < o.value :: haystack[i..][..|needle|] != needle)
 
-    ensures |haystack| < |needle| || |haystack| > INT64_MAX_LIMIT ==> o.None?
+    ensures |haystack| < |needle| || |haystack| > (UINT64_MAX_LIMIT-1) ==> o.None?
 
-    ensures o.None? && |needle| <= |haystack| && |haystack| <= INT64_MAX_LIMIT ==>
+    ensures o.None? && |needle| <= |haystack| && |haystack| <= (UINT64_MAX_LIMIT-1) ==>
               (forall i | 0 <= i <= (|haystack|-|needle|) :: haystack[i..][..|needle|] != needle)
   {
     if |haystack| < |needle| {
       return Wrappers.None;
     }
-    if |haystack| > INT64_MAX_LIMIT {
-      return Wrappers.None;
-    }
+
+    // `-1` is needed because of how `limit` is calculated below
+    expect |haystack| <= (UINT64_MAX_LIMIT-1);
 
     var size : uint64 := |needle| as uint64;
     var limit: uint64 := |haystack| as uint64 - size + 1;

--- a/StandardLibrary/src/String.dfy
+++ b/StandardLibrary/src/String.dfy
@@ -1,9 +1,12 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 include "../../libraries/src/Wrappers.dfy"
+include "../../StandardLibrary/src/Sequence.dfy"
 
 module StandardLibrary.String {
   import Wrappers
+    // import StandardLibrary.Sequence
+  import Sequence
   export provides Int2String, Base10Int2String, HasSubString, Wrappers
 
   const Base10: seq<char> := ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
@@ -60,11 +63,19 @@ module StandardLibrary.String {
     // TODO: ensures o.None? ==> no such index exists
   {
     var index: nat := 0;
+    var size: nat := |ss|;
     var limit: nat := |xs| - |ss|;
+    var subSeq: bool := false;
     while index <= limit
       decreases limit - index
     {
-      if (xs[index .. index + |ss|] == ss) {
+      subSeq := Sequence.SequenceEqual(
+        seq1 := xs,
+        seq2 := ss,
+        start1 := index,
+        start2 := 0,
+        size := size);
+      if (subSeq) {
         return Wrappers.Some(index);
       } else {
         index := index + 1;

--- a/StandardLibrary/src/UInt.dfy
+++ b/StandardLibrary/src/UInt.dfy
@@ -16,6 +16,7 @@ module StandardLibrary.UInt {
   const UINT64_LIMIT := BoundedInts.UINT64_MAX as int + 1
   const INT32_MAX_LIMIT := BoundedInts.INT32_MAX as int
   const INT64_MAX_LIMIT := BoundedInts.INT64_MAX as int
+  const UINT64_MAX_LIMIT := BoundedInts.UINT64_MAX as int
 
   predicate method UInt8Less(a: uint8, b: uint8) { a < b }
 

--- a/StandardLibrary/test/TestString.dfy
+++ b/StandardLibrary/test/TestString.dfy
@@ -27,5 +27,7 @@ module TestStrings {
     expect actual == None, "'Robbie is a Dog.' does not contain Koda";
     actual := String.HasSubString("\t", " ");
     expect actual == None, "A tab is not a space";
+    actual := String.HasSubString("large", "larger");
+    expect actual == None, "Needle larger than haystack";
   }
 }

--- a/StandardLibrary/test/TestString.dfy
+++ b/StandardLibrary/test/TestString.dfy
@@ -19,6 +19,8 @@ module TestStrings {
     expect actual == Some(10), "'Dog.' is in 'Koda is a Dog.' at index 10, but HasSubString does not think so";
     actual := String.HasSubString("Koda is a Dog.", ".");
     expect actual == Some(13), "'.' is in 'Koda is a Dog.' at index 13, but HasSubString does not think so";
+    actual := String.HasSubString("Koda is a Dog.", "");
+    expect actual == Some(0), "The empty string is in 'Koda is a Dog.' at index 0, but HasSubString does not think so";
   }
 
   method {:test} TestHasSubStringNegative()

--- a/StandardLibrary/test/TestString.dfy
+++ b/StandardLibrary/test/TestString.dfy
@@ -1,0 +1,31 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+include "../src/StandardLibrary.dfy"
+include "../src/String.dfy"
+include "../../libraries/src/Wrappers.dfy"
+
+module TestStrings {
+  import StandardLibrary.String
+  import opened Wrappers
+
+  method {:test} TestHasSubStringPositive()
+  {
+    var actual := String.HasSubString("Koda is a Dog.", "Koda");
+    expect actual == Some(0), "'Koda' is in 'Koda is a Dog.' at index 0, but HasSubString does not think so";
+    actual := String.HasSubString("Koda is a Dog.", "Koda is a Dog.");
+    expect actual == Some(0), "'Koda is a Dog.' is in 'Koda is a Dog.' at index 0, but HasSubString does not think so";
+    actual := String.HasSubString("Koda is a Dog.", "Dog.");
+    expect actual == Some(10), "'Dog.' is in 'Koda is a Dog.' at index 10, but HasSubString does not think so";
+    actual := String.HasSubString("Koda is a Dog.", ".");
+    expect actual == Some(13), "'.' is in 'Koda is a Dog.' at index 13, but HasSubString does not think so";
+  }
+
+  method {:test} TestHasSubStringNegative()
+  {
+    var actual := String.HasSubString("Robbie is a Dog.", "Koda");
+    expect actual == None, "'Robbie is a Dog.' does not contain Koda";
+    actual := String.HasSubString("\t", " ");
+    expect actual == None, "A tab is not a space";
+  }
+}


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
HasSubString checks for a String for a Sub String.
If one is found,
Some(<index-for-start-of-sub-string>) is returned.

If not, 
None is returned.

This method was mostly written by @robin-aws 

_Squash/merge commit message, if applicable:_
```
chore(STD-Dafny): HasSubString
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
