### PR TITLE
chore(release): 1.7.4 [skip ci]

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.8.0"
+version = "1.7.4"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.3-SNAPSHOT"
+version = "1.8.0"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.7.4")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.7.3</Version>
+      <Version>1.8.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.8.0</Version>
+      <Version>1.7.4</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.8.0"
+version = "1.7.4"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = "1.8.0"
-aws-cryptography-internal-kms = "1.8.0"
-aws-cryptography-internal-dynamodb = "1.8.0"
-aws-cryptography-internal-primitives = "1.8.0"
+aws-cryptography-internal-standard-library = "1.7.4"
+aws-cryptography-internal-kms = "1.7.4"
+aws-cryptography-internal-dynamodb = "1.7.4"
+aws-cryptography-internal-primitives = "1.7.4"
 
 # Package testing
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.7.3"
+version = "1.8.0"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
+aws-cryptography-internal-kms = "1.8.0"
+aws-cryptography-internal-dynamodb = "1.8.0"
+aws-cryptography-internal-primitives = "1.8.0"
 
 # Package testing
 

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.7.4")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.3</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.7.4</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.8.0"
+version = "1.7.4"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = "1.8.0"
+aws-cryptography-internal-standard-library = "1.7.4"
 cryptography = "^43.0.1"
 
 # Package testing

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.7.3"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 cryptography = "^43.0.1"
 
 # Package testing

--- a/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,5 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.AwsCryptographyPrimitivesTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This release is available in the following languages:
 
 ### Bug Fixes
 
-* **Python:** Support Python 3.13 ([#953](https://github.com/aws/aws-cryptographic-material-providers-library/issues/953)) ([000baed](https://github.com/aws/aws-cryptographic-material-providers-library/commit/000baedfab341670952449837541c88ea5cf1dba))
+- **Python:** Support Python 3.13 ([#953](https://github.com/aws/aws-cryptographic-material-providers-library/issues/953)) ([000baed](https://github.com/aws/aws-cryptographic-material-providers-library/commit/000baedfab341670952449837541c88ea5cf1dba))
 
 ## [1.7.3](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.2...v1.7.3) (2024-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,14 @@
 # Changelog
 
-# [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.3...v1.8.0) (2024-11-06)
+# [1.7.4](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.3...v1.7.4) (2024-11-06)
 
+This release is available in the following languages:
+
+- Python
 
 ### Bug Fixes
 
-* CI ([831aeea](https://github.com/aws/aws-cryptographic-material-providers-library/commit/831aeea05adbdb839241b47f6c0ce3a7deb92e33))
-* Dafny verification ([1f4d8d7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1f4d8d7048ef140816aab6e4a3a744f8ec0cf4dc))
-* DDBv2 Model backwards compatbility with DBESDK 3.7 ([8a318a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a318a4fc42aeec675321a837c927dad355ad25d))
-* empty commit ([ffa34a5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ffa34a5e1a73b85e982b8564700c92214788233d))
-* formatting ([38aa3c3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/38aa3c36abc1e877354f7d89f740e5c15301a04a))
-* Net Dafny Patch 2 file ([0d4f0f5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0d4f0f5ef3facdce1830731a8ef424ea9cb46eb0))
-* Net Dafny Patch file ([e77879b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e77879bfca0a95c652083171c9551062ac7cd01f))
-* Net Patch ([bf0a495](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bf0a4954754522e55cb3bcb0c10d8525123486c5))
-* Polymorph Python ([18f0d48](https://github.com/aws/aws-cryptographic-material-providers-library/commit/18f0d481ef6500718328dbbb90e525ce934f04ad))
-* PR comments ([381e743](https://github.com/aws/aws-cryptographic-material-providers-library/commit/381e74322a0c9837f847b360b912b4e1235baab0))
-* python formating ([bb29950](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bb29950e3b70ab23d9b79f8ec3f71ba968cb8e20))
 * **Python:** Support Python 3.13 ([#953](https://github.com/aws/aws-cryptographic-material-providers-library/issues/953)) ([000baed](https://github.com/aws/aws-cryptographic-material-providers-library/commit/000baedfab341670952449837541c88ea5cf1dba))
-
-
-### Features
-
-* ddbv2 net patch ([a36f799](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a36f7997ea26befba0ce6090314d17d44d7596f5))
-* ddbv2 re-polymorph ([1357f42](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1357f42dfd8f24dcefdc07e248911d54bec26f2a))
-* ddbv2 upgrade ([1584fbc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1584fbce54c69aaaace6935f5949e13d07613d3f))
 
 ## [1.7.3](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.2...v1.7.3) (2024-10-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+# [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.3...v1.8.0) (2024-11-06)
+
+
+### Bug Fixes
+
+* CI ([831aeea](https://github.com/aws/aws-cryptographic-material-providers-library/commit/831aeea05adbdb839241b47f6c0ce3a7deb92e33))
+* Dafny verification ([1f4d8d7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1f4d8d7048ef140816aab6e4a3a744f8ec0cf4dc))
+* DDBv2 Model backwards compatbility with DBESDK 3.7 ([8a318a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a318a4fc42aeec675321a837c927dad355ad25d))
+* empty commit ([ffa34a5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ffa34a5e1a73b85e982b8564700c92214788233d))
+* formatting ([38aa3c3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/38aa3c36abc1e877354f7d89f740e5c15301a04a))
+* Net Dafny Patch 2 file ([0d4f0f5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0d4f0f5ef3facdce1830731a8ef424ea9cb46eb0))
+* Net Dafny Patch file ([e77879b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e77879bfca0a95c652083171c9551062ac7cd01f))
+* Net Patch ([bf0a495](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bf0a4954754522e55cb3bcb0c10d8525123486c5))
+* Polymorph Python ([18f0d48](https://github.com/aws/aws-cryptographic-material-providers-library/commit/18f0d481ef6500718328dbbb90e525ce934f04ad))
+* PR comments ([381e743](https://github.com/aws/aws-cryptographic-material-providers-library/commit/381e74322a0c9837f847b360b912b4e1235baab0))
+* python formating ([bb29950](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bb29950e3b70ab23d9b79f8ec3f71ba968cb8e20))
+* **Python:** Support Python 3.13 ([#953](https://github.com/aws/aws-cryptographic-material-providers-library/issues/953)) ([000baed](https://github.com/aws/aws-cryptographic-material-providers-library/commit/000baedfab341670952449837541c88ea5cf1dba))
+
+
+### Features
+
+* ddbv2 net patch ([a36f799](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a36f7997ea26befba0ce6090314d17d44d7596f5))
+* ddbv2 re-polymorph ([1357f42](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1357f42dfd8f24dcefdc07e248911d54bec26f2a))
+* ddbv2 upgrade ([1584fbc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1584fbce54c69aaaace6935f5949e13d07613d3f))
+
 ## [1.7.3](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.2...v1.7.3) (2024-10-31)
 
 This release is available in the following languages:

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.7.4")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.7.4</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.3</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.7.3"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 
 # Package testing
 

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.8.0"
+version = "1.7.4"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = "1.8.0"
+aws-cryptography-internal-standard-library = "1.7.4"
 
 # Package testing
 

--- a/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,5 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.ComAmazonawsDynamodbTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.3</Version>
+    <Version>1.8.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.7.4</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.7.4")]

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.7.3"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.8.0"
+version = "1.7.4"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = "1.8.0"
+aws-cryptography-internal-standard-library = "1.7.4"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,5 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.ComAmazonawsKmsTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.7.3")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.7.4")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.8.0</Version>
+    <Version>1.7.4</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.7.3</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.8.0"
+version = "1.7.4"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.7.3"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,5 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.Wrappers]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.8.0"
+version = "1.7.4"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {
@@ -68,7 +68,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.7.3-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.7.4")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.3-SNAPSHOT"
+version = "1.8.0"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
@@ -1,5 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.MplManifestOptions]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
@@ -1,4 +1,4 @@
 file_format_version = "1.0"
-dafny_version = "4.8.1.0"
+dafny_version = "4.8.0.0"
 [options_by_module.TestWrappedMaterialProvidersMain]
 legacy-module-names = false

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.8.0
 dafnyVerifyVersion=4.8.0
-mplVersion=1.7.3-SNAPSHOT
+mplVersion=1.7.4


### PR DESCRIPTION
I manually changed this from 1.8.0 to 1.7.4.
We borked the MPL commit history, and `semantic-release` tried cutting this as 1.8.0.

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
