### PR TITLE
chore(rust-ecdh-extern): Update to use extern function in ESDK examples

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
+++ b/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
@@ -123,7 +123,7 @@ pub mod ECDH {
             Ok(out_buf[..new_size].to_vec())
         }
 
-        pub(crate) fn X962_to_X509(
+        pub fn X962_to_X509(
             public_key: &[u8],
             alg: &ECDHCurveSpec,
         ) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
Make the ECDH extern function `X962_to_X509` `pub` instead of `pub(crate)` to use it in the examples, in order to avoid code duplication.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
