### PR TITLE
test(KSA): Utilize Limit KMS Clients in Mutation D/E test

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/Fixtures.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/Fixtures.java
@@ -16,8 +16,11 @@ public class Fixtures {
   public static final String TEST_KEYSTORE_NAME = "KeyStoreDdbTable";
   public static final String TEST_LOGICAL_KEYSTORE_NAME = "KeyStoreDdbTable";
 
+  // KMS Keys
+  // HierarchicalGitHubKMSKeyIDTwo
   public static final String POSTAL_HORN_KEY_ARN =
     "arn:aws:kms:us-west-2:370957321024:key/bc127593-f7da-452c-a1f3-cd34c46f81f8";
+  // HierarchicalGitHubKMSKeyID
   public static final String KEYSTORE_KMS_ARN =
     "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126";
   public static final String MRK_ARN_EAST =
@@ -27,11 +30,19 @@ public class Fixtures {
   // Key MUST NOT exist in ap-south-2
   public static final String MRK_ARN_AP =
     "arn:aws:kms:ap-south-2:658956600833:key/mrk-80bd8ecdcd4342aebd84b7dc9da498a7";
+  public static final String KSA_SYSTEM_KEY =
+    "arn:aws:kms:us-west-2:370957321024:key/6613e250-b2e7-4c4c-a54e-2b241f837242";
+
+  // IAM Roles
   public static final String LIMITED_KMS_ACCESS_IAM_ROLE =
     "arn:aws:iam::370957321024:role/GitHub-CI-MPL-Limited-KMS-us-west-2";
   // ^ can not access: MRK_ARN_EAST, MRK_ARN_WEST, and MRK_ARN_AP
   public static final String NO_KMS_ACCESS_IAM_ROLE =
     "arn:aws:iam::370957321024:role/GitHub-CI-MPL-No-KMS-us-west-2";
+  public static final String KMS_POSTAL_HORN_ONLY =
+    "arn:aws:iam::370957321024:role/Restricted-KMS-HKey-Two-Only";
+  public static final String KMS_KEYSTORE_ONLY =
+    "arn:aws:iam::370957321024:role/Restricted-KMS-HKey-One-Only";
 
   public static final AwsCredentialsProvider defaultCreds =
     DefaultCredentialsProvider.create();
@@ -62,6 +73,34 @@ public class Fixtures {
     .credentialsProvider(
       CredentialUtils.credsForRole(
         Fixtures.LIMITED_KMS_ACCESS_IAM_ROLE,
+        "java-mpl-examples",
+        Region.US_WEST_2,
+        Fixtures.httpClient,
+        Fixtures.defaultCreds
+      )
+    )
+    .region(Region.US_WEST_2)
+    .httpClient(Fixtures.httpClient)
+    .build();
+  public static final KmsClient postalHornOnlyKmsClient = KmsClient
+    .builder()
+    .credentialsProvider(
+      CredentialUtils.credsForRole(
+        Fixtures.KMS_POSTAL_HORN_ONLY,
+        "java-mpl-examples",
+        Region.US_WEST_2,
+        Fixtures.httpClient,
+        Fixtures.defaultCreds
+      )
+    )
+    .region(Region.US_WEST_2)
+    .httpClient(Fixtures.httpClient)
+    .build();
+  public static final KmsClient keyStoreOnlyKmsClient = KmsClient
+    .builder()
+    .credentialsProvider(
+      CredentialUtils.credsForRole(
+        Fixtures.KMS_KEYSTORE_ONLY,
         "java-mpl-examples",
         Region.US_WEST_2,
         Fixtures.httpClient,

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
@@ -51,7 +51,7 @@ public class MutationsProvider {
   }
 
   public static SystemKey KmsSystemKey() {
-    return KmsSystemKey(Fixtures.POSTAL_HORN_KEY_ARN);
+    return KmsSystemKey(Fixtures.KSA_SYSTEM_KEY);
   }
 
   public static SystemKey KmsSystemKey(@Nonnull final String systemKeyArn) {

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsSystemKeyTrustExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/examples/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsSystemKeyTrustExample.java
@@ -90,7 +90,7 @@ public class MutationsSystemKeyTrustExample {
       result =
         workPage(
           identifier,
-          MutationsProvider.KmsSystemKey(Fixtures.POSTAL_HORN_KEY_ARN),
+          MutationsProvider.KmsSystemKey(Fixtures.KSA_SYSTEM_KEY),
           token,
           strategy,
           admin,

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
@@ -119,7 +119,7 @@ public class ExampleTests {
   @Test
   public void End2EndDecryptEncryptTest() {
     String branchKeyId = CreateKeyExample.CreateKey(
-      Fixtures.MRK_ARN_WEST,
+      Fixtures.KEYSTORE_KMS_ARN,
       null,
       AdminProvider.admin()
     );
@@ -128,8 +128,8 @@ public class ExampleTests {
       MutationDecryptEncryptExample.End2End(
         branchKeyId,
         Fixtures.POSTAL_HORN_KEY_ARN,
-        AwsKms.builder().kmsClient(Fixtures.kmsClientWest2).build(),
-        AwsKms.builder().kmsClient(Fixtures.denyMrkKmsClient).build(),
+        AwsKms.builder().kmsClient(Fixtures.keyStoreOnlyKmsClient).build(),
+        AwsKms.builder().kmsClient(Fixtures.postalHornOnlyKmsClient).build(),
         MutationsProvider.KmsSystemKey(),
         AdminProvider.admin()
       );

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/DescribeMutationTest.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/DescribeMutationTest.java
@@ -80,7 +80,7 @@ public class DescribeMutationTest {
   public void TestKmsSymEncDescription() {
     //noinspection unchecked
     SystemKey systemKey = MutationsProvider.KmsSystemKey(
-      Fixtures.POSTAL_HORN_KEY_ARN,
+      Fixtures.KSA_SYSTEM_KEY,
       Fixtures.kmsClientWest2,
       Collections.EMPTY_LIST
     );

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyKMSExample.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyKMSExample.java
@@ -15,7 +15,7 @@ public class TestMutationSystemKeyKMSExample {
       testPrefix + java.util.UUID.randomUUID().toString();
     CreateKeyExample.CreateKey(Fixtures.MRK_ARN_WEST, branchKeyId, null);
     MutationSystemKeyKMSExample.End2End(
-      Fixtures.POSTAL_HORN_KEY_ARN,
+      Fixtures.KSA_SYSTEM_KEY,
       branchKeyId,
       Fixtures.KEYSTORE_KMS_ARN
     );

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsSystemKeyKMSTamper.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/testExamples/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsSystemKeyKMSTamper.java
@@ -203,7 +203,7 @@ public class TestMutationsSystemKeyKMSTamper {
     CreateKeyExample.CreateKey(Fixtures.MRK_ARN_WEST, identifier, null);
     //noinspection unchecked
     SystemKey systemKey = MutationsProvider.KmsSystemKey(
-      Fixtures.POSTAL_HORN_KEY_ARN,
+      Fixtures.KSA_SYSTEM_KEY,
       Fixtures.kmsClientWest2,
       Collections.EMPTY_LIST
     );


### PR DESCRIPTION
This ensures that our implementation is correct,
as if it was not,
the incorrect KMS Client would be used,
and the request would fail.

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
