### PR TITLE
chore: Add missing testvectors test 

### DIFF
--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -26,7 +26,7 @@ jobs:
             ComAmazonawsDynamodb,
             AwsCryptographyPrimitives,
             AwsCryptographicMaterialProviders,
-            TestVectorsAwsCryptographicMaterialProviders
+            TestVectorsAwsCryptographicMaterialProviders,
           ]
         go-version: ["1.23"]
         os: [

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -26,7 +26,7 @@ jobs:
             ComAmazonawsDynamodb,
             AwsCryptographyPrimitives,
             AwsCryptographicMaterialProviders,
-            TestVectorsAwsCryptographicMaterialProviders,
+            TestVectorsAwsCryptographicMaterialProviders
           ]
         go-version: ["1.23"]
         os: [
@@ -83,6 +83,13 @@ jobs:
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_go CORES=$CORES
+
+      # TODO: Remove this after Go polymorph does not generate unwanted duplicate code.
+      - name: Purge polymorph code in Go
+        if: matrix.library == 'TestVectorsAwsCryptographicMaterialProviders'
+        shell: bash
+        run: |
+          make purge_polymorph_code
 
       - name: Test ${{ matrix.library }}
         working-directory: ./${{ matrix.library }}

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -87,6 +87,7 @@ jobs:
       # TODO: Remove this after Go polymorph does not generate unwanted duplicate code.
       - name: Purge polymorph code in Go
         if: matrix.library == 'TestVectorsAwsCryptographicMaterialProviders'
+        working-directory: ./${{ matrix.library }}
         shell: bash
         run: |
           make purge_polymorph_code

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -26,6 +26,7 @@ jobs:
             ComAmazonawsDynamodb,
             AwsCryptographyPrimitives,
             AwsCryptographicMaterialProviders,
+            TestVectorsAwsCryptographicMaterialProviders,
           ]
         go-version: ["1.23"]
         os: [


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
There are two tests done for test vectors in CI. 
1. Interop test: Encrypt in one language and decrypt in another
2. library_runtime_tests: where testvector is tested in the same language by running `make test_go`.

We were missing the 2nd test. So, this PR adds it.

_Squash/merge commit message, if applicable:_
```
chore: Add missing testvectors test
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
