### PR TITLE
chore: remove mac os from CI and refactor base64Lemmas

### DIFF
--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_32-core,
+            temporary-performance-testing_ubuntu-latest_64-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_64-core,
+            ubuntu-latest,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -28,7 +28,11 @@ jobs:
             AwsCryptographicMaterialProviders,
             StandardLibrary,
           ]
-        os: [macos-latest-large]
+        os: [
+              ubuntu-22.04,
+              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+              # macos-latest-large
+            ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_8-core,
+            temporary-performance-testing_ubuntu-latest_16-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_64-core,
+            temporary-performance-testing_ubuntu-latest_8-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -76,6 +76,7 @@ jobs:
         run: |
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
+          echo "Number of cores: $CORES"
           make verify CORES=$CORES
 
       - name: Check solver resource use

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -76,7 +76,6 @@ jobs:
         run: |
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
-          echo "Number of cores: $CORES"
           make verify CORES=$CORES
 
       - name: Check solver resource use

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            ubuntu-22.04,
+            temporary-performance-testing_ubuntu-latest_32-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_32-core,
+            ubuntu-22.04,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            ubuntu-latest,
+            temporary-performance-testing_ubuntu-latest_64-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,10 +29,10 @@ jobs:
             StandardLibrary,
           ]
         os: [
-              ubuntu-22.04,
-              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
-              # macos-latest-large
-            ]
+            ubuntu-22.04,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-latest-large
+          ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_16-core,
+            temporary-performance-testing_ubuntu-latest_32-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            temporary-performance-testing_ubuntu-latest_64-core,
+            ubuntu-22.04,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -29,7 +29,7 @@ jobs:
             StandardLibrary,
           ]
         os: [
-            ubuntu-22.04,
+            temporary-performance-testing_ubuntu-latest_16-core,
             # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
             # macos-latest-large
           ]

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -36,7 +36,8 @@ jobs:
             # Windows source code is tested downstream (ex. ESDK-Python CI).
             # windows-latest,
             ubuntu-22.04,
-            macos-13,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
           ]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -23,7 +23,8 @@ jobs:
             # https://taskei.amazon.dev/tasks/CrypTool-5283
             # windows-latest,
             ubuntu-22.04,
-            macos-13,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
           ]
         language: [java, net, python, rust, go]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
@@ -209,7 +210,8 @@ jobs:
             # TODO just test on mac and ubuntu for now
             # windows-latest,
             ubuntu-22.04,
-            macos-13,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
           ]
         encrypting_language: [java, net, python, rust, go]
         decrypting_language: [java, net, python, rust, go]

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -31,7 +31,8 @@ jobs:
             # TODO just test on mac for now
             # windows-latest,
             ubuntu-22.04,
-            macos-13,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
           ]
         java-versions: [8, 11, 16, 17]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -30,11 +30,11 @@ jobs:
           ]
         dotnet-version: ["6.0.x"]
         os: [
-              windows-latest, 
-              ubuntu-22.04, 
-              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
-              # macos-13,
-            ]
+            windows-latest,
+            ubuntu-22.04,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
+          ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -29,7 +29,12 @@ jobs:
             TestVectorsAwsCryptographicMaterialProviders,
           ]
         dotnet-version: ["6.0.x"]
-        os: [windows-latest, ubuntu-22.04, macos-13]
+        os: [
+              windows-latest, 
+              ubuntu-22.04, 
+              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+              # macos-13,
+            ]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -36,7 +36,8 @@ jobs:
             # Windows source code is tested downstream (ex. ESDK-Python CI).
             # windows-latest,
             ubuntu-22.04,
-            macos-13,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13,
           ]
     runs-on: ${{ matrix.os }}
     defaults:

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -29,7 +29,11 @@ jobs:
             TestVectorsAwsCryptographicMaterialProviders,
           ]
         # removed windows-latest because somehow it can't build aws-lc in CI
-        os: [ubuntu-22.04, macos-13]
+        os: [
+              ubuntu-22.04, 
+              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+              # macos-13
+            ]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -30,10 +30,10 @@ jobs:
           ]
         # removed windows-latest because somehow it can't build aws-lc in CI
         os: [
-              ubuntu-22.04, 
-              # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
-              # macos-13
-            ]
+            ubuntu-22.04,
+            # TODO: Re-enable macOS after https://t.corp.amazon.com/P205755286
+            # macos-13
+          ]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -96,7 +96,7 @@ module Base64Lemmas {
     requires Is2Padding(s[(|s| - 4)..])
     ensures Encode(DecodeValid(s)) == s
   {
-    Helper_DecodeValid2PaddingProperties(s)
+    Helper_DecodeValid2PaddingProperties(s);
     calc {
       Encode(DecodeValid(s));
     ==

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -96,11 +96,10 @@ module Base64Lemmas {
     requires Is2Padding(s[(|s| - 4)..])
     ensures Encode(DecodeValid(s)) == s
   {
+    Helper_DecodeValid2PaddingProperties(s)
     calc {
       Encode(DecodeValid(s));
     ==
-      assert |DecodeUnpadded(s[..|s|-4])| % 3 == 0;
-      assert |DecodeValid(s)| % 3 == 1;
       EncodeUnpadded(DecodeValid(s)[..(|DecodeValid(s)| - 1)]) + Encode2Padding(DecodeValid(s)[(|DecodeValid(s)| - 1)..]);
     == { DecodeValidUnpaddedPartialFrom2PaddedSeq(s); }
       EncodeUnpadded(DecodeUnpadded(s[..(|s| - 4)])) + Encode2Padding(DecodeValid(s)[(|DecodeValid(s)| - 1)..]);
@@ -113,6 +112,17 @@ module Base64Lemmas {
     == { SeqPartsMakeWhole(s, (|s| - 4)); }
       s;
     }
+  }
+
+  lemma Helper_DecodeValid2PaddingProperties(s: seq<char>)
+    requires IsBase64String(s)
+    requires |s| >= 4
+    requires Is2Padding(s[(|s| - 4)..])
+    ensures |DecodeUnpadded(s[..|s|-4])| % 3 == 0
+    ensures |DecodeValid(s)| % 3 == 1
+  {
+    assert |DecodeUnpadded(s[..|s|-4])| % 3 == 0;
+    assert |DecodeValid(s)| % 3 == 1;
   }
 
   lemma DecodeValidEncode(s: seq<char>)

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -54,7 +54,7 @@ module Base64Lemmas {
     requires Is1Padding(s[(|s| - 4)..])
     ensures Encode(DecodeValid(s)) == s
   {
-    DecodeValidEncode1PaddingHelper(s)
+    DecodeValidEncode1PaddingHelper(s);
     calc {
       Encode(DecodeValid(s));
     ==

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -54,16 +54,12 @@ module Base64Lemmas {
     requires Is1Padding(s[(|s| - 4)..])
     ensures Encode(DecodeValid(s)) == s
   {
+    DecodeValidEncode1PaddingHelper(s)
     calc {
       Encode(DecodeValid(s));
     ==
-      assert |DecodeValid(s)| % 3 == 2;
-      assert 2 <= |DecodeValid(s)|;
       EncodeUnpadded(DecodeValid(s)[..(|DecodeValid(s)| - 2)]) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeValidUnpaddedPartialFrom1PaddedSeq(s); }
-      assert IsUnpaddedBase64String(s[..(|s| - 4)]) by {
-        assert |s| % 4 == 0;
-      }
       EncodeUnpadded(DecodeUnpadded(s[..(|s| - 4)])) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeEncodeUnpadded(s[..(|s| - 4)]); }
       s[..(|s| - 4)] + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
@@ -75,6 +71,19 @@ module Base64Lemmas {
       s;
     }
   }
+
+  lemma DecodeValidEncode1PaddingHelper(s: seq<char>)
+    requires IsBase64String(s)
+    requires |s| >= 4
+    requires Is1Padding(s[(|s| - 4)..])
+  {
+    assert |DecodeValid(s)| % 3 == 2;
+    assert 2 <= |DecodeValid(s)|;
+    assert IsUnpaddedBase64String(s[..(|s| - 4)]) by {
+      assert |s| % 4 == 0;
+    }
+  }
+
 
   lemma DecodeValidUnpaddedPartialFrom2PaddedSeq(s: seq<char>)
     requires IsBase64String(s)
@@ -118,8 +127,6 @@ module Base64Lemmas {
     requires IsBase64String(s)
     requires |s| >= 4
     requires Is2Padding(s[(|s| - 4)..])
-    ensures |DecodeUnpadded(s[..|s|-4])| % 3 == 0
-    ensures |DecodeValid(s)| % 3 == 1
   {
     assert |DecodeUnpadded(s[..|s|-4])| % 3 == 0;
     assert |DecodeValid(s)| % 3 == 1;

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -96,7 +96,7 @@ module Base64Lemmas {
     requires Is2Padding(s[(|s| - 4)..])
     ensures Encode(DecodeValid(s)) == s
   {
-    Helper_DecodeValid2PaddingProperties(s);
+    DecodeValid2PaddingPropertiesHelper(s);
     calc {
       Encode(DecodeValid(s));
     ==
@@ -114,7 +114,7 @@ module Base64Lemmas {
     }
   }
 
-  lemma Helper_DecodeValid2PaddingProperties(s: seq<char>)
+  lemma DecodeValid2PaddingPropertiesHelper(s: seq<char>)
     requires IsBase64String(s)
     requires |s| >= 4
     requires Is2Padding(s[(|s| - 4)..])

--- a/StandardLibrary/src/Base64Lemmas.dfy
+++ b/StandardLibrary/src/Base64Lemmas.dfy
@@ -60,6 +60,9 @@ module Base64Lemmas {
     ==
       EncodeUnpadded(DecodeValid(s)[..(|DecodeValid(s)| - 2)]) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeValidUnpaddedPartialFrom1PaddedSeq(s); }
+      assert IsUnpaddedBase64String(s[..(|s| - 4)]) by {
+        assert |s| % 4 == 0;
+      }
       EncodeUnpadded(DecodeUnpadded(s[..(|s| - 4)])) + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
     == { DecodeEncodeUnpadded(s[..(|s| - 4)]); }
       s[..(|s| - 4)] + Encode1Padding(DecodeValid(s)[(|DecodeValid(s)| - 2)..]);
@@ -79,9 +82,6 @@ module Base64Lemmas {
   {
     assert |DecodeValid(s)| % 3 == 2;
     assert 2 <= |DecodeValid(s)|;
-    assert IsUnpaddedBase64String(s[..(|s| - 4)]) by {
-      assert |s| % 4 == 0;
-    }
   }
 
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
- Temporarily remove macOS from CI so that CI starts working because of https://github.com/dotnet/sdk/issues/46857.
- Needed to break 2 lemma in Standard library because verification was going out of resource.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
