### PR TITLE
chore(release): 1.9.0

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.9.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.8.0</Version>
+      <Version>1.9.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.8.0"
+version = "1.9.0"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.9.0"
+aws-cryptography-internal-kms = "1.9.0"
+aws-cryptography-internal-dynamodb = "1.9.0"
+aws-cryptography-internal-primitives = "1.9.0"
 
 # Package testing
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
@@ -1,179 +1,238 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.AwsCryptographyKeyStoreTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsArnParsing]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkMatchForDecrypt]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsUtils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStoreErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KmsArn]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Structure]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KMSKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DDBKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeyStoreTable]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStore]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Materials]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Keyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkAreUnique]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Constants]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MaterialWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CanonicalEncryptionContext]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.IntermediateKeyWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.EdkWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.ErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StrictMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsDiscoveryKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DiscoveryMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkDiscoveryKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MrkAwareDiscoveryMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MrkAwareStrictMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.LocalCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.SynchronizedLocalCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StormTracker]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StormTrackingCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CacheConstants]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsHierarchicalKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsRsaKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.EcdhEdkWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawECDHKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsEcdhKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawAESKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawRSAKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Defaults]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Commitment]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultClientSupplier]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RequiredEncryptionContextCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.9.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.8.0"
+version = "1.9.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.9.0"
 cryptography = "^43.0.1"
 
 # Package testing

--- a/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,59 +1,78 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.AwsCryptographyPrimitivesTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternRandom]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Random]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AESEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternDigest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Digest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Signature]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.KdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.RSAEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AtomicPrimitives]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AesKdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+# [1.9.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.8.0...v1.9.0) (2025-02-03)
+
+
+### Bug Fixes
+
+* CI ([d9e2a1e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d9e2a1e673a5a81ff030b45b6a66ead35040484f))
+* DafnyLibraries.FileIO extern ([b150c48](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b150c48a0570407dc0462c6e91929ff18a92897c))
+* ECDH ValidatePublicKey err msg ([34a48fc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/34a48fcde591a5aef53ec29a44e11885efcea8ea))
+* for test vectors, use SetToSequenceSorted ([#1034](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1034)) ([21ad206](https://github.com/aws/aws-cryptographic-material-providers-library/commit/21ad206c54de90276ff4c8a23311731e66ab2a73))
+* **GHW:** check-files apply to PR, not to diff b/w HEAD and branch ([#1075](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1075)) ([1f53a92](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1f53a92481e89ae7656acb5240919ed161abe74d))
+* improve golang externs ([#1133](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1133)) ([b6ee16e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b6ee16e47ae44d5af140dd5b934870f21565aa18))
+* **Java:** Improve Collection of Errors string ([#1056](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1056)) ([9e195a1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9e195a1960fa18e1dc6efd0c9057c2ec6aed8e11))
+* line breaks ([21536c7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/21536c79fba4c31671bf02fd0cd56dad7e2d624e))
+* PR comments ([798214b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/798214b474edbecca6907054d3635f6f9903f6d6))
+* PR comments ([a21c0b3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a21c0b38b7ac184697b98524e9fe93ac974c9a3a))
+* PR comments ([7dd95bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7dd95bc8656f51d70529253691036ee10cc6b53a))
+* PR comments ([eed0d87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eed0d87ec161af904f57f229436bd731f465795d))
+* PR comments ([435515e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/435515eba9fbd3e457520aebfc1a26a968ab7a57))
+* re-enable aes_gcm_192 ([#1143](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1143)) ([23650a9](https://github.com/aws/aws-cryptographic-material-providers-library/commit/23650a9c6e1c897455e2d59d15b7d7a2c5a07cdd))
+* region ([5930ae4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/5930ae44e17014e660132298ffd37528b711e3be))
+* region ([e3454b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e3454b5a7fbf3c462ed56507133521a362ff89b1))
+* remove [@sensitive](https://github.com/sensitive) from smithy models ([#1123](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1123)) ([c939f3a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c939f3a6608aea60d1d3c2d6aa64ceef969457c2))
+* repo rename ([#1218](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1218)) ([c2f003c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c2f003cb679b9282981b539bbe50102e0952cb97))
+* revert pyproject.toml drop ([b5dbb5c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b5dbb5c83d0cc1c13676694c721dc160087e2ba9))
+* rust code used for testing must be allowed dead code ([#1148](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1148)) ([5997919](https://github.com/aws/aws-cryptographic-material-providers-library/commit/59979192a51ef5b1864ac36d57925d55eb562fa2))
+* SetToSequence should be a method, not a function ([#1035](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1035)) ([1169bc8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1169bc8ef34ebfe3937ea3be8acf7a187ef1517a))
+* smithy-dafny ([#1136](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1136)) ([6005777](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6005777e8157a1273a4293ac3b1c135d25140a47))
+
+
+### Features
+
+* Adds CI ([511ed35](https://github.com/aws/aws-cryptographic-material-providers-library/commit/511ed358751c846fca46e111001841f7dd7f3bf6))
+* check in polymorph go generated code  ([#1137](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1137)) ([d0fefbf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d0fefbf2a6a363a7aa6940ce7a45eb8e395654f0))
+* Check-in polymorph generated code ([bfc7cb9](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bfc7cb9f5645544d956a1c500a686c133196eb02))
+* ddb Go externs ([1e3737b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1e3737b2f6294e9399f19ac9fd7377f8b0e526f7))
+* **ddb:** Go release v0.0.1 ([#1201](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1201)) ([5293bfd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/5293bfd755952b243a57c9cb7e6718d807e09d9a))
+* **ddb:** Go release v0.0.3 ([#1210](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1210)) ([983f553](https://github.com/aws/aws-cryptographic-material-providers-library/commit/983f553337954a97db43e2c8cfb8bfa3378db345))
+* **Go:** Go module rename ([#1196](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1196)) ([b0876ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b0876ace8d4882dbee77887712469f799015e9dc))
+* kms externs for Go ([2d1f6d1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2d1f6d1da826433c566c4ce4d5ff53d7f7ab1bdc))
+* **kms:** Go release v0.0.1 ([#1199](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1199)) ([9c80544](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9c80544bbfeac5547915aa93795f9b79eac7db6b))
+* mpl externs ([#1105](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1105)) ([29bc52e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/29bc52eccca8dcb5cbce8c90563b8461b9ba0454))
+* **mpl:** Go release v0.0.1 ([#1211](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1211)) ([4508ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4508ab84bd6017e7db6f353d2195b93ac30761c9))
+* Primitives CI ([ce6e942](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ce6e9421a0632beae2fe554f258d0243ec4b99c3))
+* Primitives for Go ([8066826](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8066826b3b17b2355af4d8bf94dab54325932ae6))
+* **primitives:** Go release v0.0.1 ([#1203](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1203)) ([6bf0bbe](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6bf0bbe25650da820c4133e1d1b1bce813d33a9e))
+* StandardLibrary for Go ([587b57e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/587b57ee5ec341c9961e0d1689dfb26b1a271055))
+* StandardLibrary for Go ([94b4fd0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/94b4fd0e9f8a491103c5b9ca0b0c8ab892dd580e))
+* StandardLibrary for Go ([6ce1ce3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6ce1ce32f65955fea922eb9237ee813fa5536eb8))
+* **StdLib:** Go v0.0.1 release ([#1195](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1195)) ([95e54bf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95e54bf5ab4a5881f04f11a00aae074c7810add3))
+
 # [1.8.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.4...v1.8.0) (2024-11-19)
 
 This release is available in the following languages:

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.9.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.8.0"
+version = "1.9.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.9.0"
 # Package testing
 
 [tool.poetry.group.test]

--- a/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.ComAmazonawsDynamodbTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Dynamodb"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.9.0")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.8.0"
+version = "1.9.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.9.0"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.ComAmazonawsKmsTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Kms"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.8.0")]
+[assembly: AssemblyVersion("1.9.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.8.0</Version>
+    <Version>1.9.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.8.0"
+version = "1.9.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,254 +1,342 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.Wrappers]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Relations]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."Seq.MergeSort"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Math]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Seq]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.BoundedInts]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractUnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Unicode]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Functions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeEncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf8EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf16EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FileIO]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GeneralInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Mul]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivMod]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Power]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Logarithm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibraryInterop]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.UInt"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.Sequence"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.String"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibrary]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UUID]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UTF8]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Time]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Streams]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Sorting]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.SortedSets]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.HexStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetOpt]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FloatCompare]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ConcurrentCall]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64Lemmas]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Actions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DafnyLibraries]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Writers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Cursors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Parsers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Seq"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Vectors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Errors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Grammar"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.Uint16StrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.SpecProperties"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
@@ -1,104 +1,138 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.MplManifestOptions]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllAlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedAbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTestVectorKeysTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.JSONHelpers]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyMaterial]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyrings]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyStores]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyringFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CmmFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeysVectorOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllHierarchy]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKms]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAware]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAwareDiscovery]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsRsa]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsEcdh]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawAES]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawRSA]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllDefaultCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRequiredEncryptionContextCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllMulti]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WriteJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CompleteVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.ParseJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProvidersMain]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
@@ -1,4 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.8.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.TestWrappedMaterialProvidersMain]
 legacy-module-names = false
+rust-sync = false

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.0
-mplVersion=1.8.0-SNAPSHOT
+mplVersion=1.9.0


### PR DESCRIPTION
# [1.9.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.8.0...v1.9.0) (2025-02-03)

### Bug Fixes

* CI ([d9e2a1e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d9e2a1e673a5a81ff030b45b6a66ead35040484f))
* DafnyLibraries.FileIO extern ([b150c48](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b150c48a0570407dc0462c6e91929ff18a92897c))
* ECDH ValidatePublicKey err msg ([34a48fc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/34a48fcde591a5aef53ec29a44e11885efcea8ea))
* for test vectors, use SetToSequenceSorted ([#1034](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1034)) ([21ad206](https://github.com/aws/aws-cryptographic-material-providers-library/commit/21ad206c54de90276ff4c8a23311731e66ab2a73))
* **GHW:** check-files apply to PR, not to diff b/w HEAD and branch ([#1075](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1075)) ([1f53a92](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1f53a92481e89ae7656acb5240919ed161abe74d))
* improve golang externs ([#1133](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1133)) ([b6ee16e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b6ee16e47ae44d5af140dd5b934870f21565aa18))
* **Java:** Improve Collection of Errors string ([#1056](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1056)) ([9e195a1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9e195a1960fa18e1dc6efd0c9057c2ec6aed8e11))
* line breaks ([21536c7](https://github.com/aws/aws-cryptographic-material-providers-library/commit/21536c79fba4c31671bf02fd0cd56dad7e2d624e))
* PR comments ([798214b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/798214b474edbecca6907054d3635f6f9903f6d6))
* PR comments ([a21c0b3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/a21c0b38b7ac184697b98524e9fe93ac974c9a3a))
* PR comments ([7dd95bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7dd95bc8656f51d70529253691036ee10cc6b53a))
* PR comments ([eed0d87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eed0d87ec161af904f57f229436bd731f465795d))
* PR comments ([435515e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/435515eba9fbd3e457520aebfc1a26a968ab7a57))
* re-enable aes_gcm_192 ([#1143](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1143)) ([23650a9](https://github.com/aws/aws-cryptographic-material-providers-library/commit/23650a9c6e1c897455e2d59d15b7d7a2c5a07cdd))
* region ([5930ae4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/5930ae44e17014e660132298ffd37528b711e3be))
* region ([e3454b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e3454b5a7fbf3c462ed56507133521a362ff89b1))
* remove [@sensitive](https://github.com/sensitive) from smithy models ([#1123](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1123)) ([c939f3a](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c939f3a6608aea60d1d3c2d6aa64ceef969457c2))
* repo rename ([#1218](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1218)) ([c2f003c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c2f003cb679b9282981b539bbe50102e0952cb97))
* revert pyproject.toml drop ([b5dbb5c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b5dbb5c83d0cc1c13676694c721dc160087e2ba9))
* rust code used for testing must be allowed dead code ([#1148](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1148)) ([5997919](https://github.com/aws/aws-cryptographic-material-providers-library/commit/59979192a51ef5b1864ac36d57925d55eb562fa2))
* SetToSequence should be a method, not a function ([#1035](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1035)) ([1169bc8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1169bc8ef34ebfe3937ea3be8acf7a187ef1517a))
* smithy-dafny ([#1136](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1136)) ([6005777](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6005777e8157a1273a4293ac3b1c135d25140a47))

### Features

* Adds CI ([511ed35](https://github.com/aws/aws-cryptographic-material-providers-library/commit/511ed358751c846fca46e111001841f7dd7f3bf6))
* check in polymorph go generated code  ([#1137](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1137)) ([d0fefbf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d0fefbf2a6a363a7aa6940ce7a45eb8e395654f0))
* Check-in polymorph generated code ([bfc7cb9](https://github.com/aws/aws-cryptographic-material-providers-library/commit/bfc7cb9f5645544d956a1c500a686c133196eb02))
* ddb Go externs ([1e3737b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1e3737b2f6294e9399f19ac9fd7377f8b0e526f7))
* **ddb:** Go release v0.0.1 ([#1201](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1201)) ([5293bfd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/5293bfd755952b243a57c9cb7e6718d807e09d9a))
* **ddb:** Go release v0.0.3 ([#1210](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1210)) ([983f553](https://github.com/aws/aws-cryptographic-material-providers-library/commit/983f553337954a97db43e2c8cfb8bfa3378db345))
* **Go:** Go module rename ([#1196](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1196)) ([b0876ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/b0876ace8d4882dbee77887712469f799015e9dc))
* kms externs for Go ([2d1f6d1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2d1f6d1da826433c566c4ce4d5ff53d7f7ab1bdc))
* **kms:** Go release v0.0.1 ([#1199](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1199)) ([9c80544](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9c80544bbfeac5547915aa93795f9b79eac7db6b))
* mpl externs ([#1105](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1105)) ([29bc52e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/29bc52eccca8dcb5cbce8c90563b8461b9ba0454))
* **mpl:** Go release v0.0.1 ([#1211](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1211)) ([4508ab8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4508ab84bd6017e7db6f353d2195b93ac30761c9))
* Primitives CI ([ce6e942](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ce6e9421a0632beae2fe554f258d0243ec4b99c3))
* Primitives for Go ([8066826](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8066826b3b17b2355af4d8bf94dab54325932ae6))
* **primitives:** Go release v0.0.1 ([#1203](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1203)) ([6bf0bbe](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6bf0bbe25650da820c4133e1d1b1bce813d33a9e))
* StandardLibrary for Go ([587b57e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/587b57ee5ec341c9961e0d1689dfb26b1a271055))
* StandardLibrary for Go ([94b4fd0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/94b4fd0e9f8a491103c5b9ca0b0c8ab892dd580e))
* StandardLibrary for Go ([6ce1ce3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6ce1ce32f65955fea922eb9237ee813fa5536eb8))
* **StdLib:** Go v0.0.1 release ([#1195](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1195)) ([95e54bf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95e54bf5ab4a5881f04f11a00aae074c7810add3))

_Issue #, if available:_

_Description of changes:_

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
