### PR TITLE
chore(dafny): add test for get keys 

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
@@ -694,7 +694,7 @@ module GetKeys {
 
     // Verify the digest matches
     if (bkcFromStorage != protectedMdDigest) {
-      var e := Types.KeyStoreException(
+      var e := Types.BranchKeyCiphertextException(
         message := ErrorMessages.MD_DIGEST_SHA_NOT_MATCHED
       );
       return Failure(e);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -73,7 +73,7 @@ module Fixtures {
     54,  54, 102, 99,  56,  97, 102, 57, 102
   ]
   const hv2BranchKeyId := "test-hv2-branch-key-badaa332-29f2-4c72-8ad7-071eb48499c3"
-  const hv2BranchKeyIdWithEC := "347fdc7d-e93f-4166-97c2-5f5e0053d335"
+  const hv2BranchKeyVersion := "347fdc7d-e93f-4166-97c2-5f5e0053d335"
   const hv2BranchKeyIdActiveVersionUtf8Bytes: seq<uint8> := [
     51, 52, 55, 102, 100, 99, 55, 100, 45, 101, 57,
     51, 102, 45, 52, 49, 54, 54, 45, 57, 55, 99, 50,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -189,7 +189,6 @@ module TestGetKeys {
     testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdWithEC, hv2BranchKeyIdActiveVersionUtf8Bytes);
   }
 
-
   method {:test} TestGetActiveKeyWithIncorrectKmsKeyArn() {
     var kmsClient :- expect KMS.KMSClient();
     var ddbClient :- expect DDB.DynamoDBClient();
@@ -209,7 +208,6 @@ module TestGetKeys {
     var ddbClient :- expect DDB.DynamoDBClient();
 
     var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName := branchKeyStoreName, logicalName := incorrectLogicalName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
-
 
     var activeResult := keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(
@@ -237,7 +235,7 @@ module TestGetKeys {
     var kmsClient :- expect KMS.KMSClient();
     var ddbClient :- expect DDB.DynamoDBClient();
 
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
+    var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
 
     var activeResult := keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(
@@ -264,13 +262,8 @@ module TestGetKeys {
     );
 
     var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
-
-    var activeResult :- expect keyStore.GetActiveBranchKey(
-      Types.GetActiveBranchKeyInput(
-        branchKeyIdentifier := branchKeyId
-      ));
-
-    expect |activeResult.branchKeyMaterials.branchKey| == 32;
+    testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
+    testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
   }
 
   method testBeaconKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string)

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -264,7 +264,7 @@ module TestGetKeys {
           )))
     );
 
-    var keyStore :- expect KeyStore.KeyStore(keyStoreConfig);
+    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
 
     var activeResult :- expect keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -22,35 +22,29 @@ module TestGetKeys {
 
   const incorrectLogicalName := "MySuperAwesomeTableName"
 
-  method {:test} TestGetBeaconKey()
+  method {:test} TestGetKeysHappyCase()
   {
     var kmsClient :- expect KMS.KMSClient();
     var ddbClient :- expect DDB.DynamoDBClient();
     var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-    
+
     var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
 
     testBeaconKeyHappyCase(keyStore, branchKeyId);
     testBeaconKeyHappyCase(keyStore, hv2BranchKeyId);
-  }
-
-  method {:test} {:isolate_assertions} TestGetActiveKey()
-  {
-    var kmsClient :- expect KMS.KMSClient();
-    var ddbClient :- expect DDB.DynamoDBClient();
-    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-    
-    var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
 
     testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
     testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
+
+    testBranchKeyVersionHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersion, branchKeyIdActiveVersionUtf8Bytes);
+    testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyVersion, hv2BranchKeyIdActiveVersionUtf8Bytes);
   }
 
-  // TODO-HV2-M1: Add MRK test
+  // TODO-HV2-M1: Add MRK test for hv2
   method {:test} {:isolate_assertions} TestGetActiveMrkKey()
   {
     var ddbClient :- expect DDB.DynamoDBClient();
-    
+
     var eastKeyStoreConfig := Types.KeyStoreConfig(
       id := None,
       kmsConfiguration := KmsConfigEast,
@@ -175,20 +169,6 @@ module TestGetKeys {
     // it's an opaque error, so I can't test its contents
   }
 
-  method {:test} TestGetBranchKeyVersion()
-  {
-    var keyStore :- expect DefaultKeyStore();
-
-    var versionResult :- expect keyStore.GetBranchKeyVersion(
-      Types.GetBranchKeyVersionInput(
-        branchKeyIdentifier := branchKeyId,
-        branchKeyVersion := branchKeyIdActiveVersion
-      ));
-
-    testBranchKeyVersionHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersion, branchKeyIdActiveVersionUtf8Bytes);
-    testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdWithEC, hv2BranchKeyIdActiveVersionUtf8Bytes);
-  }
-
   method {:test} TestKeyWithIncorrectKmsKeyArn() {
     var kmsClient :- expect KMS.KMSClient();
     var ddbClient :- expect DDB.DynamoDBClient();
@@ -202,10 +182,130 @@ module TestGetKeys {
     GetBeaconKeyWithIncorrectKmsKeyArnHelper(keyStore, hv2BranchKeyId);
 
     GetBranchKeyVersionWithIncorrectKmsKeyArnHelper(keyStore, branchKeyId, branchKeyIdActiveVersion);
-    GetBranchKeyVersionWithIncorrectKmsKeyArnHelper(keyStore, branchKeyId, hv2BranchKeyIdWithEC);
+    GetBranchKeyVersionWithIncorrectKmsKeyArnHelper(keyStore, hv2BranchKeyId, hv2BranchKeyVersion);
   }
 
-  method GetActiveKeyWithIncorrectKmsKeyArnHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string) 
+  method {:test} TestGetActiveKeyWrongLogicalKeyStoreName() {
+    var kmsClient :- expect KMS.KMSClient();
+    var ddbClient :- expect DDB.DynamoDBClient();
+
+    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName := branchKeyStoreName, logicalName := incorrectLogicalName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
+    GetActiveKeyWrongLogicalKeyStoreName(keyStore, branchKeyId, "1");
+    GetActiveKeyWrongLogicalKeyStoreName(keyStore, hv2BranchKeyId, "2");
+
+    GetBeaconKeyWrongLogicalKeyStoreName(keyStore, branchKeyId, "1");
+    GetBeaconKeyWrongLogicalKeyStoreName(keyStore, hv2BranchKeyId, "2");
+  }
+
+  method {:test} TestGetKeyDoesNotExistFails()
+  {
+    var kmsClient :- expect KMS.KMSClient();
+    var ddbClient :- expect DDB.DynamoDBClient();
+
+    var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
+    GetActiveKeyDoesNotExistFailsHelper(keyStore, "Robbie");
+    GetBeaconKeyDoesNotExistFailsHelper(keyStore, "Robbie");
+    GetBranchKeyVersionDoesNotExistFailsHelper(keyStore, "Robbie", branchKeyIdActiveVersion);
+  }
+
+  method {:test} TestGetKeysWithNoClients() {
+    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
+
+    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
+
+    testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
+    testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
+
+    testBeaconKeyHappyCase(keyStore, branchKeyId);
+    testBeaconKeyHappyCase(keyStore, hv2BranchKeyId);
+
+    testBranchKeyVersionHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersion, branchKeyIdActiveVersionUtf8Bytes);
+    testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyVersion, hv2BranchKeyIdActiveVersionUtf8Bytes);
+  }
+
+  method GetActiveKeyWrongLogicalKeyStoreName(keyStore: Types.IKeyStoreClient, branchKeyId: string, hv: string)
+    requires keyStore.ValidState()
+    modifies keyStore.Modifies
+  {
+    var activeResult := keyStore.GetActiveBranchKey(
+      Types.GetActiveBranchKeyInput(
+        branchKeyIdentifier := branchKeyId
+      ));
+    expect activeResult.Failure?;
+
+    if (hv == "1") {
+      match activeResult.error {
+        case ComAmazonawsKms(nestedError) =>
+          expect nestedError.InvalidCiphertextException?;
+        case _ => expect false, "Wrong Logical Keystore Name SHOULD Fail with KMS InvalidCiphertextException.";
+      }
+    } else if (hv == "2") {
+      expect activeResult.error == Types.Error.BranchKeyCiphertextException(message := ErrorMessages.MD_DIGEST_SHA_NOT_MATCHED);
+    } else {
+      expect false;
+    }
+  }
+
+  method GetBeaconKeyWrongLogicalKeyStoreName(keyStore: Types.IKeyStoreClient, branchKeyId: string, hv: string)
+    requires keyStore.ValidState()
+    modifies keyStore.Modifies
+  {
+    var beaconKeyResult := keyStore.GetBeaconKey(
+      Types.GetBeaconKeyInput(
+        branchKeyIdentifier := branchKeyId
+      ));
+    expect beaconKeyResult.Failure?;
+    if (hv == "1") {
+      match beaconKeyResult.error {
+        case ComAmazonawsKms(nestedError) =>
+          expect nestedError.InvalidCiphertextException?;
+        case _ => expect false, "Wrong Logical Keystore Name SHOULD Fail with KMS InvalidCiphertextException.";
+      }
+    } else if (hv == "2") {
+      expect beaconKeyResult.error == Types.Error.BranchKeyCiphertextException(message := ErrorMessages.MD_DIGEST_SHA_NOT_MATCHED);
+    } else {
+      expect false;
+    }
+  }
+
+  method GetActiveKeyDoesNotExistFailsHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string)
+    requires keyStore.ValidState()
+    modifies keyStore.Modifies
+  {
+    var activeResult := keyStore.GetActiveBranchKey(
+      Types.GetActiveBranchKeyInput(
+        branchKeyIdentifier := branchKeyId
+      ));
+    expect activeResult.Failure?;
+    expect activeResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
+  }
+
+  method GetBeaconKeyDoesNotExistFailsHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string)
+    requires keyStore.ValidState()
+    modifies keyStore.Modifies
+  {
+    var beaconKeyResult := keyStore.GetBeaconKey(
+      Types.GetBeaconKeyInput(
+        branchKeyIdentifier := branchKeyId
+      ));
+    expect beaconKeyResult.Failure?;
+    expect beaconKeyResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
+  }
+
+  method GetBranchKeyVersionDoesNotExistFailsHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersion: string)
+    requires keyStore.ValidState()
+    modifies keyStore.Modifies
+  {
+    var versionResult := keyStore.GetBranchKeyVersion(
+      Types.GetBranchKeyVersionInput(
+        branchKeyIdentifier := branchKeyId,
+        branchKeyVersion := branchKeyIdActiveVersion
+      ));
+    expect versionResult.Failure?;
+    expect versionResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
+  }
+
+  method GetActiveKeyWithIncorrectKmsKeyArnHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string)
     requires keyStore.ValidState()
     modifies keyStore.Modifies
   {
@@ -242,75 +342,6 @@ module TestGetKeys {
 
     expect versionResult.Failure?;
     expect versionResult.error == Types.KeyStoreException(message := ErrorMessages.GET_KEY_ARN_DISAGREEMENT);
-  }
-
-  method {:test} TestGetActiveKeyWrongLogicalKeyStoreName() {
-    var kmsClient :- expect KMS.KMSClient();
-    var ddbClient :- expect DDB.DynamoDBClient();
-
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName := branchKeyStoreName, logicalName := incorrectLogicalName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
-
-    var activeResult := keyStore.GetActiveBranchKey(
-      Types.GetActiveBranchKeyInput(
-        branchKeyIdentifier := branchKeyId
-      ));
-
-    expect activeResult.Failure?;
-    match activeResult.error {
-      case ComAmazonawsKms(nestedError) =>
-        expect nestedError.InvalidCiphertextException?;
-      case _ => expect false, "Wrong Logical Keystore Name SHOULD Fail with KMS InvalidCiphertextException.";
-    }
-
-    var activeResultHV2 := keyStore.GetActiveBranchKey(
-      Types.GetActiveBranchKeyInput(
-        branchKeyIdentifier := hv2BranchKeyId
-      ));
-
-    expect activeResultHV2.Failure?;
-    expect activeResultHV2.error == Types.Error.BranchKeyCiphertextException(message := ErrorMessages.MD_DIGEST_SHA_NOT_MATCHED);
-  }
-
-  method {:test} TestGetActiveKeyDoesNotExistFails()
-  {
-    var kmsClient :- expect KMS.KMSClient();
-    var ddbClient :- expect DDB.DynamoDBClient();
-
-    var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
-
-    var activeResult := keyStore.GetActiveBranchKey(
-      Types.GetActiveBranchKeyInput(
-        branchKeyIdentifier := "Robbie"
-      ));
-
-    expect activeResult.Failure?;
-    expect activeResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
-    //AwsCryptographyKeyStoreTypes.Error.KeyStoreException(No item found for corresponding branch key identifier.)
-  }
-
-  
-  method {:test} TestGetActiveKeyWithNoClients() {
-    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
-    testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
-    testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
-  }
-
-  method {:test} TestGetBeaconKeyWithNoClients() {
-    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
-    testBeaconKeyHappyCase(keyStore, branchKeyId);
-    testBeaconKeyHappyCase(keyStore, hv2BranchKeyId);
-  }
-
-  method {:test} TestGetBranchKeyVersionWithNoClients() {
-    var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
-
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
-    testBranchKeyVersionHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersion, branchKeyIdActiveVersionUtf8Bytes);
-    testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdWithEC, hv2BranchKeyIdActiveVersionUtf8Bytes);
   }
 
   method testBeaconKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string)

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -33,18 +33,6 @@ module TestGetKeys {
     testBeaconKeyResult(keyStore, hv2BranchKeyId);
   }
 
-  method {:only} testBeaconKeyResult(keyStore: KeyStore.KeyStoreClient, branchKeyId: string) 
-    requires keyStore.ValidState()
-  {
-    var beaconKeyResult :- expect keyStore.GetBeaconKey(
-      Types.GetBeaconKeyInput(
-        branchKeyIdentifier := branchKeyId
-      ));
-    expect beaconKeyResult.beaconKeyMaterials.beaconKeyIdentifier == branchKeyId;
-    expect beaconKeyResult.beaconKeyMaterials.beaconKey.Some?;
-    expect |beaconKeyResult.beaconKeyMaterials.beaconKey.value| == 32;
-  }
-
   method {:test} {:isolate_assertions} TestGetActiveKey()
   {
     var kmsClient :- expect KMS.KMSClient();
@@ -398,5 +386,20 @@ module TestGetKeys {
                   )))
       );
       keyStore :- expect KeyStore.KeyStore(keyStoreConfig);
+  }
+
+  method testBeaconKeyResult(keyStore: KeyStore.KeyStoreClient, branchKeyId: string) 
+    requires keyStore.ValidState()
+  {
+    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
+
+    var beaconKeyResult :- expect keyStore.GetBeaconKey(
+      Types.GetBeaconKeyInput(
+        branchKeyIdentifier := branchKeyId
+      ));
+      
+    expect beaconKeyResult.beaconKeyMaterials.beaconKeyIdentifier == branchKeyId;
+    expect beaconKeyResult.beaconKeyMaterials.beaconKey.Some?;
+    expect |beaconKeyResult.beaconKeyMaterials.beaconKey.value| == 32;
   }
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -111,8 +111,8 @@ module TestGetKeys {
     testBeaconKeyHappyCase(keyStore, branchKeyId);
     testBeaconKeyHappyCase(keyStore, hv2BranchKeyId);
 
-    testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
-    testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
+    testActiveBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
+    testActiveBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
 
     testBranchKeyVersionHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersion, branchKeyIdActiveVersionUtf8Bytes);
     testBranchKeyVersionHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyVersion, hv2BranchKeyIdActiveVersionUtf8Bytes);
@@ -294,8 +294,8 @@ module TestGetKeys {
 
     var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
 
-    testBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
-    testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
+    testActiveBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
+    testActiveBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
 
     testBeaconKeyHappyCase(keyStore, branchKeyId);
     testBeaconKeyHappyCase(keyStore, hv2BranchKeyId);
@@ -459,7 +459,7 @@ module TestGetKeys {
     expect |beaconKeyResult.beaconKeyMaterials.beaconKey.value| == 32;
   }
 
-  method testBranchKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
+  method testActiveBranchKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
     requires keyStore.ValidState()
     modifies keyStore.Modifies
   {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -209,7 +209,7 @@ module TestGetKeys {
     var ddbClient :- expect DDB.DynamoDBClient();
 
     var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName := branchKeyStoreName, logicalName := incorrectLogicalName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
-    
+
     assume {:axiom} keyStore.Modifies == {}; // Turns off verification
 
     var activeResult := keyStore.GetActiveBranchKey(
@@ -244,7 +244,7 @@ module TestGetKeys {
       Types.GetActiveBranchKeyInput(
         branchKeyIdentifier := "Robbie"
       ));
-      
+
     expect activeResult.Failure?;
     expect activeResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
     //AwsCryptographyKeyStoreTypes.Error.KeyStoreException(No item found for corresponding branch key identifier.)
@@ -274,7 +274,7 @@ module TestGetKeys {
     expect |activeResult.branchKeyMaterials.branchKey| == 32;
   }
 
-  method testBeaconKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string) 
+  method testBeaconKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string)
     requires keyStore.ValidState()
   {
     assume {:axiom} keyStore.Modifies == {}; // Turns off verification
@@ -283,13 +283,13 @@ module TestGetKeys {
       Types.GetBeaconKeyInput(
         branchKeyIdentifier := branchKeyId
       ));
-      
+
     expect beaconKeyResult.beaconKeyMaterials.beaconKeyIdentifier == branchKeyId;
     expect beaconKeyResult.beaconKeyMaterials.beaconKey.Some?;
     expect |beaconKeyResult.beaconKeyMaterials.beaconKey.value| == 32;
   }
 
-  method testBranchKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>) 
+  method testBranchKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
     requires keyStore.ValidState()
   {
     assume {:axiom} keyStore.Modifies == {}; // Turns off verification
@@ -298,13 +298,13 @@ module TestGetKeys {
       Types.GetActiveBranchKeyInput(
         branchKeyIdentifier := branchKeyId
       ));
-      
+
     expect branchKeyResult.branchKeyMaterials.branchKeyIdentifier == branchKeyId;
     expect branchKeyResult.branchKeyMaterials.branchKeyVersion == branchKeyIdActiveVersionUtf8Bytes;
     expect |branchKeyResult.branchKeyMaterials.branchKey| == 32;
   }
 
-  method testBranchKeyVersionHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersion: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>) 
+  method testBranchKeyVersionHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersion: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
     requires keyStore.ValidState()
   {
     assume {:axiom} keyStore.Modifies == {}; // Turns off verification
@@ -314,7 +314,7 @@ module TestGetKeys {
         branchKeyIdentifier := branchKeyId,
         branchKeyVersion := branchKeyIdActiveVersion
       ));
-    
+
     var testBytes :- expect UTF8.Encode(branchKeyIdActiveVersion);
 
     expect versionResult.branchKeyMaterials.branchKeyIdentifier == branchKeyId;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -292,7 +292,7 @@ module TestGetKeys {
   method {:test} TestGetKeysWithNoClients() {
     var kmsConfig := Types.KMSConfiguration.kmsKeyArn(keyArn);
 
-    var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
+    var keyStore :- expect KeyStoreWithNoClient(kmsId:=keyArn, physicalName:=branchKeyStoreName, logicalName := logicalKeyStoreName);
 
     testActiveBranchKeyHappyCase(keyStore, branchKeyId, branchKeyIdActiveVersionUtf8Bytes);
     testActiveBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -239,22 +239,14 @@ module TestGetKeys {
 
     var keyStore := GetKeyStore(kmsClient, ddbClient, keyArn, logicalKeyStoreName, branchKeyStoreName);
 
-    TestGetActiveKeyDoesNotExistFailsHelper(keyStore, "Robbie")
-    //AwsCryptographyKeyStoreTypes.Error.KeyStoreException(No item found for corresponding branch key identifier.)
-  }
-
-  method TestGetActiveKeyDoesNotExistFailsHelper(keyStore: Types.IKeyStoreClient, branchKeyId: string) 
-    requires keyStore.ValidState()
-  {
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
-
     var branchKeyResult :- expect keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(
-        branchKeyIdentifier := branchKeyId
+        branchKeyIdentifier := "Robbie"
       ));
       
     expect activeResult.Failure?;
     expect activeResult.error == Types.KeyStoreException(message := ErrorMessages.NO_CORRESPONDING_BRANCH_KEY);
+    //AwsCryptographyKeyStoreTypes.Error.KeyStoreException(No item found for corresponding branch key identifier.)
   }
 
   method {:test} TestGetActiveKeyWithNoClients() {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -46,6 +46,7 @@ module TestGetKeys {
     testBranchKeyHappyCase(keyStore, hv2BranchKeyId, hv2BranchKeyIdActiveVersionUtf8Bytes);
   }
 
+  // TODO-HV2-M1: Add MRK test
   method {:test} {:isolate_assertions} TestGetActiveMrkKey()
   {
     var ddbClient :- expect DDB.DynamoDBClient();
@@ -276,9 +277,8 @@ module TestGetKeys {
 
   method testBeaconKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string)
     requires keyStore.ValidState()
+    modifies keyStore.Modifies
   {
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
-
     var beaconKeyResult :- expect keyStore.GetBeaconKey(
       Types.GetBeaconKeyInput(
         branchKeyIdentifier := branchKeyId
@@ -291,9 +291,8 @@ module TestGetKeys {
 
   method testBranchKeyHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
     requires keyStore.ValidState()
+    modifies keyStore.Modifies
   {
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
-
     var branchKeyResult :- expect keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(
         branchKeyIdentifier := branchKeyId
@@ -306,9 +305,8 @@ module TestGetKeys {
 
   method testBranchKeyVersionHappyCase(keyStore: Types.IKeyStoreClient, branchKeyId: string, branchKeyIdActiveVersion: string, branchKeyIdActiveVersionUtf8Bytes: seq<uint8>)
     requires keyStore.ValidState()
+    modifies keyStore.Modifies
   {
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
-
     var versionResult :- expect keyStore.GetBranchKeyVersion(
       Types.GetBranchKeyVersionInput(
         branchKeyIdentifier := branchKeyId,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/TestGetKeys.dfy
@@ -195,7 +195,6 @@ module TestGetKeys {
     var ddbClient :- expect DDB.DynamoDBClient();
 
     var keyStore :- expect DefaultKeyStore(kmsId := keyArn, physicalName := branchKeyStoreName, logicalName := logicalKeyStoreName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
 
     var activeResult := keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(
@@ -211,7 +210,6 @@ module TestGetKeys {
 
     var keyStore :- expect DefaultKeyStore(kmsId:=keyArn, physicalName := branchKeyStoreName, logicalName := incorrectLogicalName, ddbClient? := Some(ddbClient), kmsClient? := Some(kmsClient));
 
-    assume {:axiom} keyStore.Modifies == {}; // Turns off verification
 
     var activeResult := keyStore.GetActiveBranchKey(
       Types.GetActiveBranchKeyInput(


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Adds:

1. TestGetKeysHappyCase (all 3)
2. TestKeyWithIncorrectKmsKeyArn (all 3)
3. TestGetKeyWrongLogicalKeyStoreName (all 3)
4. TestGetKeyDoesNotExistFails (all 3)(covers hv1 and hv2)
5. TestGetKeysWithNoClients (all 3)

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
