### PR TITLE
feat: Simplify error when decrypting a single EDK

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsEcdhKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsEcdhKeyring.dfy
@@ -348,10 +348,14 @@ module {:options "/functionSyntax:4" } AwsKmsEcdhKeyring {
       //# If OnDecrypt fails to successfully decrypt any encrypted data key,
       //# then it MUST yield an error that includes all the collected errors.
       var SealedDecryptionMaterials :- outcome
-      .MapFailure(errors => Types.CollectionOfErrors(
-                      list := errors,
-                      message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
-                    )
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
+                      )
       );
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -368,10 +368,14 @@ module AwsKmsHierarchicalKeyring {
       //# If OnDecrypt fails to successfully decrypt any [encrypted data key]
       //# (../structures.md#encrypted-data-key), then it MUST yield an error
       //# that includes all the collected errors.
-      .MapFailure(errors => Types.CollectionOfErrors(
-                      list := errors,
-                      message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
-                    )
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
+                      )
       );
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsKeyring.dfy
@@ -541,9 +541,13 @@ module AwsKmsKeyring {
       //# If OnDecrypt fails to successfully decrypt any [encrypted data key]
       //# (../structures.md#encrypted-data-key), then it MUST yield an error
       //# that includes all the collected errors.
-      .MapFailure(errors => Types.CollectionOfErrors(
-                      list := errors,
-                      message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));
       return Success(Types.OnDecryptOutput(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsMrkKeyring.dfy
@@ -516,8 +516,13 @@ module AwsKmsMrkKeyring {
       );
 
       var SealedDecryptionMaterials :- outcome
-      .MapFailure(errors => Types.CollectionOfErrors( list := errors,
-                                                                    message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));
       assert Last(attempts).input in input.encryptedDataKeys;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsRsaKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsRsaKeyring.dfy
@@ -262,8 +262,13 @@ module AwsKmsRsaKeyring {
       );
 
       var SealedDecryptionMaterials :- outcome
-      .MapFailure(errors => Types.CollectionOfErrors(list := errors,
-                                                                   message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured KMS Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."));
 
       assert decryptClosure.Ensures(Seq.Last(attempts).input, Success(SealedDecryptionMaterials), Seq.DropLast(attempts));
       return Success(Types.OnDecryptOutput(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/RawECDHKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/RawECDHKeyring.dfy
@@ -363,10 +363,14 @@ module {:options "/functionSyntax:4" } RawECDHKeyring {
       //# If OnDecrypt fails to successfully decrypt any encrypted data key,
       //# then it MUST yield an error that includes all the collected errors.
       var SealedDecryptionMaterials :- outcome
-      .MapFailure(errors => Types.CollectionOfErrors(
-                      list := errors,
-                      message := "No Configured Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
-                    )
+      .MapFailure(errors =>
+                    if |errors| == 1 then
+                      errors[0]
+                    else
+                      Types.CollectionOfErrors(
+                        list := errors,
+                        message := "No Configured Key was able to decrypt the Data Key. The list of encountered Exceptions is available via `list`."
+                      )
       );
 
       assert decryptClosure.Ensures(Last(attempts).input, Success(SealedDecryptionMaterials), DropLast(attempts));


### PR DESCRIPTION
Decryption may attempt to decrypt multipule encrypted data keys (EDK) To return all errors we wrap them in a `CollectionOfErrors`.

However, unwrapping these errors can be complicated. To simplify, if there is only a single error,
don’t wrap it, just return the single error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
