### PR TITLE
fix(MPL): remove un-used imports

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationStateStructures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationStateStructures.dfy
@@ -1,8 +1,6 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 include "../Model/AwsCryptographyKeyStoreAdminTypes.dfy"
-include "../../../../libraries/src/Collections/Sets/Sets.dfy"
-include "../../../../libraries/src/Collections/Maps/Maps.dfy"
 include "../../../../libraries/src/JSON/API.dfy"
 include "../../../../libraries/src/JSON/Errors.dfy"
 include "../../../../libraries/src/JSON/Values.dfy"
@@ -18,8 +16,6 @@ module {:options "/functionSyntax:4" } MutationStateStructures {
   import opened Seq
   import UTF8
   import String = StandardLibrary.String
-  import Sets
-  import Maps
   import SortedSets
 
   import ErrorMessages = KeyStoreErrorMessages


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Dafny has some sensitivity with module imports that,
when this library is used in a Java environment with the DB-ESDK,
end up causing duplicated class paths.

```
[ht:validateClasspath]      for the following classes:
[ht:validateClasspath]          Sets_Compile.__default
[ht:validateClasspath]          Maps_Compile.__default
```

This occurs because the Mutation feature branch added 
a dependency on Dafny-lang's library's Maps and Sets modules,
which are already dependencies of the DB-ESDK.

Dafny's `library` flag would have avoided this,
IF and ONLY IF the DB-ESDK is compiled by Dafny 
**knowing** that the MPL uses Maps and Sets.

Because the MPL added these dependencies,
it fails class path validation with older DB-ESDKs.

We do not have a CI check for class path validation.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
