### PR TITLE
chore(rust-ecdh-extern): Rollback update to extern function

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
+++ b/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
@@ -123,7 +123,7 @@ pub mod ECDH {
             Ok(out_buf[..new_size].to_vec())
         }
 
-        pub(crate) fn X962_to_X509(
+        pub(crate) fn X962_to_X509( 
             public_key: &[u8],
             alg: &ECDHCurveSpec,
         ) -> Result<Vec<u8>, String> {

--- a/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
+++ b/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
@@ -123,7 +123,7 @@ pub mod ECDH {
             Ok(out_buf[..new_size].to_vec())
         }
 
-        pub(crate) fn X962_to_X509( 
+        pub(crate) fn X962_to_X509(
             public_key: &[u8],
             alg: &ECDHCurveSpec,
         ) -> Result<Vec<u8>, String> {

--- a/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
+++ b/AwsCryptographicMaterialProviders/runtimes/rust/src/ecdh.rs
@@ -123,7 +123,7 @@ pub mod ECDH {
             Ok(out_buf[..new_size].to_vec())
         }
 
-        pub fn X962_to_X509(
+        pub(crate) fn X962_to_X509(
             public_key: &[u8],
             alg: &ECDHCurveSpec,
         ) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
Reverts aws/aws-cryptographic-material-providers-library#1076

Once aws-lc-rs supports the various formats we need, we want to drop the dependence on aws-lc-sys.

If we keep the function public, we will have to support it forever. This will make the above update a blocking change. For Rust ECDH examples, we will create a function that mimics `X962_to_X509` so that we can update it with the aws-lc-rs conversions once they are supported.