### PR TITLE
chore(release): 1.8.0 [skip ci]

### DIFF
--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -26,10 +26,10 @@ jobs:
             macos-13,
           ]
         language: [
-            java, 
-            net, 
-            # python, 
-            rust
+            java,
+            net,
+            # python,
+            rust,
           ]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
         dotnet-version: ["6.0.x"]
@@ -201,13 +201,13 @@ jobs:
             java,
             net,
             # python,
-            rust
+            rust,
           ]
         decrypting_language: [
             java,
             net,
             # python,
-            rust
+            rust,
           ]
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -197,8 +197,18 @@ jobs:
             ubuntu-latest,
             macos-13,
           ]
-        encrypting_language: [java, net, python, rust]
-        decrypting_language: [java, net, python, rust]
+        encrypting_language: [
+            java,
+            net,
+            # python,
+            rust
+          ]
+        decrypting_language: [
+            java,
+            net,
+            # python,
+            rust
+          ]
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -25,7 +25,12 @@ jobs:
             ubuntu-latest,
             macos-13,
           ]
-        language: [java, net, python, rust]
+        language: [
+            java, 
+            net, 
+            # python, 
+            rust
+          ]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}

--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.4-SNAPSHOT"
+version = "1.8.0"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.7.4")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.7.4</Version>
+      <Version>1.8.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.7.4"
+version = "1.8.0"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
+aws-cryptography-internal-kms = "1.8.0"
+aws-cryptography-internal-dynamodb = "1.8.0"
+aws-cryptography-internal-primitives = "1.8.0"
 
 # Package testing
 

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.7.4")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.7.4"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 cryptography = "^43.0.1"
 
 # Package testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,20 @@ This release is available in the following languages:
 
 ### Bug Fixes
 
-* Drop SelectOpt from MutableMap ([bdb6509](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bdb65098881245dfed0f2251bd654313e31b1b89))
-* Externs ([0bc1f96](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0bc1f961462dd9e3821fea438e3067d543adab9c))
-* formatting ([b608ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b608ab88e155bdb23e21f8b3f0f75116b58b182d))
-* **Python-Release:** Run validate tests from release commit ([41c0c94](https://github.com/aws/aws-cryptographic-material-providers-library/commit/41c0c94aac165addcef6e75bc7bad5c1dffa16ac))
-* **Python:** CMCs release lock for unhandled runtime exceptions ([#979](https://github.com/aws/aws-cryptographic-material-providers-library/issues/979)) ([1510b77](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1510b772550646b6e1f26df5b0e6e96b3e48a6e3))
-* **Python:** return error on interrupted sleep ([#1003](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1003)) ([405cf37](https://github.com/aws/aws-cryptographic-material-providers-library/commit/405cf37a20ffe8c36f49eccc95a7482ee97d3f7b))
-* remove input and output traits on DynamoDB operations ([#1012](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1012)) ([8377acf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8377acfbd505236ca9bb58f21f95cfc5122d1cf9))
-* return error on interrupted sleep ([#993](https://github.com/aws/aws-cryptographic-material-providers-library/issues/993)) ([f49460a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f49460a569ea03778db3d1856a54b7d9b53fb9e6))
-* rust CI ([42e39cc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/42e39cc8e64b18387b738746457924bcf5dd47e9))
-
+- Drop SelectOpt from MutableMap ([bdb6509](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bdb65098881245dfed0f2251bd654313e31b1b89))
+- Externs ([0bc1f96](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0bc1f961462dd9e3821fea438e3067d543adab9c))
+- formatting ([b608ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b608ab88e155bdb23e21f8b3f0f75116b58b182d))
+- **Python-Release:** Run validate tests from release commit ([41c0c94](https://github.com/aws/aws-cryptographic-material-providers-library/commit/41c0c94aac165addcef6e75bc7bad5c1dffa16ac))
+- **Python:** CMCs release lock for unhandled runtime exceptions ([#979](https://github.com/aws/aws-cryptographic-material-providers-library/issues/979)) ([1510b77](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1510b772550646b6e1f26df5b0e6e96b3e48a6e3))
+- **Python:** return error on interrupted sleep ([#1003](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1003)) ([405cf37](https://github.com/aws/aws-cryptographic-material-providers-library/commit/405cf37a20ffe8c36f49eccc95a7482ee97d3f7b))
+- remove input and output traits on DynamoDB operations ([#1012](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1012)) ([8377acf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8377acfbd505236ca9bb58f21f95cfc5122d1cf9))
+- return error on interrupted sleep ([#993](https://github.com/aws/aws-cryptographic-material-providers-library/issues/993)) ([f49460a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f49460a569ea03778db3d1856a54b7d9b53fb9e6))
+- rust CI ([42e39cc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/42e39cc8e64b18387b738746457924bcf5dd47e9))
 
 ### Features
 
-* **Rust:** Interop test vectors; bump Dafny to 4.9.0 ([#1004](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1004)) ([a505a30](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a505a304f7cf7ed2490498af85c703dc85faf7ab))
-* Storm cache supports millisecond resolution ([#1011](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1011)) ([6f09d5d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6f09d5d23ecd76658e6d90b23e15ce5daade5bd2))
+- **Rust:** Interop test vectors; bump Dafny to 4.9.0 ([#1004](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1004)) ([a505a30](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a505a304f7cf7ed2490498af85c703dc85faf7ab))
+- Storm cache supports millisecond resolution ([#1011](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1011)) ([6f09d5d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6f09d5d23ecd76658e6d90b23e15ce5daade5bd2))
 
 # [1.7.4](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.3...v1.7.4) (2024-11-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+# [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.4...v1.8.0) (2024-11-19)
+
+
+### Bug Fixes
+
+* Drop SelectOpt from MutableMap ([bdb6509](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bdb65098881245dfed0f2251bd654313e31b1b89))
+* Externs ([0bc1f96](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0bc1f961462dd9e3821fea438e3067d543adab9c))
+* formatting ([b608ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b608ab88e155bdb23e21f8b3f0f75116b58b182d))
+* **Python-Release:** Run validate tests from release commit ([41c0c94](https://github.com/aws/aws-cryptographic-material-providers-library/commit/41c0c94aac165addcef6e75bc7bad5c1dffa16ac))
+* **Python:** CMCs release lock for unhandled runtime exceptions ([#979](https://github.com/aws/aws-cryptographic-material-providers-library/issues/979)) ([1510b77](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1510b772550646b6e1f26df5b0e6e96b3e48a6e3))
+* **Python:** return error on interrupted sleep ([#1003](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1003)) ([405cf37](https://github.com/aws/aws-cryptographic-material-providers-library/commit/405cf37a20ffe8c36f49eccc95a7482ee97d3f7b))
+* remove input and output traits on DynamoDB operations ([#1012](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1012)) ([8377acf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8377acfbd505236ca9bb58f21f95cfc5122d1cf9))
+* return error on interrupted sleep ([#993](https://github.com/aws/aws-cryptographic-material-providers-library/issues/993)) ([f49460a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f49460a569ea03778db3d1856a54b7d9b53fb9e6))
+* rust CI ([42e39cc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/42e39cc8e64b18387b738746457924bcf5dd47e9))
+
+
+### Features
+
+* **Rust:** Interop test vectors; bump Dafny to 4.9.0 ([#1004](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1004)) ([a505a30](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a505a304f7cf7ed2490498af85c703dc85faf7ab))
+* Storm cache supports millisecond resolution ([#1011](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1011)) ([6f09d5d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6f09d5d23ecd76658e6d90b23e15ce5daade5bd2))
+
 # [1.7.4](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.3...v1.7.4) (2024-11-06)
 
 This release is available in the following languages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.4...v1.8.0) (2024-11-19)
 
+This release is available in the following languages:
+
+- Java
 
 ### Bug Fixes
 

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.7.4")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.7.4"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.7.4")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.7.4"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.8.0"
 
 # Package testing
 

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.7.4")]
+[assembly: AssemblyVersion("1.8.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.7.4</Version>
+    <Version>1.8.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.7.4"
+version = "1.8.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -81,6 +81,9 @@ python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
 [options_by_module."StandardLibrary.UInt"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
 [options_by_module."StandardLibrary.String"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -68,7 +68,7 @@ repositories {
 dependencies {
     implementation("org.dafny:DafnyRuntime:${dafnyVersion}")
     implementation("software.amazon.smithy.dafny:conversion:0.1.1")
-    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.7.4-SNAPSHOT")
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:1.8.0")
     implementation(platform("software.amazon.awssdk:bom:2.25.1"))
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.4-SNAPSHOT"
+version = "1.8.0"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.0
-mplVersion=1.7.4-SNAPSHOT
+mplVersion=1.8.0


### PR DESCRIPTION
# [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.4...v1.8.0) (2024-11-19)

### Bug Fixes

* Drop SelectOpt from MutableMap ([bdb6509](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bdb65098881245dfed0f2251bd654313e31b1b89))
* Externs ([0bc1f96](https://github.com/aws/aws-cryptographic-material-providers-library/commit/0bc1f961462dd9e3821fea438e3067d543adab9c))
* formatting ([b608ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b608ab88e155bdb23e21f8b3f0f75116b58b182d))
* **Python-Release:** Run validate tests from release commit ([41c0c94](https://github.com/aws/aws-cryptographic-material-providers-library/commit/41c0c94aac165addcef6e75bc7bad5c1dffa16ac))
* **Python:** CMCs release lock for unhandled runtime exceptions ([#979](https://github.com/aws/aws-cryptographic-material-providers-library/issues/979)) ([1510b77](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1510b772550646b6e1f26df5b0e6e96b3e48a6e3))
* **Python:** return error on interrupted sleep ([#1003](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1003)) ([405cf37](https://github.com/aws/aws-cryptographic-material-providers-library/commit/405cf37a20ffe8c36f49eccc95a7482ee97d3f7b))
* remove input and output traits on DynamoDB operations ([#1012](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1012)) ([8377acf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8377acfbd505236ca9bb58f21f95cfc5122d1cf9))
* return error on interrupted sleep ([#993](https://github.com/aws/aws-cryptographic-material-providers-library/issues/993)) ([f49460a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f49460a569ea03778db3d1856a54b7d9b53fb9e6))
* rust CI ([42e39cc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/42e39cc8e64b18387b738746457924bcf5dd47e9))

### Features

* **Rust:** Interop test vectors; bump Dafny to 4.9.0 ([#1004](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1004)) ([a505a30](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a505a304f7cf7ed2490498af85c703dc85faf7ab))
* Storm cache supports millisecond resolution ([#1011](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1011)) ([6f09d5d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6f09d5d23ecd76658e6d90b23e15ce5daade5bd2))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
