### PR TITLE
fix(dafny): BKSA CreateKey formal verification

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
@@ -63,7 +63,7 @@ module CanonicalEncryptionContext {
     else Failure(Types.AwsCryptographicMaterialProvidersException( message := "Unable to serialize encryption context"))
   }
 
-  // @texastony had a dream of using this predicates to 
+  // @texastony had a dream of using this predicates to
   // remove duplicate code in HVUtils
   // and CreateKeyHV2.dfy but has given up on the dream for now.
   // TODO-HV-2-FOLLOW : Complete Dream or Kill this
@@ -114,15 +114,15 @@ module CanonicalEncryptionContext {
     ensures
       && output.Success?
       ==>
-      && var content? := EncryptionContextToAAD(encryptionContext);
-      && content?.Success?
-      && |crypto.History.Digest| == |old(crypto.History.Digest)| + 1
-      && var digestEvent := Seq.Last(crypto.History.Digest);
-      && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
-      && digestEvent.input.message == content?.value
-      && digestEvent.output.Success?
-      && |digestEvent.output.value| == 48 // 384 bits / 8 bits per byte == 48 bytes
-      && digestEvent.output.value == output.value
+        && var content? := EncryptionContextToAAD(encryptionContext);
+        && content?.Success?
+        && |crypto.History.Digest| == |old(crypto.History.Digest)| + 1
+        && var digestEvent := Seq.Last(crypto.History.Digest);
+        && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
+        && digestEvent.input.message == content?.value
+        && digestEvent.output.Success?
+        && |digestEvent.output.value| == 48 // 384 bits / 8 bits per byte == 48 bytes
+        && digestEvent.output.value == output.value
   {
     var canonicalEC :- EncryptionContextToAAD(encryptionContext);
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
@@ -72,7 +72,7 @@ module CanonicalEncryptionContext {
     modifies Crypto.Modifies
     ensures Crypto.ValidState()
     ensures output.Success? ==>
-              && 0 < |Crypto.History.Digest|
+              && |Crypto.History.Digest| == |old(Crypto.History.Digest)| + 1
               && Seq.Last(Crypto.History.Digest).output.Success?
               && var DigestInput := Seq.Last(Crypto.History.Digest).input;
               && var DigestOutput := Seq.Last(Crypto.History.Digest).output;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/CanonicalEncryptionContext.dfy
@@ -63,22 +63,66 @@ module CanonicalEncryptionContext {
     else Failure(Types.AwsCryptographicMaterialProvidersException( message := "Unable to serialize encryption context"))
   }
 
+  // @texastony had a dream of using this predicates to 
+  // remove duplicate code in HVUtils
+  // and CreateKeyHV2.dfy but has given up on the dream for now.
+  // TODO-HV-2-FOLLOW : Complete Dream or Kill this
+  // predicate digestSHA384ContextPostConditions(
+  //   nameonly content: seq<uint8>,
+  //   nameonly digest: seq<uint8>,
+  //   nameonly digestEvent: AtomicPrimitives.Types.DafnyCallEvent<AtomicPrimitives.Types.DigestInput, Result<seq<uint8>, AtomicPrimitives.Types.Error>>
+  // )
+  // {
+  //   var input := digestEvent.input;
+  //   var output := digestEvent.output;
+  //   && input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
+  //   && input.message == content
+  //   && output.Success?
+  //   ==>
+  //     && |output.value| == 48 // 384 bits / 8 bits per byte == 48 bytes
+  //     && output.value == digest
+  // }
+
+  // twostate predicate encryptionContextDigestPostConditions(
+  //   crypto: AtomicPrimitives.AtomicPrimitivesClient,
+  //   encryptionContext: Types.EncryptionContext,
+  //   digest: seq<uint8>
+  // )
+  //   reads crypto.History
+  // {
+  //   && var content? := EncryptionContextToAAD(encryptionContext);
+  //   && content?.Success?
+  //   && |crypto.History.Digest| == |old(crypto.History.Digest)| + 1
+  //   && var digestEvent := Seq.Last(crypto.History.Digest);
+  //   && digestSHA384ContextPostConditions(
+  //     content := content?.value,
+  //     digest := digest,
+  //     digestEvent := digestEvent)
+  // }
+
   method EncryptionContextDigest(
-    Crypto: AtomicPrimitives.AtomicPrimitivesClient,
+    crypto: AtomicPrimitives.AtomicPrimitivesClient,
     encryptionContext: Types.EncryptionContext
   )
     returns (output: Result<seq<uint8>, CanonizeDigestError>)
-    requires Crypto.ValidState()
-    modifies Crypto.Modifies
-    ensures Crypto.ValidState()
-    ensures output.Success? ==>
-              && |Crypto.History.Digest| == |old(Crypto.History.Digest)| + 1
-              && Seq.Last(Crypto.History.Digest).output.Success?
-              && var DigestInput := Seq.Last(Crypto.History.Digest).input;
-              && var DigestOutput := Seq.Last(Crypto.History.Digest).output;
-              && DigestInput.digestAlgorithm == AtomicPrimitives.Types.SHA_384
-              && DigestOutput.value == output.value
-              && |output.value| == 48 // 384 bits / 8 bits per byte == 48 bytes
+    requires crypto.ValidState()
+    modifies crypto.Modifies
+    ensures crypto.ValidState()
+    // We tried to collapse all of this post condition into a common predicate.
+    // We failed; we will have to copy and paste it.
+    // @texastony thinks reason is that is very difficult to keep track of the input.
+    ensures
+      && output.Success?
+      ==>
+      && var content? := EncryptionContextToAAD(encryptionContext);
+      && content?.Success?
+      && |crypto.History.Digest| == |old(crypto.History.Digest)| + 1
+      && var digestEvent := Seq.Last(crypto.History.Digest);
+      && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
+      && digestEvent.input.message == content?.value
+      && digestEvent.output.Success?
+      && |digestEvent.output.value| == 48 // 384 bits / 8 bits per byte == 48 bytes
+      && digestEvent.output.value == output.value
   {
     var canonicalEC :- EncryptionContextToAAD(encryptionContext);
 
@@ -86,7 +130,7 @@ module CanonicalEncryptionContext {
       digestAlgorithm := AtomicPrimitives.Types.SHA_384,
       message := canonicalEC
     );
-    var maybeDigest := Crypto.Digest(DigestInput);
+    var maybeDigest := crypto.Digest(DigestInput);
     var digest :- maybeDigest.MapFailure(e => Types.AwsCryptographyPrimitives(e));
 
     // The digest is not truncated.

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/HierarchicalVersionUtils.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/HierarchicalVersionUtils.dfy
@@ -46,23 +46,23 @@ module {:options "/functionSyntax:4" } HierarchicalVersionUtils {
   // TODO-HV2: Create a known answer test for CreateBKCDigest. See https://github.com/aws/aws-cryptographic-material-providers-library/commit/09a84e15b5d7311b0418180ddda69dc7314b320e
   method CreateBKCDigest (
     branchKeyContext: map<string, string>,
-    cryptoClient: AtomicPrimitives.AtomicPrimitivesClient
+    Crypto: AtomicPrimitives.AtomicPrimitivesClient
   ) returns (output: Result<seq<uint8>, BKCDigestError>)
     requires Structure.BranchKeyContext?(branchKeyContext)
-    requires cryptoClient.ValidState()
-    modifies cryptoClient.Modifies
-    ensures cryptoClient.ValidState()
+    requires Crypto.ValidState()
+    modifies Crypto.Modifies
+    ensures Crypto.ValidState()
     ensures output.Success? ==>
-              && 0 < |cryptoClient.History.Digest|
-              && Seq.Last(cryptoClient.History.Digest).output.Success?
-              && var DigestInput := Seq.Last(cryptoClient.History.Digest).input;
-              && var DigestOutput := Seq.Last(cryptoClient.History.Digest).output;
+              && |Crypto.History.Digest| == |old(Crypto.History.Digest)| + 1
+              && Seq.Last(Crypto.History.Digest).output.Success?
+              && var DigestInput := Seq.Last(Crypto.History.Digest).input;
+              && var DigestOutput := Seq.Last(Crypto.History.Digest).output;
               && DigestInput.digestAlgorithm == AtomicPrimitives.Types.SHA_384
               && DigestOutput.value == output.value
               && |output.value| == Structure.BKC_DIGEST_LENGTH as int
   {
     var utf8BKContext :- EncodeEncryptionContext(branchKeyContext).MapFailure(WrapStringToError);
-    var digestResult := CanonicalEncryptionContext.EncryptionContextDigest(cryptoClient, utf8BKContext);
+    var digestResult := CanonicalEncryptionContext.EncryptionContextDigest(Crypto, utf8BKContext);
     if (digestResult.Failure?) {
       var error: Types.Error;
       error := match digestResult.error {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/HierarchicalVersionUtils.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/HierarchicalVersionUtils.dfy
@@ -46,23 +46,26 @@ module {:options "/functionSyntax:4" } HierarchicalVersionUtils {
   // TODO-HV2: Create a known answer test for CreateBKCDigest. See https://github.com/aws/aws-cryptographic-material-providers-library/commit/09a84e15b5d7311b0418180ddda69dc7314b320e
   method CreateBKCDigest (
     branchKeyContext: map<string, string>,
-    Crypto: AtomicPrimitives.AtomicPrimitivesClient
+    crypto: AtomicPrimitives.AtomicPrimitivesClient
   ) returns (output: Result<seq<uint8>, BKCDigestError>)
-    requires Structure.BranchKeyContext?(branchKeyContext)
-    requires Crypto.ValidState()
-    modifies Crypto.Modifies
-    ensures Crypto.ValidState()
-    ensures output.Success? ==>
-              && |Crypto.History.Digest| == |old(Crypto.History.Digest)| + 1
-              && Seq.Last(Crypto.History.Digest).output.Success?
-              && var DigestInput := Seq.Last(Crypto.History.Digest).input;
-              && var DigestOutput := Seq.Last(Crypto.History.Digest).output;
-              && DigestInput.digestAlgorithm == AtomicPrimitives.Types.SHA_384
-              && DigestOutput.value == output.value
-              && |output.value| == Structure.BKC_DIGEST_LENGTH as int
+    requires crypto.ValidState() && Structure.BranchKeyContext?(branchKeyContext)
+    modifies crypto.Modifies
+    ensures crypto.ValidState()
+    ensures EncodeEncryptionContext(branchKeyContext).Failure? ==> output.Failure?
+    ensures
+      && output.Success?
+      ==>
+        // Note there is no proof that the input to the digest
+        // is utf8BKContext; dafny could not handle that
+        && |crypto.History.Digest| == |old(crypto.History.Digest)| + 1
+        && var digestEvent := Seq.Last(crypto.History.Digest);
+        && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
+        && digestEvent.output.Success?
+        && digestEvent.output.value == output.value
+        && |output.value| == Structure.BKC_DIGEST_LENGTH as int
   {
     var utf8BKContext :- EncodeEncryptionContext(branchKeyContext).MapFailure(WrapStringToError);
-    var digestResult := CanonicalEncryptionContext.EncryptionContextDigest(Crypto, utf8BKContext);
+    var digestResult := CanonicalEncryptionContext.EncryptionContextDigest(crypto, utf8BKContext);
     if (digestResult.Failure?) {
       var error: Types.Error;
       error := match digestResult.error {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -7,6 +7,7 @@ include "ApplyMutation.dfy"
 include "KmsUtils.dfy"
 include "DescribeMutation.dfy"
 include "CreateKeysHV2.dfy"
+include "BKSAOperationUtils.dfy"
 
 module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKeyStoreAdminOperations {
   import opened AwsKmsUtils
@@ -31,6 +32,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   import DM = DescribeMutation
   import KmsUtils
   import CreateKeysHV2
+  import OptUtils = BKSAOperationUtils
 
   datatype Config = Config(
     nameonly logicalKeyStoreName: string,
@@ -279,6 +281,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
   predicate CreateKeyEnsuresPublicly(input: CreateKeyInput , output: Result<CreateKeyOutput, Error>)
   {true}
 
+  // TODO-HV-2-FOLLOW : Refactor BKS & BKSA CreateKey to remove duplicate code
   method CreateKey ( config: InternalConfig , input: CreateKeyInput )
     returns (output: Result<CreateKeyOutput, Error>)
 
@@ -320,6 +323,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
             HierarchyVersion := hvInput
           ));
       case v2 =>
+        // TODO-HV-2-FOLLOW : Refactor BKS & BKSA CreateKey to remove duplicate code
         :- Need(
           keyManagerStrat.kmsSimple?,
           Types.KeyStoreAdminException(message :="Only KMS Simple is supported at this time for HV-2 to Create Keys")
@@ -329,6 +333,10 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
         // See Smithy-Dafny : https://github.com/smithy-lang/smithy-dafny/pull/543
         assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
+        var keyManagerAndStorage := OptUtils.KeyManagerAndStorage(
+            config.storage, keyManagerStrat
+        );
+        assert keyManagerAndStorage.ValidState();
         :- Need(input.Identifier.Some? ==>
                   && input.EncryptionContext.Some?
                   && 0 < |input.EncryptionContext.value|,
@@ -397,16 +405,14 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
                 Types.KeyStoreAdminException( message := ErrorMessages.UTF8_ENCODING_ENCRYPTION_CONTEXT_ERROR));
 
         output := CreateKeysHV2.CreateBranchAndBeaconKeys(
-          branchKeyIdentifier,
-          map i <- encodedEncryptionContext :: i.0.value := i.1.value,
-          timestamp,
-          branchKeyVersion,
-          legacyConfig.logicalKeyStoreName,
-          legacyConfig.kmsConfiguration,
-          legacyConfig.grantTokens,
-          legacyConfig.kmsClient,
-          legacyConfig.storage,
-          hvInput
+          branchKeyIdentifier := branchKeyIdentifier,
+          encryptionContext := map i <- encodedEncryptionContext :: i.0.value := i.1.value,
+          timestamp := timestamp,
+          branchKeyVersion := branchKeyVersion,
+          logicalKeyStoreName := config.logicalKeyStoreName,
+          kmsConfiguration := legacyConfig.kmsConfiguration,
+          keyManagerAndStorage := keyManagerAndStorage,
+          hierarchyVersion := hvInput
         );
     }
   }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -334,7 +334,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
         assume {:axiom} legacyConfig.kmsClient.Modifies < MutationLie();
 
         var keyManagerAndStorage := OptUtils.KeyManagerAndStorage(
-            config.storage, keyManagerStrat
+          config.storage, keyManagerStrat
         );
         assert keyManagerAndStorage.ValidState();
         :- Need(input.Identifier.Some? ==>

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/BKSAOperationUtils.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/BKSAOperationUtils.dfy
@@ -1,0 +1,30 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+include "../Model/AwsCryptographyKeyStoreAdminTypes.dfy"
+include "KmsUtils.dfy"
+
+/** Utilities to simplify the logic in AwsCryptographyKeyStoreAdminOperations. */
+module {:options "/functionSyntax:4" } BKSAOperationUtils {
+  import opened Wrappers
+  import KeyStoreTypes = AwsCryptographyKeyStoreOperations.Types
+  import KmsUtils
+
+  // TODO-HV-2-FOLLOW : It may help the BKS proofs to use this datatype
+  /** Constrains the relationship of the storage & KMS client(s), 
+    ensuring they a valid but their histories are separate. */
+  datatype KeyManagerAndStorage = KeyManagerAndStorage(
+    storage : KeyStoreTypes.IKeyStorageInterface,
+    keyManagerStrat: KmsUtils.keyManagerStrat
+  )
+  {
+    ghost predicate ValidState()
+    {
+      && storage.ValidState()
+      && keyManagerStrat.ValidState()
+      && storage.Modifies !! keyManagerStrat.Modifies
+    }
+    ghost const Modifies := multiset(storage.Modifies) + multiset(keyManagerStrat.Modifies)
+  }
+
+}

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
@@ -4,6 +4,8 @@
 include "../Model/AwsCryptographyKeyStoreAdminTypes.dfy"
 include "../../AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy"
 include "../../../../AwsCryptographyPrimitives/Model/AwsCryptographyPrimitivesTypes.dfy"
+include "BKSAOperationUtils.dfy"
+include "KmsUtils.dfy"
 
 module {:options "/functionSyntax:4" } CreateKeysHV2 {
   // Standard Library Imports
@@ -30,23 +32,26 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     // (Branch) Key Store Admin Imports
   import HvUtils = HierarchicalVersionUtils
   import Types = AwsCryptographyKeyStoreAdminTypes
+  import OptUtils = BKSAOperationUtils
+  import KmsUtils
 
-  datatype CryptoAndKMS = CryptoAndKMS(
+  /** Constrains the relationship of the Crypto & KMS client, 
+    ensuring they a valid but their histories are separate.
+    Also allows us to make claims about the Grant Tokens and kmsConfig. */
+  datatype CryptoAndKms = CryptoAndKms(
     kmsConfig: KeyStoreTypes.KMSConfiguration,
-    grantTokens: KMS.Types.GrantTokenList,
-    kms: KMS.Types.IKMSClient,
-    Crypto: AtomicPrimitives.AtomicPrimitivesClient
+    kms: KmsUtils.keyManagerStrat,
+    crypto: AtomicPrimitives.AtomicPrimitivesClient
   ) {
     ghost predicate ValidState()
     {
       && kms.ValidState()
-      && KMS.Types.IsValid_GrantTokenList(grantTokens)
       && KMSKeystoreOperations.HasKeyId(kmsConfig)
       && KmsArn.ValidKmsArn?(KMSKeystoreOperations.GetKeyId(kmsConfig))
-      && kms.Modifies !! Crypto.Modifies
-      && Crypto.ValidState()
+      && kms.Modifies !! crypto.Modifies
+      && crypto.ValidState()
     }
-    ghost const Modifies := multiset(kms.Modifies) + multiset(Crypto.Modifies)
+    ghost const Modifies := multiset(kms.Modifies) + multiset(crypto.Modifies)
   }
 
   function ConvertKmsErrorToError(
@@ -72,36 +77,28 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
 
   // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
   method CreateBranchAndBeaconKeys(
-    branchKeyIdentifier: string,
-    encryptionContext: map<string, string>,
-    timestamp: string,
-    branchKeyVersion: string,
-    logicalKeyStoreName: string,
-    kmsConfiguration: KeyStoreTypes.KMSConfiguration,
-    grantTokens: KMS.Types.GrantTokenList,
-    kmsClient: KMS.Types.IKMSClient,
-    storage: KeyStoreTypes.IKeyStorageInterface,
-    hierarchyVersion: KeyStoreTypes.HierarchyVersion
+    nameonly branchKeyIdentifier: string,
+    nameonly encryptionContext: map<string, string>,
+    nameonly timestamp: string,
+    nameonly branchKeyVersion: string,
+    nameonly logicalKeyStoreName: string,
+    nameonly kmsConfiguration: KeyStoreTypes.KMSConfiguration,
+    nameonly keyManagerAndStorage: OptUtils.KeyManagerAndStorage,
+    nameonly hierarchyVersion: KeyStoreTypes.HierarchyVersion
   )
     returns (output: Result<Types.CreateKeyOutput, Types.Error>)
-    // Generic Stateful pre and post conditions
     requires
-      && kmsClient.ValidState()
-      && storage.ValidState()
-      && kmsClient.Modifies !! storage.Modifies
-    modifies multiset(storage.Modifies) + multiset(kmsClient.Modifies)
-    ensures
-      && storage.ValidState()
-      && kmsClient.ValidState()
-      && kmsClient.Modifies !! storage.Modifies
-    // 
-    requires
+      // TODO-HV-2-M? : Support KmsDecryptEncrypt?
+      && keyManagerAndStorage.keyManagerStrat.kmsSimple?
+      && keyManagerAndStorage.ValidState()
       && KMSKeystoreOperations.HasKeyId(kmsConfiguration)
       && KmsArn.ValidKmsArn?(KMSKeystoreOperations.GetKeyId(kmsConfiguration))
       && hierarchyVersion.v2?
       && 0 < |branchKeyIdentifier|
       && 0 < |branchKeyVersion|
       && forall k <- encryptionContext :: DDB.Types.IsValid_AttributeName(Structure.ENCRYPTION_CONTEXT_PREFIX + k)
+    modifies keyManagerAndStorage.Modifies
+    ensures keyManagerAndStorage.ValidState()
   {
     // Construct Branch Key Contexts for ACTIVE, Version and Beacon items.
     var decryptOnlyBranchKeyContext := Structure.DecryptOnlyBranchKeyEncryptionContext(
@@ -141,30 +138,30 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
       e => Types.AwsCryptographyPrimitives(
           AwsCryptographyPrimitives := e));
 
-    var CryptoAndKMS := CryptoAndKMS(kmsConfiguration, grantTokens, kmsClient, crypto);
+    var CryptoAndKms := CryptoAndKms(kmsConfiguration, keyManagerAndStorage.keyManagerStrat, crypto);
     var decrytOnlyBKItem :- packAndCallKMS(
       branchKeyContext := decryptOnlyBranchKeyContext,
-      CryptoAndKMS := CryptoAndKMS,
+      cryptoAndKms := CryptoAndKms,
       material := activePlaintextMaterial,
       encryptionContext := encryptionContext
     );
 
     var activeBKItem :- packAndCallKMS(
       branchKeyContext := activeBranchKeyContext,
-      CryptoAndKMS := CryptoAndKMS,
+      cryptoAndKms := CryptoAndKms,
       material := activePlaintextMaterial,
       encryptionContext := encryptionContext
     );
 
     var beaconBKItem :- packAndCallKMS(
       branchKeyContext := beaconBranchKeyContext,
-      CryptoAndKMS := CryptoAndKMS,
+      cryptoAndKms := CryptoAndKms,
       material := beaconPlaintextMaterial,
       encryptionContext := encryptionContext
     );
 
     // Write ACTIVE, Version & Beacon Items to storage
-    var writeItems? := storage.WriteNewEncryptedBranchKey(
+    var writeItems? := keyManagerAndStorage.storage.WriteNewEncryptedBranchKey(
       KeyStoreTypes.WriteNewEncryptedBranchKeyInput(
         Active := activeBKItem,
         Version := decrytOnlyBKItem,
@@ -175,9 +172,10 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
       e => Types.AwsCryptographyKeyStore(
           AwsCryptographyKeyStore:= e
         ));
-
+    // By making this ghost, we avoid the Dafny transpiler emitting in Java etc.
+    ghost var storage := keyManagerAndStorage.storage;
     assert |storage.History.WriteNewEncryptedBranchKey| == |old(storage.History.WriteNewEncryptedBranchKey)| + 1;
-    ghost var writeEvent := storage.History.WriteNewEncryptedBranchKey[-1 % |storage.History.WriteNewEncryptedBranchKey|];
+    ghost var writeEvent := Seq.Last(storage.History.WriteNewEncryptedBranchKey);
     assert
       && writeEvent.output.Success?
       && writeEvent.input.Active == activeBKItem
@@ -192,42 +190,44 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
 
   method packAndCallKMS(
     nameonly branchKeyContext: map<string, string>,
-    nameonly CryptoAndKMS: CryptoAndKMS,
+    nameonly cryptoAndKms: CryptoAndKms,
     nameonly material: seq<uint8>,
     nameonly encryptionContext: map<string, string>
   )
     returns (output: Result<KeyStoreTypes.EncryptedHierarchicalKey, Types.Error>)
-
-    requires CryptoAndKMS.ValidState()
-    modifies CryptoAndKMS.Modifies
-    ensures CryptoAndKMS.ValidState()
-
     requires
+      && cryptoAndKms.ValidState()
       && Structure.BranchKeyContext?(branchKeyContext)
       && |material| == Structure.AES_256_LENGTH as int
-      && KMSKeystoreOperations.AttemptKmsOperation?(CryptoAndKMS.kmsConfig, branchKeyContext[Structure.KMS_FIELD])
-      && KMSKeystoreOperations.GetKeyId(CryptoAndKMS.kmsConfig) == branchKeyContext[Structure.KMS_FIELD]
-
-    // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
-    ensures output.Success? ==>
-              && |CryptoAndKMS.kms.History.Encrypt| == |old(CryptoAndKMS.kms.History.Encrypt)| + 1
-              && var kmsEvent :=  CryptoAndKMS.kms.History.Encrypt[-1 % |CryptoAndKMS.kms.History.Encrypt|];
-              && kmsEvent.output.Success?
-              && var kmsInput := kmsEvent.input;
-              && KMSKeystoreOperations.Compatible?(CryptoAndKMS.kmsConfig, kmsInput.KeyId)
-              && |kmsInput.Plaintext| == (Structure.BKC_DIGEST_LENGTH + Structure.AES_256_LENGTH) as int
-              && kmsInput.EncryptionContext == Some(encryptionContext)
-              && kmsInput.GrantTokens == Some(CryptoAndKMS.grantTokens)
-              && kmsEvent.output.value.CiphertextBlob.Some?
-              && var digest := kmsInput.Plaintext[..Structure.BKC_DIGEST_LENGTH];
-              && material == kmsInput.Plaintext[Structure.BKC_DIGEST_LENGTH..]
-              && |CryptoAndKMS.Crypto.History.Digest| == |old(CryptoAndKMS.Crypto.History.Digest)| + 1
-              && var digestEvent := CryptoAndKMS.Crypto.History.Digest[-1 % |CryptoAndKMS.Crypto.History.Digest|];
-              && digestEvent.output.Success?
-              && digestEvent.output.value == digest
-              && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
+      && KMSKeystoreOperations.AttemptKmsOperation?(cryptoAndKms.kmsConfig, branchKeyContext[Structure.KMS_FIELD])
+      && KMSKeystoreOperations.GetKeyId(cryptoAndKms.kmsConfig) == branchKeyContext[Structure.KMS_FIELD]
+         // TODO-HV-2-M? : Support KmsDecryptEncrypt?
+      && cryptoAndKms.kms.kmsSimple?
+    modifies cryptoAndKms.Modifies
+    // Note: even if the method fails, the clients are ValidState
+    ensures cryptoAndKms.ValidState()
+    ensures
+         // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
+      && output.Success? ==>
+        && var kms := cryptoAndKms.kms.kmsSimple.kmsClient;
+        && |kms.History.Encrypt| == |old(kms.History.Encrypt)| + 1
+        && var kmsEvent :=  Seq.Last(kms.History.Encrypt);
+        && kmsEvent.output.Success?
+        && var kmsInput := kmsEvent.input;
+        && KMSKeystoreOperations.Compatible?(cryptoAndKms.kmsConfig, kmsInput.KeyId)
+        && |kmsInput.Plaintext| == (Structure.BKC_DIGEST_LENGTH + Structure.AES_256_LENGTH) as int
+        && kmsInput.EncryptionContext == Some(encryptionContext)
+        && kmsInput.GrantTokens == Some(cryptoAndKms.kms.kmsSimple.grantTokens)
+        && kmsEvent.output.value.CiphertextBlob.Some?
+        && var digest := kmsInput.Plaintext[..Structure.BKC_DIGEST_LENGTH];
+        && material == kmsInput.Plaintext[Structure.BKC_DIGEST_LENGTH..]
+        && |cryptoAndKms.crypto.History.Digest| == |old(cryptoAndKms.crypto.History.Digest)| + 1
+        && var digestEvent := Seq.Last(cryptoAndKms.crypto.History.Digest);
+        && digestEvent.output.Success?
+        && digestEvent.output.value == digest
+        && digestEvent.input.digestAlgorithm == AtomicPrimitives.Types.SHA_384
   {
-    var digest? := HvUtils.CreateBKCDigest(branchKeyContext, CryptoAndKMS.Crypto);
+    var digest? := HvUtils.CreateBKCDigest(branchKeyContext, cryptoAndKms.crypto);
     var digest :- digest?.MapFailure(
       e => Types.AwsCryptographyKeyStore(
           AwsCryptographyKeyStore:= e));
@@ -236,9 +236,9 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
       plaintextTuple,
       encryptionContext,
       branchKeyContext[Structure.KMS_FIELD],
-      CryptoAndKMS.kmsConfig,
-      CryptoAndKMS.grantTokens,
-      CryptoAndKMS.kms
+      cryptoAndKms.kmsConfig,
+      cryptoAndKms.kms.kmsSimple.grantTokens,
+      cryptoAndKms.kms.kmsSimple.kmsClient
     );
     var wrappedMaterial :- wrappedMaterial?.MapFailure(e => ConvertKmsErrorToError(e));
     return Success(Structure.ConstructEncryptedHierarchicalKey(branchKeyContext, wrappedMaterial));

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
@@ -139,7 +139,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
           AwsCryptographyPrimitives := e));
 
     var CryptoAndKms := CryptoAndKms(kmsConfiguration, keyManagerAndStorage.keyManagerStrat, crypto);
-    var decrytOnlyBKItem :- packAndCallKMS(
+    var decryptOnlyBKItem :- packAndCallKMS(
       branchKeyContext := decryptOnlyBranchKeyContext,
       cryptoAndKms := CryptoAndKms,
       material := activePlaintextMaterial,
@@ -164,7 +164,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     var writeItems? := keyManagerAndStorage.storage.WriteNewEncryptedBranchKey(
       KeyStoreTypes.WriteNewEncryptedBranchKeyInput(
         Active := activeBKItem,
-        Version := decrytOnlyBKItem,
+        Version := decryptOnlyBKItem,
         Beacon := beaconBKItem
       )
     );
@@ -179,7 +179,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     assert
       && writeEvent.output.Success?
       && writeEvent.input.Active == activeBKItem
-      && writeEvent.input.Version == decrytOnlyBKItem
+      && writeEvent.input.Version == decryptOnlyBKItem
       && writeEvent.input.Beacon == beaconBKItem;
     output := Success(
       Types.CreateKeyOutput(
@@ -207,7 +207,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     // Note: even if the method fails, the clients are ValidState
     ensures cryptoAndKms.ValidState()
     ensures
-         // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
+      // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
       && output.Success? ==>
         && var kms := cryptoAndKms.kms.kmsSimple.kmsClient;
         && |kms.History.Encrypt| == |old(kms.History.Encrypt)| + 1

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/CreateKeysHV2.dfy
@@ -1,40 +1,36 @@
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+include "../Model/AwsCryptographyKeyStoreAdminTypes.dfy"
 include "../../AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy"
 include "../../../../AwsCryptographyPrimitives/Model/AwsCryptographyPrimitivesTypes.dfy"
-include "../../AwsCryptographyKeyStore/src/Structure.dfy"
-include "../../AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy"
-include "../../AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy"
-include "../../AwsCryptographyKeyStore/src/KeyStoreErrorMessages.dfy"
-include "../../AwsCryptographicMaterialProviders/src/AwsArnParsing.dfy"
-include "../../AwsCryptographyKeyStore/src/KmsArn.dfy"
-include "SystemKey/ContentHandler.dfy"
 
-// TODO-HV-2-M1: WIP
 module {:options "/functionSyntax:4" } CreateKeysHV2 {
-  // TODO-HV-2-M1-FF: Group imports according to libraries
+  // Standard Library Imports
   import opened StandardLibrary
   import opened Wrappers
+  import opened Seq
+  import opened UInt = StandardLibrary.UInt
+  import Time
+    // SDK Imports
+  import DDB = ComAmazonawsDynamodbTypes
+  import KMS = ComAmazonawsKmsTypes
+    // Crypto Primitives Imports
+  import AtomicPrimitives
+  import CryptoTypes = AwsCryptographyPrimitivesTypes
+    // MPL Imports
+  import AwsArnParsing
+  import CanonicalEncryptionContext
+    // (Branch) Key Store Imports
   import Structure
   import DefaultKeyStorageInterface
   import KMSKeystoreOperations
   import ErrorMessages = KeyStoreErrorMessages
-
-  import opened Seq
-  import opened UInt = StandardLibrary.UInt
   import KeyStoreTypes = AwsCryptographyKeyStoreTypes
-  import Types = AwsCryptographyKeyStoreAdminTypes
-  import DDB = ComAmazonawsDynamodbTypes
-  import KMS = ComAmazonawsKmsTypes
-  import AwsArnParsing
   import KmsArn
-  import AtomicPrimitives
-  import CanonicalEncryptionContext
-  import Time
+    // (Branch) Key Store Admin Imports
   import HvUtils = HierarchicalVersionUtils
-  import CryptoTypes = AwsCryptographyPrimitivesTypes
-  import ContentHandler = SystemKey.ContentHandler
+  import Types = AwsCryptographyKeyStoreAdminTypes
 
   function ConvertKmsErrorToError(
     e: KMSKeystoreOperations.KmsError
@@ -55,6 +51,22 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
           AwsCryptographyKeyStore := e
         )
     }
+  }
+
+  // TODO-HV-2-GA : We need to refactor BKSA and probably BKS to have a CryptoClient so we can make statements
+  // about the history of the SHA requests.
+  lemma assumeSHAIsInjective(
+    messageADigestEvent: CryptoTypes.DafnyCallEvent<CryptoTypes.DigestInput, Result<seq<uint8>, CryptoTypes.Error>>,
+    messageBDigestEvent: CryptoTypes.DafnyCallEvent<CryptoTypes.DigestInput, Result<seq<uint8>, CryptoTypes.Error>>
+  )
+  {
+    assume {:axiom}
+      && messageADigestEvent.output.Success?
+      && messageBDigestEvent.output.Success?
+      ==>
+        (messageADigestEvent.input.message != messageBDigestEvent.input.message
+         <==>
+         messageADigestEvent.output.value != messageBDigestEvent.output.value);
   }
 
   // TODO-HV-2-GA: Update Specification for HV-2 Branch Key Creation
@@ -133,8 +145,16 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
                 && Structure.ENCRYPTION_CONTEXT_PREFIX + k in decryptOnlyBranchKeyContext
                 && decryptOnlyBranchKeyContext[Structure.ENCRYPTION_CONTEXT_PREFIX + k] == customEncryptionContext[k])
 
-        && WrappedBranchKeyCreationHV2?(
+        && WrappedDecryptOnlyCreationHV2?(
              kmsEncryptRequestForDecryptOnlyBKI,
+             kmsClient,
+             kmsConfiguration,
+             grantTokens,
+             customEncryptionContext,
+             decryptOnlyBranchKeyContext
+           )
+
+        && WrappedBranchKeyActiveCreationHV2?(
              kmsEncryptRequestForActiveBKI,
              kmsClient,
              kmsConfiguration,
@@ -163,6 +183,9 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
               && var kmsEncryptRequestForActiveBKI := kmsClient.History.Encrypt[-2 % |kmsClient.History.Encrypt|];
               // The third and last request we made is for the new Beacon BKI
               && var kmsEncryptRequestForBeaconBKI := kmsClient.History.Encrypt[-1 % |kmsClient.History.Encrypt|];
+              && kmsEncryptRequestForDecryptOnlyBKI.output.Success?
+              && kmsEncryptRequestForActiveBKI.output.Success?
+              && kmsEncryptRequestForBeaconBKI.output.Success?
               && var decryptOnlyBranchKeyContext := Structure.DecryptOnlyBranchKeyEncryptionContext(
                                                       branchKeyIdentifier,
                                                       branchKeyVersion,
@@ -277,6 +300,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     var beaconPlaintextTuple := HvUtils.PackPlainTextTuple(beaconDigest, beaconPlaintextMaterial);
 
     assert KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, decryptOnlyBranchKeyContext[Structure.KMS_FIELD]);
+    ghost var initialKmsEncryptReqHistory := kmsClient.History.Encrypt;
     var wrappedDecryptOnlyBranchKey? := KMSKeystoreOperations.EncryptKey(
       decryptOnlyPlaintextTuple,
       customEncryptionContext,
@@ -286,7 +310,22 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
       kmsClient
     );
     var wrappedDecryptOnlyBranchKey :- wrappedDecryptOnlyBranchKey?.MapFailure(e => ConvertKmsErrorToError(e));
+    assert |initialKmsEncryptReqHistory| + 1 ==  |kmsClient.History.Encrypt|;
+    assert |kmsClient.History.Encrypt| == |old(kmsClient.History.Encrypt)| + 1;
+    ghost var kmsEncryptRequestForDecryptOnlyBKI :=  Seq.Last(kmsClient.History.Encrypt);
+
     var decrytOnlyBKItem := Structure.ConstructEncryptedHierarchicalKey(decryptOnlyBranchKeyContext,wrappedDecryptOnlyBranchKey);
+    assert decrytOnlyBKItem == Structure.ConstructEncryptedHierarchicalKey(
+                                 Structure.DecryptOnlyBranchKeyEncryptionContext(
+                                   branchKeyIdentifier,
+                                   branchKeyVersion,
+                                   timestamp,
+                                   logicalKeyStoreName,
+                                   KMSKeystoreOperations.GetKeyId(kmsConfiguration),
+                                   hierarchyVersion,
+                                   customEncryptionContext
+                                 ),
+                                 wrappedDecryptOnlyBranchKey);
 
     assert KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, activeBranchKeyContext[Structure.KMS_FIELD]);
     var wrappedActiveBranchKey? := KMSKeystoreOperations.EncryptKey(
@@ -299,6 +338,10 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     );
     var wrappedActiveBranchKey :- wrappedActiveBranchKey?.MapFailure(e => ConvertKmsErrorToError(e));
     var activeBKItem := Structure.ConstructEncryptedHierarchicalKey(activeBranchKeyContext, wrappedActiveBranchKey);
+    assert activeBKItem == Structure.ConstructEncryptedHierarchicalKey(
+                             Structure.ActiveBranchKeyEncryptionContext(decryptOnlyBranchKeyContext),
+                             wrappedActiveBranchKey);
+    ghost var kmsEncryptRequestForActiveBKI :=  Seq.Last(kmsClient.History.Encrypt);
 
     assert KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, beaconBranchKeyContext[Structure.KMS_FIELD]);
     var wrappedBeaconKey? := KMSKeystoreOperations.EncryptKey(
@@ -311,6 +354,36 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     );
     var wrappedBeaconKey :- wrappedBeaconKey?.MapFailure(e => ConvertKmsErrorToError(e));
     var beaconBKItem := Structure.ConstructEncryptedHierarchicalKey(beaconBranchKeyContext, wrappedBeaconKey);
+    ghost var kmsEncryptRequestForBeaconBKI :=  Seq.Last(kmsClient.History.Encrypt);
+    assert
+      && kmsEncryptRequestForDecryptOnlyBKI.output.Success?
+      && kmsEncryptRequestForActiveBKI.output.Success?
+      && kmsEncryptRequestForDecryptOnlyBKI.output.Success?;
+    assert
+      && kmsEncryptRequestForDecryptOnlyBKI != kmsEncryptRequestForActiveBKI
+      && kmsEncryptRequestForActiveBKI != kmsEncryptRequestForBeaconBKI
+      && kmsEncryptRequestForDecryptOnlyBKI != kmsEncryptRequestForBeaconBKI
+    by {
+      assert
+        && kmsEncryptRequestForDecryptOnlyBKI.input.Plaintext != kmsEncryptRequestForActiveBKI.input.Plaintext
+        && kmsEncryptRequestForActiveBKI.input.Plaintext != kmsEncryptRequestForBeaconBKI.input.Plaintext
+        && kmsEncryptRequestForDecryptOnlyBKI.input.Plaintext != kmsEncryptRequestForBeaconBKI.input.Plaintext by
+      {
+        // TODO-HV-2-GA : Revise to use assumeSHAIsInjective
+        // The Dafny contract of the SHA-384 function CAN NOT ensure that every unique input has a unique output.
+        // This means we cannot prove that the outcome of SHA-384 is unique,
+        // and therefore cannot prove that the Plaintext input to KMS Encrypt are unique.
+        assume {:axiom} && kmsEncryptRequestForDecryptOnlyBKI.input.Plaintext != kmsEncryptRequestForActiveBKI.input.Plaintext
+                        && kmsEncryptRequestForActiveBKI.input.Plaintext != kmsEncryptRequestForBeaconBKI.input.Plaintext
+                        && kmsEncryptRequestForDecryptOnlyBKI.input.Plaintext != kmsEncryptRequestForBeaconBKI.input.Plaintext;
+      }
+    }
+
+    assert
+      kmsEncryptRequestForDecryptOnlyBKI.input.GrantTokens
+   == kmsEncryptRequestForActiveBKI.input.GrantTokens
+   == kmsEncryptRequestForDecryptOnlyBKI.input.GrantTokens
+   == Some(grantTokens);
 
     // Write ACTIVE, Version & Beacon Items to storage
     var writeItems? := storage.WriteNewEncryptedBranchKey(
@@ -332,40 +405,10 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
       ));
   }
 
-  twostate predicate WrappedBranchKeyCreationHV2?(
-    new kmsEncryptRequestForDecryptOnlyBKI: KMS.DafnyCallEvent<KMS.EncryptRequest, Result<KMS.EncryptResponse, KMS.Error>>,
-    new kmsEncryptRequestForActiveBKI: KMS.DafnyCallEvent<KMS.EncryptRequest, Result<KMS.EncryptResponse, KMS.Error>>,
-    kmsClient: KMS.IKMSClient,
-    kmsConfiguration: KeyStoreTypes.KMSConfiguration,
-    grantTokens: KMS.GrantTokenList,
-    encryptionContext:  map<string, string>,
+  predicate BranchKeyContextForDecyrptHV2?(
     branchKeyContext: map<string, string>
   )
-    reads kmsClient.History
-    requires KMSKeystoreOperations.HasKeyId(kmsConfiguration) && KmsArn.ValidKmsArn?(KMSKeystoreOperations.GetKeyId(kmsConfiguration))
-    requires old(kmsClient.History.Encrypt) < kmsClient.History.Encrypt
-    requires
-      && kmsEncryptRequestForDecryptOnlyBKI in kmsClient.History.Encrypt[|old(kmsClient.History.Encrypt)|..]
-      && kmsEncryptRequestForActiveBKI in kmsClient.History.Encrypt[|old(kmsClient.History.Encrypt)|..]
   {
-    // Verify the KMS request to create the decrypt-only ciphertext was constructed correctly
-    && WrappedDecryptOnlyCreationHV2?(
-         kmsEncryptRequestForDecryptOnlyBKI,
-         kmsClient,
-         kmsConfiguration,
-         grantTokens,
-         encryptionContext,
-         branchKeyContext)
-
-    // Verify the KMS request to create the ACTIVE ciphertext was constructed correctly
-    && WrappedBranchKeyActiveCreationHV2?(
-         kmsEncryptRequestForActiveBKI,
-         kmsClient,
-         kmsConfiguration,
-         grantTokens,
-         encryptionContext,
-         branchKeyContext)
-
     // Verify branch key context  relationships
     && Structure.BranchKeyContext?(branchKeyContext)
        // The BKC is for a DECRYPT_ONLY, or a Version, and there fore is prefixed with `branch:version:`
@@ -376,7 +419,7 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     && branchKeyContext[Structure.HIERARCHY_VERSION] == Structure.HIERARCHY_VERSION_VALUE_2
   }
 
-  twostate predicate WrappedDecryptOnlyCreationHV2?(
+  twostate predicate /* {:isolate_assertions} */ WrappedDecryptOnlyCreationHV2?(
     new kmsEncryptRequestForDecryptOnlyBKI: KMS.DafnyCallEvent<KMS.EncryptRequest, Result<KMS.EncryptResponse, KMS.Error>>,
     kmsClient: KMS.IKMSClient,
     kmsConfiguration: KeyStoreTypes.KMSConfiguration,
@@ -397,11 +440,12 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     && decryptOnlyInput.GrantTokens == Some(grantTokens)
     && kmsEncryptRequestForDecryptOnlyBKI.output.Success?
     && kmsEncryptRequestForDecryptOnlyBKI.output.value.CiphertextBlob.Some?
-    && kmsEncryptRequestForDecryptOnlyBKI.output.value.KeyId.Some?
-    && kmsEncryptRequestForDecryptOnlyBKI.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
+       // There is no reason to proove the KMS response, if succesful, adhered to KMS behavior
+       // && kmsEncryptRequestForDecryptOnlyBKI.output.value.KeyId.Some?
+       // && kmsEncryptRequestForDecryptOnlyBKI.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
   }
 
-  twostate predicate WrappedBranchKeyActiveCreationHV2?(
+  twostate predicate /* {:isolate_assertions} */ WrappedBranchKeyActiveCreationHV2?(
     new kmsEncryptRequestForActiveBKI: KMS.DafnyCallEvent<KMS.EncryptRequest, Result<KMS.EncryptResponse, KMS.Error>>,
     kmsClient: KMS.IKMSClient,
     kmsConfiguration: KeyStoreTypes.KMSConfiguration,
@@ -422,12 +466,13 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     && activeInput.GrantTokens == Some(grantTokens)
     && kmsEncryptRequestForActiveBKI.output.Success?
     && kmsEncryptRequestForActiveBKI.output.value.CiphertextBlob.Some?
-    && kmsEncryptRequestForActiveBKI.output.value.KeyId.Some?
-    && kmsEncryptRequestForActiveBKI.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
+       // There is no reason to proove the KMS response, if succesful, adhered to KMS behavior
+       // && kmsEncryptRequestForActiveBKI.output.value.KeyId.Some?
+       // && kmsEncryptRequestForActiveBKI.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
   }
 
 
-  twostate predicate WrappedBeaconKeyCreationHV2?(
+  twostate predicate /* {:isolate_assertions} */ WrappedBeaconKeyCreationHV2?(
     new beaconHistory: KMS.DafnyCallEvent<KMS.EncryptRequest, Result<KMS.EncryptResponse, KMS.Error>>,
     kmsClient: KMS.IKMSClient,
     kmsConfiguration: KeyStoreTypes.KMSConfiguration,
@@ -449,8 +494,9 @@ module {:options "/functionSyntax:4" } CreateKeysHV2 {
     && beaconInput.GrantTokens == Some(grantTokens)
     && beaconHistory.output.Success?
     && beaconHistory.output.value.CiphertextBlob.Some?
-    && beaconHistory.output.value.KeyId.Some?
-    && beaconHistory.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
+       // There is no reason to proove the KMS response, if succesful, adhered to KMS behavior
+       // && beaconHistory.output.value.KeyId.Some?
+       // && beaconHistory.output.value.KeyId.value == KMSKeystoreOperations.GetKeyId(kmsConfiguration)
 
     // Verify branch key context for beacon
     && Structure.BRANCH_KEY_TYPE_PREFIX < decryptOnlyBranchKeyContext[Structure.TYPE_FIELD]


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
fix(dafny): BKSA Create Key HV-2

It is difficult for Dafny to keep track of the KMS Encrypt requests,
as the three are nearly identical,
with the exception of the Branch Key Context Digest (bkcd).

But a SHA-384 Digest is only "socially" injective;
the domain of SHA-384 is greater than the range.

Instead,
we can break the KMS Encrypt request into a helper
method that is much easier to reason about.

Then, 
we do not need to track the different KMS requests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
