### PR TITLE
refactor: Mark Down headings for the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,10 @@
-_Issue #, if available:_
+### Issue #, if available:
 
-_Description of changes:_
+### Description of changes:
 
-_Squash/merge commit message, if applicable:_
+### Squash/merge commit message, if applicable:
+```
+<message>
+```
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,7 @@
 ### Description of changes:
 
 ### Squash/merge commit message, if applicable:
+
 ```
 <message>
 ```


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_
I prefer using Mark Down headings over italics to delineate the sections of a PR description.
In general, 
I find we either completely ignore the descriptions (author & reviewer),
or we want to use them to detail a significant amount of detail.

For the second case,
I think headings is more useful.

_Squash/merge commit message, if applicable:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
