### PR TITLE
chore: add kms:GenerateRandom permission to CI role

### DIFF
--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -231,6 +231,7 @@ Resources:
                 "kms:Decrypt",
                 "kms:Encrypt",
                 "kms:GenerateDataKeyWithoutPlaintext",
+                "kms:GenerateRandom",
                 "kms:ReEncrypt*",
                 "kms:DescribeKey",
                 "kms:CreateGrant",

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -231,7 +231,6 @@ Resources:
                 "kms:Decrypt",
                 "kms:Encrypt",
                 "kms:GenerateDataKeyWithoutPlaintext",
-                "kms:GenerateRandom",
                 "kms:ReEncrypt*",
                 "kms:DescribeKey",
                 "kms:CreateGrant",
@@ -263,7 +262,14 @@ Resources:
                 "arn:aws:kms:*:${AWS::AccountId}:key/${EccP384}",
                 "arn:aws:kms:*:${AWS::AccountId}:key/${EccP521}"
               ]
-            }
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "kms:GenerateRandom"
+              ],
+              "Resource": "*"
+            },   
           ]
         }
       ManagedPolicyName: Hierarchical-GitHub-KMS-Key-Policy

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -268,8 +268,10 @@ Resources:
               "Action": [
                 "kms:GenerateRandom"
               ],
-              "Resource": "*"
-            },   
+              "Resource": [
+                "*"
+              ]
+            }   
           ]
         }
       ManagedPolicyName: Hierarchical-GitHub-KMS-Key-Policy


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
1. Adds `kms:GenerateRandom` permission to `Hierarchical-GitHub-KMS-Key-Policy` to allow CI role to support HV-2.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
