### PR TITLE
fix(Dafny): correct error message

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
@@ -150,12 +150,13 @@ module GetKeys {
     var branchKeyItemFromStorage := ActiveOutput.Item;
 
     :- Need(
-      || storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
-      || (
-           && Structure.ActiveHierarchicalSymmetricKey?(branchKeyItemFromStorage)
-           && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
-           && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
-         ),
+      (|| storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
+       || (
+            && Structure.ActiveHierarchicalSymmetricKey?(branchKeyItemFromStorage)
+            && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
+            && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+          ))
+      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException(
         message := ErrorMessages.INVALID_ACTIVE_BRANCH_KEY_FROM_STORAGE)
     );
@@ -173,8 +174,7 @@ module GetKeys {
       )
     );
     :- Need(
-      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD])
-      && KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
+      KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException( message := ErrorMessages.GET_KEY_ARN_DISAGREEMENT)
     );
 
@@ -341,22 +341,22 @@ module GetKeys {
     var branchKeyItemFromStorage := VersionItem.Item;
 
     :- Need(
-      || storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
-      || (
-           && Structure.DecryptOnlyHierarchicalSymmetricKey?(branchKeyItemFromStorage)
-           && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
-           && branchKeyItemFromStorage.Type == Types.HierarchicalSymmetricVersion(
-                                                 Types.HierarchicalSymmetric(
-                                                   Version := input.branchKeyVersion
-                                                 ))
-           && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
-         ),
+      (|| storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
+       || (
+            && Structure.DecryptOnlyHierarchicalSymmetricKey?(branchKeyItemFromStorage)
+            && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
+            && branchKeyItemFromStorage.Type == Types.HierarchicalSymmetricVersion(
+                                                  Types.HierarchicalSymmetric(
+                                                    Version := input.branchKeyVersion
+                                                  ))
+            && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+          ))
+      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException(
         message := ErrorMessages.INVALID_BRANCH_KEY_VERSION_FROM_STORAGE)
     );
     :- Need(
-      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD])
-      && KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
+      KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException( message := ErrorMessages.GET_KEY_ARN_DISAGREEMENT)
     );
     var branchKey: KMS.DecryptResponse :- KMSKeystoreOperations.DecryptKeyForHv1(
@@ -502,17 +502,17 @@ module GetKeys {
     var branchKeyItemFromStorage := BeaconOutput.Item;
 
     :- Need(
-      || storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
-      || (
-           && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
-           && Structure.ActiveHierarchicalSymmetricBeaconKey?(branchKeyItemFromStorage)
-           && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
-         ),
+      (|| storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
+       || (
+            && branchKeyItemFromStorage.Identifier == input.branchKeyIdentifier
+            && Structure.ActiveHierarchicalSymmetricBeaconKey?(branchKeyItemFromStorage)
+            && branchKeyItemFromStorage.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
+          ))
+      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException(
         message := ErrorMessages.INVALID_BEACON_KEY_FROM_STORAGE)
     );
     :- Need(
-      && KmsArn.ValidKmsArn?(branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD])
       && KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, branchKeyItemFromStorage.EncryptionContext[Structure.KMS_FIELD]),
       Types.KeyStoreException( message := ErrorMessages.GET_KEY_ARN_DISAGREEMENT)
     );


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
If the KMS-ARN is an alias or otherwise an invalid, 
it is was read from Storage in-correctly the Stored item was invalid;
it was NOT KMS-ARN disagreement b/w the KMS Configuration
and the Branch Key.

### Squash/merge commit message, if applicable:

```
<message>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
