### PR TITLE
ci(Go, Rust): disable for current HV-2 work

### DIFF
--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -25,14 +25,15 @@ jobs:
             ubuntu-22.04,
             macos-13,
           ]
-        # TODO-Rust-CI: Removing Rust Runtimes until the underlying issue resolved.
-        # TODO-Rust-CI: Rust runtimes checks are failing to resolve dafny_runtime imports
+        # TODO-HV-2-Rust: Removing Rust Runtimes until the underlying issue resolved.
+        # TODO-HV-2-Rust: Rust runtimes checks are failing to resolve dafny_runtime imports
+        # TODO-HV-2-Go: Removing Go CI until we rebase or need it
         language: [
             java,
             net,
             # rust,
             python,
-            go,
+            # go,
           ]
         # https://taskei.amazon.dev/tasks/CrypTool-5284
         dotnet-version: ["6.0.x"]
@@ -222,10 +223,10 @@ jobs:
             ubuntu-22.04,
             macos-13,
           ]
-        # TODO-Rust-CI: Removing Rust Runtimes until the underlying issue resolved.
-        # TODO-Rust-CI: Rust runtimes checks are failing to resolve dafny_runtime imports
-        encrypting_language: [java, net, python, go]
-        decrypting_language: [java, net, python, go]
+        # TODO-HV-2-Rust: Removing Rust Runtimes until the underlying issue resolved.
+        # TODO-HV-2-Go: Removing Go CI until we rebase or need it
+        encrypting_language: [java, net, python] # , go, rust]
+        decrypting_language: [java, net, python] # , go, rust]
         dotnet-version: ["6.0.x"]
     runs-on: ${{ matrix.os }}
     permissions:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -37,8 +37,7 @@ jobs:
     with:
       dafny: ${{ inputs.dafny }}
       regenerate-code: ${{ inputs.regenerate-code }}
-  # TODO-Rust-CI: Removing Rust Runtimes until the underlying issue resolved.
-  # TODO-Rust-CI: Rust runtimes checks are failing to resolve dafny_runtime imports.
+  # TODO-HV-2-Rust: Removing Rust Runtimes until the underlying issue resolved.
   #  manual-ci-rust:
   #    uses: ./.github/workflows/library_rust_tests.yml
   #    with:
@@ -49,11 +48,12 @@ jobs:
     with:
       dafny: ${{ inputs.dafny }}
       regenerate-code: ${{ inputs.regenerate-code }}
-  manual-ci-go:
-    uses: ./.github/workflows/library_go_tests.yml
-    with:
-      dafny: ${{ inputs.dafny }}
-      regenerate-code: ${{ inputs.regenerate-code }}
+  # TODO-HV-2-Go: Removing Go CI until we rebase or need it
+  # manual-ci-go:
+  #   uses: ./.github/workflows/library_go_tests.yml
+  #   with:
+  #     dafny: ${{ inputs.dafny }}
+  #     regenerate-code: ${{ inputs.regenerate-code }}
   manual-interop-test:
     uses: ./.github/workflows/library_interop_tests.yml
     with:

--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -39,8 +39,7 @@ jobs:
     uses: ./.github/workflows/library_net_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
-  # TODO-Rust-CI: Removing Rust Runtimes until the underlying issue resolved.
-  # TODO-Rust-CI: Rust runtimes checks are failing to resolve dafny_runtime imports
+  # TODO-HV-2-Rust: Removing Rust until we rebase or need it
   # pr-ci-rust:
   #   needs: getVersion
   #   uses: ./.github/workflows/library_rust_tests.yml
@@ -51,11 +50,12 @@ jobs:
     uses: ./.github/workflows/library_python_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
-  pr-ci-go:
-    needs: getVersion
-    uses: ./.github/workflows/library_go_tests.yml
-    with:
-      dafny: ${{needs.getVersion.outputs.version}}
+  # TODO-HV-2-Go: Removing Go CI until we rebase or need it
+  # pr-ci-go:
+  #   needs: getVersion
+  #   uses: ./.github/workflows/library_go_tests.yml
+  #   with:
+  #     dafny: ${{needs.getVersion.outputs.version}}
   pr-interop-test:
     needs: getVersion
     uses: ./.github/workflows/library_interop_tests.yml
@@ -73,7 +73,9 @@ jobs:
       - pr-ci-java
       - pr-ci-net
       - pr-ci-python
-      - pr-ci-go
+      # TODO-HV-2-Go: Removing Go CI until we rebase or need it
+      # - pr-ci-go
+      # TODO-HV-2-Rust: Removing Rust until we rebase or need it
       # - pr-ci-rust
       - pr-interop-test
       - pr-ci-examples

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,8 +36,7 @@ jobs:
     uses: ./.github/workflows/library_net_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
-  # TODO-Rust-CI: Removing Rust Runtimes until the underlying issue resolved.
-  # TODO-Rust-CI: Rust runtimes checks are failing to resolve dafny_runtime imports
+  # TODO-HV-2-Rust: Removing Rust until we rebase or need it.
   # push-ci-rust:
   #   needs: getVersion
   #   uses: ./.github/workflows/library_rust_tests.yml
@@ -48,11 +47,12 @@ jobs:
     uses: ./.github/workflows/library_python_tests.yml
     with:
       dafny: ${{needs.getVersion.outputs.version}}
-  push-ci-go:
-    needs: getVersion
-    uses: ./.github/workflows/library_go_tests.yml
-    with:
-      dafny: ${{needs.getVersion.outputs.version}}
+  # TODO-HV-2-Go: Removing Go CI until we rebase or need it
+  # push-ci-go:
+  #   needs: getVersion
+  #   uses: ./.github/workflows/library_go_tests.yml
+  #   with:
+  #     dafny: ${{needs.getVersion.outputs.version}}
   pr-interop-test:
     needs: getVersion
     uses: ./.github/workflows/library_interop_tests.yml


### PR DESCRIPTION
### Issue #, if available:
HV-2 early Milestones

### Description of changes:

Disable CI for Rust & Go for now; we will re-enable when we can or when we need to.

### Squash/merge commit message, if applicable:

```
ci(Go, Rust): disable for current HV-2 work
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
