### PR TITLE
chore(dafny): Check terminalEC union inferredEC for unique EC 

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/ErrorMessages.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/ErrorMessages.dfy
@@ -71,4 +71,7 @@ module {:options "/functionSyntax:4" } KeyStoreErrorMessages {
 
   const NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS :=
     "Duplicate attribute name found in branch key item after removing prefix 'aws-crypto-ec'."
+
+  const NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE :=
+    "Duplicate attribute name found in terminal encryption context key and existing attribute in non reserved attribute without 'aws-crypto-ec'."
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -197,19 +197,15 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
       Types.KeyStoreAdminException(
         message := "Active Branch Key Item read from storage is malformed!")
     );
-    if (
-        && input.Mutations.TerminalHierarchyVersion.Some?
-        && input.Mutations.TerminalHierarchyVersion.value.v2?
-      ) {
-      // TODO-HV-2-M2 : Check combination of terminalEC and inferredEC for unique EC
-      :- Need(
-        HvUtils.HasUniqueTransformedKeys?(readItems.ActiveItem.EncryptionContext),
-        Types.KeyStoreAdminException(
-          message :=
-            KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS
-        )
-      );
-    }
+    var isTerminalHv2 := input.Mutations.TerminalHierarchyVersion.Some? && 
+                        input.Mutations.TerminalHierarchyVersion.value.v2?;
+    :- Need(
+      !isTerminalHv2 || HvUtils.HasUniqueTransformedKeys?(readItems.ActiveItem.EncryptionContext),
+      Types.KeyStoreAdminException(
+        message :=
+          KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS
+      )
+    );
     :- Need(
       || input.storage is DefaultKeyStorageInterface.DynamoDBKeyStorageInterface
       || (
@@ -271,6 +267,12 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
       );
       terminalEC? := Some(terminalEC);
       assert terminalEC.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES;
+      :- Need(
+        && (!isTerminalHv2 || HvUtils.HasUniqueTransformedKeys?(terminalEC)),
+        Types.KeyStoreAdminException(
+          message := KeyStoreErrorMessages.NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE
+        )
+      );
     }
 
     assert KmsArn.ValidKmsArn?(activeItem.KmsArn);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -197,8 +197,8 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
       Types.KeyStoreAdminException(
         message := "Active Branch Key Item read from storage is malformed!")
     );
-    var isTerminalHv2 := input.Mutations.TerminalHierarchyVersion.Some? && 
-                        input.Mutations.TerminalHierarchyVersion.value.v2?;
+    var isTerminalHv2 := input.Mutations.TerminalHierarchyVersion.Some? &&
+                         input.Mutations.TerminalHierarchyVersion.value.v2?;
     :- Need(
       !isTerminalHv2 || HvUtils.HasUniqueTransformedKeys?(readItems.ActiveItem.EncryptionContext),
       Types.KeyStoreAdminException(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
@@ -55,7 +55,7 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
     // Commented code creates a branch key and adds {"Koda": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
-    // Adding {"Koda": "Is a dog."} will NOT create a non unique branch key context 
+    // Adding {"Koda": "Is a dog."} will NOT create a non unique branch key context
     //
     // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);
     // var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
@@ -18,8 +18,8 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
     var testId := "DO-NOT-EDIT-Branch-Key-For-HasUniqueTransformedKeys-Check";
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
-    // Commented code that adds {"Robbie": "Is a dog."} to the dynamodb item "DO-NOT-EDIT-Branch-Key-For-HasUniqueTransformedKeys-Check" in table KeyStoreDdbTable
-    // This code will create a branch key and make changes so that branch key item contains non unique branch key context key
+    // Commented code adds creates a branch key and adds {"Robbie": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
+    // Adding {"Robbie": "Is a dog."} will create a non unique branch key context
     //
     // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);
     // var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
@@ -54,8 +54,8 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
     var testId := "DO-NOT-EDIT-Branch-Key-For-TestNonUniqueTerminalAndInferredECKeys-Check";
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
-    // Commented code that adds {"Koda": "Is a dog."} to the dynamodb item "DO-NOT-EDIT-Branch-Key-For-TestNonUniqueTerminalAndInferredECKeys-Check" in table KeyStoreDdbTable
-    // This code will create a branch key and make changes so that branch key item contains non unique branch key context key
+    // Commented code adds creates a branch key and adds {"Koda": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
+    // Adding {"Koda": "Is a dog."} will NOT create a non unique branch key context 
     //
     // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);
     // var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
@@ -43,7 +43,7 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
       SystemKey := systemKey,
       DoNotVersion := Some(true));
     var initializeOutput := underTest.InitializeMutation(initInput);
-    
+
     expect initializeOutput.Failure?, "Should have failed to InitializeMutation HV-2.";
     expect initializeOutput.error.KeyStoreAdminException?, "Should have KeyStoreAdminException";
     expect initializeOutput.error.message == KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS, "Incorrect error message. Should have had `KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS`";
@@ -81,7 +81,7 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
       SystemKey := systemKey,
       DoNotVersion := Some(true));
     var initializeOutput := underTest.InitializeMutation(initInput);
-    
+
     expect initializeOutput.Failure?, "Should have failed to InitializeMutation HV-2.";
     expect initializeOutput.error.KeyStoreAdminException?, "Should have KeyStoreAdminException";
     expect initializeOutput.error.message == KeyStoreErrorMessages.NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE, "Incorrect error message. Should have had `KeyStoreErrorMessages.NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE`";

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
@@ -43,9 +43,47 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
       SystemKey := systemKey,
       DoNotVersion := Some(true));
     var initializeOutput := underTest.InitializeMutation(initInput);
+    
     expect initializeOutput.Failure?, "Should have failed to InitializeMutation HV-2.";
-
     expect initializeOutput.error.KeyStoreAdminException?, "Should have KeyStoreAdminException";
     expect initializeOutput.error.message == KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS, "Incorrect error message. Should have had `KeyStoreErrorMessages.NOT_UNIQUE_BRANCH_KEY_CONTEXT_KEYS`";
+  }
+
+  method {:test} TestNonUniqueTerminalAndInferredECKeys() {
+
+    var testId := "DO-NOT-EDIT-Branch-Key-For-TestNonUniqueTerminalAndInferredECKeys-Check";
+    var ddbClient :- expect Fixtures.ProvideDDBClient();
+    var kmsClient :- expect Fixtures.ProvideKMSClient();
+    // Commented code that adds {"Koda": "Is a dog."} to the dynamodb item "DO-NOT-EDIT-Branch-Key-For-TestNonUniqueTerminalAndInferredECKeys-Check" in table KeyStoreDdbTable
+    // This code will create a branch key and make changes so that branch key item contains non unique branch key context key
+    //
+    // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);
+    // var _ :- expect AdminFixtures.AddAttributeWithoutLibrary(
+    //   id:=testId,
+    //   keyValue:=AdminFixtures.KeyValue(key:="Koda", value:="Is a dog."),
+    //   alsoViolateBeacon? := true, ddbClient? := Some(ddbClient),
+    //   kmsClient?:=Some(kmsClient), violateReservedAttribute:=true);
+
+    var underTest :- expect AdminFixtures.DefaultAdmin();
+    var strategy :- expect AdminFixtures.DefaultKeyManagerStrategy(kmsClient?:=Some(kmsClient));
+    var systemKey := Types.SystemKey.trustStorage(trustStorage := Types.TrustStorage());
+
+    var terminalEC: KeyStoreTypes.EncryptionContextString := map["Koda" := "Is a dog."];
+    var mutationsRequest := Types.Mutations(
+      TerminalKmsArn := Some(Fixtures.postalHornKeyArn),
+      TerminalHierarchyVersion := Some(KeyStoreTypes.HierarchyVersion.v2),
+      TerminalEncryptionContext := Some(terminalEC)
+    );
+    var initInput := Types.InitializeMutationInput(
+      Identifier := testId,
+      Mutations := mutationsRequest,
+      Strategy := Some(strategy),
+      SystemKey := systemKey,
+      DoNotVersion := Some(true));
+    var initializeOutput := underTest.InitializeMutation(initInput);
+    
+    expect initializeOutput.Failure?, "Should have failed to InitializeMutation HV-2.";
+    expect initializeOutput.error.KeyStoreAdminException?, "Should have KeyStoreAdminException";
+    expect initializeOutput.error.message == KeyStoreErrorMessages.NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE, "Incorrect error message. Should have had `KeyStoreErrorMessages.NOT_UNIQUE_TERMINAL_EC_AND_EXISTING_ATTRIBUTE`";
   }
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestHierarchyVersion.dfy
@@ -18,7 +18,7 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
     var testId := "DO-NOT-EDIT-Branch-Key-For-HasUniqueTransformedKeys-Check";
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
-    // Commented code adds creates a branch key and adds {"Robbie": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
+    // Commented code creates a branch key and adds {"Robbie": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
     // Adding {"Robbie": "Is a dog."} will create a non unique branch key context
     //
     // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);
@@ -54,7 +54,7 @@ module {:options "/functionSyntax:4" } TestHierarchyVersion {
     var testId := "DO-NOT-EDIT-Branch-Key-For-TestNonUniqueTerminalAndInferredECKeys-Check";
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
-    // Commented code adds creates a branch key and adds {"Koda": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
+    // Commented code creates a branch key and adds {"Koda": "Is a dog."} to the branch key item by violating the reserved attribute in table KeyStoreDdbTable
     // Adding {"Koda": "Is a dog."} will NOT create a non unique branch key context 
     //
     // Fixtures.CreateHappyCaseId(id:=testId, versionCount:=0);


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This PR adds check terminalEC union inferredEC for unique EC. There is a edge case that this check will be helpful on.

Edge case:

1. I have a branch key item with unexpected EC {"Koda" : "is a dog"} which is a unique BKC
2. I mutate this item. My terminal EC is also {"Koda" : "is a dog"}.
3. While mutation, we preserve the unexpected EC `{"Koda" : "is a dog"}`.
4. Given (3.), mutating will cause collision.

Unexpected EC = attribute without key prefixed with `aws-crypto-ec`

### Squash/merge commit message, if applicable:

```
chore(dafny): Check terminalEC union inferredEC for unique EC
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
