### PR TITLE
chore(dafny): Use new branch key id for test 

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -62,10 +62,10 @@ module Fixtures {
   const branchKeyIdWithEC := "4bb57643-07c1-419e-92ad-0df0df149d7c"
   // This is branchKeyIdActiveVersion above, as utf8bytes
   const branchKeyIdActiveVersionUtf8Bytes: seq<uint8> := [
-    102, 101, 100, 55,  97, 100,  51, 51,  45,
-    48,  55,  55, 52,  45,  52, 102, 57,  55,
-    45,  97,  97, 53, 101,  45,  54, 99,  55,
-    54,  54, 102, 99,  56,  97, 102, 57, 102
+    50, 53, 49, 101, 52, 100, 57, 100, 45, 
+    50, 52, 99, 52, 45, 52, 102, 48, 51, 
+    45, 97, 57, 54, 51, 45, 55, 98, 101, 
+    100, 102, 57, 102, 54, 48, 100, 98, 97
   ]
   // THESE ARE TESTING RESOURCES DO NOT USE IN A PRODUCTION ENVIRONMENT
   const keyArn := "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126"

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -56,8 +56,8 @@ module Fixtures {
 
   const branchKeyStoreName := "KeyStoreDdbTable"
   const logicalKeyStoreName := branchKeyStoreName
-  const branchKeyId := "75789115-1deb-4fe3-a2ec-be9e885d1945"
-  const branchKeyIdActiveVersion := "fed7ad33-0774-4f97-aa5e-6c766fc8af9f"
+  const branchKeyId := "760a5c96-6ea5-4474-9f0c-06062a27d44b"
+  const branchKeyIdActiveVersion := "251e4d9d-24c4-4f03-a963-7bedf9f60dba"
 
   const branchKeyIdWithEC := "4bb57643-07c1-419e-92ad-0df0df149d7c"
   // This is branchKeyIdActiveVersion above, as utf8bytes

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -56,16 +56,13 @@ module Fixtures {
 
   const branchKeyStoreName := "KeyStoreDdbTable"
   const logicalKeyStoreName := branchKeyStoreName
-  const branchKeyId := "760a5c96-6ea5-4474-9f0c-06062a27d44b"
-  const branchKeyIdActiveVersion := "251e4d9d-24c4-4f03-a963-7bedf9f60dba"
+  const branchKeyId := "ea8f69d0-8671-4b66-9977-e104b7e958b7"
+  const branchKeyIdActiveVersion := "b56ae3e6-6116-4d7b-9a82-3fbc6e9454fb"
 
   const branchKeyIdWithEC := "4bb57643-07c1-419e-92ad-0df0df149d7c"
   // This is branchKeyIdActiveVersion above, as utf8bytes
   const branchKeyIdActiveVersionUtf8Bytes: seq<uint8> := [
-    50, 53, 49, 101, 52, 100, 57, 100, 45, 
-    50, 52, 99, 52, 45, 52, 102, 48, 51, 
-    45, 97, 57, 54, 51, 45, 55, 98, 101, 
-    100, 102, 57, 102, 54, 48, 100, 98, 97
+    98,53,54,97,101,51,101,54,45,54,49,49,54,45,52,100,55,98,45,57,97,56,50,45,51,102,98,99,54,101,57,52,53,52,102,98
   ]
   // THESE ARE TESTING RESOURCES DO NOT USE IN A PRODUCTION ENVIRONMENT
   const keyArn := "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126"


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
The old branch key id is broken. So, this PR.

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
