### PR TITLE
fix(Java): Improve Collection of Errors string

### DIFF
--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/java/dafny-4.9.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographicMaterialProviders/java/dafny-4.9.0.patch
@@ -1,0 +1,29 @@
+diff --git b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java
+index 796adaa3e..062f23538 100644
+--- b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java
++++ a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java
+@@ -4,6 +4,9 @@
+ package software.amazon.cryptography.materialproviders.model;
+ 
+ import java.util.List;
++import java.util.stream.Collectors;
++import software.amazon.awssdk.utils.CollectionUtils;
++import software.amazon.awssdk.utils.StringUtils;
+ 
+ public class CollectionOfErrors extends RuntimeException {
+ 
+@@ -134,6 +137,14 @@ public class CollectionOfErrors extends RuntimeException {
+     }
+ 
+     public CollectionOfErrors build() {
++      if (!(this.list == null || this.list.isEmpty())) {
++        this.message =
++          this.message +
++          " String rep of Exceptions in list.\n" +
++          this.list.stream()
++            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
++            .collect(Collectors.joining("\n"));
++      }
+       return new CollectionOfErrors(this);
+     }
+   }

--- a/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/java/dafny-4.9.0.patch
+++ b/AwsCryptographicMaterialProviders/codegen-patches/AwsCryptographyKeyStore/java/dafny-4.9.0.patch
@@ -1,0 +1,28 @@
+diff --git b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java
+index 9247dd55f..df7b32b85 100644
+--- b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java
++++ a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java
+@@ -4,6 +4,8 @@
+ package software.amazon.cryptography.keystore.model;
+ 
+ import java.util.List;
++import java.util.stream.Collectors;
++import software.amazon.awssdk.utils.CollectionUtils;
+ 
+ public class CollectionOfErrors extends RuntimeException {
+ 
+@@ -134,6 +136,14 @@ public class CollectionOfErrors extends RuntimeException {
+     }
+ 
+     public CollectionOfErrors build() {
++      if (!(this.list == null || this.list.isEmpty())) {
++        this.message =
++          this.message +
++          " String rep of Exceptions in list.\n" +
++          this.list.stream()
++            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
++            .collect(Collectors.joining("\n"));
++      }
+       return new CollectionOfErrors(this);
+     }
+   }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/CollectionOfErrors.java
@@ -4,6 +4,8 @@
 package software.amazon.cryptography.keystore.model;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.utils.CollectionUtils;
 
 public class CollectionOfErrors extends RuntimeException {
 
@@ -134,6 +136,14 @@ public class CollectionOfErrors extends RuntimeException {
     }
 
     public CollectionOfErrors build() {
+      if (!(this.list == null || this.list.isEmpty())) {
+        this.message =
+          this.message +
+          " String rep of Exceptions in list.\n" +
+          this.list.stream()
+            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
+            .collect(Collectors.joining("\n"));
+      }
       return new CollectionOfErrors(this);
     }
   }

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/CollectionOfErrors.java
@@ -4,6 +4,9 @@
 package software.amazon.cryptography.materialproviders.model;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import software.amazon.awssdk.utils.CollectionUtils;
+import software.amazon.awssdk.utils.StringUtils;
 
 public class CollectionOfErrors extends RuntimeException {
 
@@ -134,6 +137,14 @@ public class CollectionOfErrors extends RuntimeException {
     }
 
     public CollectionOfErrors build() {
+      if (!(this.list == null || this.list.isEmpty())) {
+        this.message =
+          this.message +
+          " String rep of Exceptions in list.\n" +
+          this.list.stream()
+            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
+            .collect(Collectors.joining("\n"));
+      }
       return new CollectionOfErrors(this);
     }
   }

--- a/AwsCryptographyPrimitives/codegen-patches/java/dafny-4.9.0.patch
+++ b/AwsCryptographyPrimitives/codegen-patches/java/dafny-4.9.0.patch
@@ -1,0 +1,27 @@
+diff --git b/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java a/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java
+index 7ba6ce4a4..4a0a9986d 100644
+--- b/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java
++++ a/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java
+@@ -4,6 +4,7 @@
+ package software.amazon.cryptography.primitives.model;
+ 
+ import java.util.List;
++import java.util.stream.Collectors;
+ 
+ public class CollectionOfErrors extends RuntimeException {
+ 
+@@ -134,6 +135,14 @@ public class CollectionOfErrors extends RuntimeException {
+     }
+ 
+     public CollectionOfErrors build() {
++      if (!(this.list == null || this.list.isEmpty())) {
++        this.message =
++          this.message +
++          " String rep of Exceptions in list.\n" +
++          this.list.stream()
++            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
++            .collect(Collectors.joining("\n"));
++      }
+       return new CollectionOfErrors(this);
+     }
+   }

--- a/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java
+++ b/AwsCryptographyPrimitives/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/primitives/model/CollectionOfErrors.java
@@ -4,6 +4,7 @@
 package software.amazon.cryptography.primitives.model;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class CollectionOfErrors extends RuntimeException {
 
@@ -134,6 +135,14 @@ public class CollectionOfErrors extends RuntimeException {
     }
 
     public CollectionOfErrors build() {
+      if (!(this.list == null || this.list.isEmpty())) {
+        this.message =
+          this.message +
+          " String rep of Exceptions in list.\n" +
+          this.list.stream()
+            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
+            .collect(Collectors.joining("\n"));
+      }
       return new CollectionOfErrors(this);
     }
   }

--- a/TestVectorsAwsCryptographicMaterialProviders/codegen-patches/KeyVectors/java/dafny-4.9.0.patch
+++ b/TestVectorsAwsCryptographicMaterialProviders/codegen-patches/KeyVectors/java/dafny-4.9.0.patch
@@ -1,0 +1,19 @@
+diff --git b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java
+index c8bb5b93a..8d1499d27 100644
+--- b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java
++++ a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java
+@@ -134,6 +134,14 @@ public class CollectionOfErrors extends RuntimeException {
+     }
+ 
+     public CollectionOfErrors build() {
++      if (!(this.list == null || this.list.isEmpty())) {
++        this.message =
++          this.message +
++          " String rep of Exceptions in list.\n" +
++          this.list.stream()
++            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
++            .collect(Collectors.joining("\n"));
++      }
+       return new CollectionOfErrors(this);
+     }
+   }

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviderstestvectorkeys/model/CollectionOfErrors.java
@@ -134,6 +134,14 @@ public class CollectionOfErrors extends RuntimeException {
     }
 
     public CollectionOfErrors build() {
+      if (!(this.list == null || this.list.isEmpty())) {
+        this.message =
+          this.message +
+          " String rep of Exceptions in list.\n" +
+          this.list.stream()
+            .map(ex -> ex.getClass().getSimpleName() + ": " + ex.getMessage())
+            .collect(Collectors.joining("\n"));
+      }
       return new CollectionOfErrors(this);
     }
   }


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Collection of Errors is a frustrating error because it requires customer action
completely serialize it into logs.

We can make a simple fix in Java to improve the CX,
by always serializing the list into the Collection Of Error's
message.

We concatenate the given error message with 
a serialization of all the nested errors.

_Squash/merge commit message, if applicable:_
```
fix(Java): Improve Collection of Errors string
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
