### PR TITLE
fix(Python-Release): Run validate tests from release commit

### DIFF
--- a/AwsCryptographicMaterialProviders/codebuild/release-python/validate.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/validate.yml
@@ -25,6 +25,9 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Check out tests for release commit
+      - git fetch --tags
+      - git checkout $COMMIT_ID
       # Install test dependencies
       - pyenv install --skip-existing 3.11
       - pyenv local 3.11

--- a/AwsCryptographyPrimitives/codebuild/release-python/validate.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/validate.yml
@@ -20,6 +20,9 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Check out tests for release commit
+      - git fetch --tags
+      - git checkout $COMMIT_ID
       # Install test dependencies
       - pyenv install --skip-existing 3.11
       - pyenv local 3.11

--- a/ComAmazonawsDynamodb/codebuild/release-python/validate.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/validate.yml
@@ -20,6 +20,9 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Check out tests for release commit
+      - git fetch --tags
+      - git checkout $COMMIT_ID
       # Install test dependencies
       - pyenv install --skip-existing 3.11
       - pyenv local 3.11

--- a/ComAmazonawsKms/codebuild/release-python/validate.yml
+++ b/ComAmazonawsKms/codebuild/release-python/validate.yml
@@ -20,6 +20,9 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Check out tests for release commit
+      - git fetch --tags
+      - git checkout $COMMIT_ID
       # Install test dependencies
       - pyenv install --skip-existing 3.11
       - pyenv local 3.11

--- a/StandardLibrary/codebuild/release-python/validate.yml
+++ b/StandardLibrary/codebuild/release-python/validate.yml
@@ -20,6 +20,9 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Check out tests for release commit
+      - git fetch --tags
+      - git checkout $COMMIT_ID
       # Install test dependencies
       - pyenv install --skip-existing 3.11
       - pyenv local 3.11


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Release validate step failed because the `validate` tests are built from the head of main.
The head of main has a new Dafny module that the release commit doesn't have: [StandardLibrary.Sequence](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f9fb3ef40b56bedf29839daa3cfe9153ae94d932#diff-6b1486e3357d28c1914d5d449d07b9e9caea5da120af728b16cd2abb81e69656R6).
The tests fail because they're expecting to find `StandardLibrary.Sequence` in the release code, but it isn't there.
The tests should build from the release commit, not the head of main.

Fix: Tests build from the same commit the release was built from.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
