### PR TITLE
chore(Python): Restrict poetry-core to <2.0.0

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -48,5 +48,5 @@ sphinx = "^7"
 sphinx_rtd_theme = "^2"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -48,5 +48,5 @@ sphinx = "^7"
 sphinx_rtd_theme = "^2"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -35,5 +35,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -35,5 +35,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -33,5 +33,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -33,5 +33,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -34,5 +34,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -34,5 +34,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -39,5 +39,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -39,5 +39,5 @@ twine = "5.1.1"
 wheel = "0.38.4"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -18,5 +18,5 @@ aws-cryptographic-material-providers = { path = "../../../AwsCryptographicMateri
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]"]
 build-backend = "poetry.core.masonry.api"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -18,5 +18,5 @@ aws-cryptographic-material-providers = { path = "../../../AwsCryptographicMateri
 pytest = "^7.4.0"
 
 [build-system]
-requires = ["poetry-core<2.0.0"]"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

poetry released a new major version: https://pypi.org/project/poetry/2.0.0/
Python projects picked this up automatically because they didn't specify a maximum version for poetry.
This is bad, since this is a breaking change, and it broke building new Python libraries.
This doesn't break customers using the already-distributed MPL packages. This only breaks the build system, and we only rebuild the library in CI and for releases. I can install the published MPL from PyPI and use it without issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
