### PR TITLE
chore(GHW): Smithy-Diff should be on the PR diff, not diff b/w main

### DIFF
--- a/.github/workflows/smithy-diff.yml
+++ b/.github/workflows/smithy-diff.yml
@@ -22,10 +22,11 @@ jobs:
         shell: bash
         env:
           GITHUB_HEAD: ${{github.event.pull_request.head.ref}}
+          GITHUB_BASE: ${{github.event.pull_request.base.ref}}
         run:
           # Checks to see if any of the smithy Models are being updated.
           # Doing this check allows us to catch things like, missing @javadoc trait documentation or bug in smithy dafny that has not be resolved.
-          echo "FILES=$(git diff --name-only origin/main origin/${GITHUB_HEAD} | grep '\.smithy$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
+          echo "FILES=$(git diff --name-only origin/${GITHUB_BASE} origin/${GITHUB_HEAD} | grep '\.smithy$' | tr '\n' ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Check if FILES is not empty
         id: comment


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

I have noticed that the this workflow is commenting on PRs that do not even have a Smithy Diff.
The reason is that it always compares b/w `main` and the PR's Head.

I suggest the workflow check the PRs diff,
as compared to the diff b/w PR's HEAD and main.

_Squash/merge commit message, if applicable:_
```
chore(GHW): Smithy-Diff should be on the PR diff, not diff b/w main 
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
