### PR TITLE
fix(dafny): BKS Mutation Items treat `hierarchy-version` as schema version

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -652,12 +652,10 @@ module DefaultKeyStorageInterface {
       var lockCanidate := ddbResponse.Responses.value[0].Item;
       var lockItem: Option<Types.MutationCommitment> :-
         MutationCommitmentFromOptionalItem(lockCanidate, input.Identifier, ddbTableName);
-      assert lockItem.Some? ==> lockCanidate.Some? && Structure.MutationCommitmentAttribute?(lockCanidate.value);
 
       var indexCanidate := ddbResponse.Responses.value[1].Item;
       var indexItem: Option<Types.MutationIndex> :-
         MutationIndexFromOptionalItem(indexCanidate, input.Identifier, ddbTableName);
-      assert indexItem.Some? ==> indexCanidate.Some? && Structure.MutationIndexAttribute?(indexCanidate.value);
 
       return Success(
           Types.GetMutationOutput(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DefaultKeyStorageInterface.dfy
@@ -577,7 +577,7 @@ module DefaultKeyStorageInterface {
     }
 
 
-    method {:vcs_split_on_every_assert} GetMutation' ( input: Types.GetMutationInput )
+    method GetMutation' ( input: Types.GetMutationInput )
       returns (output: Result<Types.GetMutationOutput, Types.Error>)
       requires ValidState()
       modifies Modifies - {History}
@@ -585,32 +585,23 @@ module DefaultKeyStorageInterface {
       ensures ValidState()
       ensures GetMutationEnsuresPublicly(input, output)
       ensures unchanged(History)
-
       ensures |ddbClient.History.TransactGetItems| == |old(ddbClient.History.TransactGetItems)| + 1
-      ensures output.Success?
-              ==>
-                && Seq.Last(ddbClient.History.TransactGetItems).output.Success?
-
+      ensures
+        output.Success?
+        ==>
+          && var tgi := Seq.Last(ddbClient.History.TransactGetItems);
+          && tgi.output.Success?
+          && tgi.output.value.Responses.Some?
+          && var responses := tgi.output.value.Responses.value;
+          && |responses| == 2
+          && var commitment? := MutationCommitmentFromOptionalItem(responses[0].Item, input.Identifier, ddbTableName);
+          && commitment?.Success?
+          && var index? := MutationIndexFromOptionalItem(responses[1].Item, input.Identifier, ddbTableName);
+          && index?.Success?
+          && output.value.MutationCommitment == commitment?.value
+          && output.value.MutationIndex == index?.value
       ensures
         && old(ddbClient.History.TransactGetItems) < ddbClient.History.TransactGetItems
-
-      // If the lock is invalid, must fail
-      // TODO-Mutations-FF I cannot get these prove quickly, even though they seem quite straight forward
-      // ensures
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.Success?
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.Some?
-      //   && |Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value| == 2
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value[0].Item.Some?
-      //   && !Structure.MutationCommitmentAttribute?(Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value[0].Item.value)
-      //   ==> output.Failure?
-      // If the index is invalid, must fail
-      // ensures
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.Success?
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.Some?
-      //   && |Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value| == 2
-      //   && Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value[1].Item.Some?
-      //   && !Structure.MutationIndexAttribute?(Seq.Last(ddbClient.History.TransactGetItems).output.value.Responses.value[1].Item.value)
-      //   ==> output.Failure?
     {
       var transactItems: DDB.TransactGetItemList
         := Seq.Map(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/StorageHelpers.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/StorageHelpers.dfy
@@ -17,6 +17,58 @@ module {:options "/functionSyntax:4"} StorageHelpers {
   const ToAttributeMap := Structure.ToAttributeMap
   const ToEncryptedHierarchicalKey := Structure.ToEncryptedHierarchicalKey
 
+  function HasValidBKType?(
+    item: DDB.Types.AttributeMap,
+    identifier: string,
+    ddbTableName: string
+  ): (output: Result<Structure.ValidBKType, Types.Error>)
+    ensures
+      output.Success?
+      ==>
+        && Structure.TYPE_FIELD in item
+        && item[Structure.TYPE_FIELD].S?
+        && Structure.ValidBKType?(item[Structure.TYPE_FIELD].S)
+        && output.value == item[Structure.TYPE_FIELD].S
+  {
+    :- Need(
+         && Structure.TYPE_FIELD in item
+         && item[Structure.TYPE_FIELD].S?
+         && Structure.ValidBKType?(item[Structure.TYPE_FIELD].S),
+         Types.KeyStorageException(
+           message:="Item returned by DDB has an unsupported Type or is missing it enitrely."
+           + " TableName: " + ddbTableName
+           + "\tBranch Key ID: " + identifier)
+       );
+    Success(item[Structure.TYPE_FIELD].S)
+  }
+
+  function HasValidHierarchyVersion?(
+    item: DDB.Types.AttributeMap,
+    identifier: string,
+    ddbTableName: string,
+    bkType: Structure.ValidBKType
+  ): (output: Result<string, Types.Error>)
+    ensures
+      output.Success?
+      ==>
+        && Structure.HIERARCHY_VERSION in item
+        && item[Structure.HIERARCHY_VERSION].N?
+        && Structure.StringIsValidHierarchyVersion?(item[Structure.HIERARCHY_VERSION].N)
+        && output.value == item[Structure.HIERARCHY_VERSION].N
+  {
+    :- Need(
+         && Structure.HIERARCHY_VERSION in item
+         && item[Structure.HIERARCHY_VERSION].N?
+         && Structure.StringIsValidHierarchyVersion?(item[Structure.HIERARCHY_VERSION].N),
+         Types.KeyStorageException(
+           message:="Item returned by DDB has an unsupported Schema Version (`hierarchy-version`) or is missing it entirely."
+           + " TableName: " + ddbTableName
+           + "\tBranch Key ID: " + identifier
+           + "\tBK Type/SortKey: " + bkType)
+       );
+    Success(item[Structure.HIERARCHY_VERSION].N)
+  }
+
   function MutationCommitmentFromOptionalItem(
     item?: Option<DDB.Types.AttributeMap>,
     identifier: string,
@@ -38,23 +90,25 @@ module {:options "/functionSyntax:4"} StorageHelpers {
     ddbTableName: string
   ): (output: Result<Types.MutationCommitment, Types.Error>)
     ensures output.Success? ==>
+              var schemaVersion? := HasValidHierarchyVersion?(item, identifier, ddbTableName, Structure.MUTATION_COMMITMENT_TYPE);
+              && schemaVersion?.Success?
               && (output.value.Identifier == identifier)
-              && Structure.MutationCommitmentAttribute?(item)
-              && output.value == Structure.ToMutationCommitment(item)
-    ensures !Structure.MutationCommitmentAttribute?(item) ==> output.Failure?
+              && Structure.MutationCommitmentAttribute?(item, schemaVersion?.value)
+              && output.value == Structure.ToMutationCommitment(item, schemaVersion?.value)
   {
+    var schemaVersion :- HasValidHierarchyVersion?(item, identifier, ddbTableName, Structure.MUTATION_COMMITMENT_TYPE);
     :- Need(
-         Structure.MutationCommitmentAttribute?(item),
+         Structure.MutationCommitmentAttribute?(item, schemaVersion),
          Types.KeyStorageException(
-           message:="Malformed Mutation Lock encountered. TableName: "
+           message:="Malformed Mutation Commitment encountered. TableName: "
            + ddbTableName + "\tBranch Key ID: " + identifier)
        );
-    var mLock := Structure.ToMutationCommitment(item);
+    var mLock := Structure.ToMutationCommitment(item, schemaVersion);
     :- Need(
          mLock.Identifier == identifier,
          Types.KeyStorageException(
            message:=
-             "Mutation Lock returned by DDB is for wrong Branch Key ID. "
+             "Mutation Commitment returned by DDB is for wrong Branch Key ID. "
              + "TableName: " + ddbTableName
              + "\tRequested Branch Key ID: " + identifier
              + "\tReturned Branch Key ID: " + mLock.Identifier)
@@ -83,18 +137,20 @@ module {:options "/functionSyntax:4"} StorageHelpers {
     ddbTableName: string
   ): (output: Result<Types.MutationIndex, Types.Error>)
     ensures output.Success? ==>
+              var schemaVersion? := HasValidHierarchyVersion?(item, identifier, ddbTableName, Structure.MUTATION_INDEX_TYPE);
+              && schemaVersion?.Success?
               && (output.value.Identifier == identifier)
-              && Structure.MutationIndexAttribute?(item)
-              && output.value == Structure.ToMutationIndex(item)
-    ensures !Structure.MutationIndexAttribute?(item) ==> output.Failure?
+              && Structure.MutationIndexAttribute?(item, schemaVersion?.value)
+              && output.value == Structure.ToMutationIndex(item, schemaVersion?.value)
   {
+    var schemaVersion :- HasValidHierarchyVersion?(item, identifier, ddbTableName, Structure.MUTATION_INDEX_TYPE);
     :- Need(
-         Structure.MutationIndexAttribute?(item),
+         Structure.MutationIndexAttribute?(item, schemaVersion),
          Types.KeyStorageException(
            message:="Malformed Mutation Index encountered. TableName: "
            + ddbTableName + "\tBranch Key ID: " + identifier)
        );
-    var mIndex := Structure.ToMutationIndex(item);
+    var mIndex := Structure.ToMutationIndex(item, schemaVersion);
     :- Need(
          mIndex.Identifier == identifier,
          Types.KeyStorageException(
@@ -120,6 +176,8 @@ module {:options "/functionSyntax:4"} StorageHelpers {
               && output.value.EncryptionContext[Structure.TABLE_FIELD] == logicalKeyStoreName
               && KmsArn.ValidKmsArn?(output.value.KmsArn)
   {
+    var bkType :- HasValidBKType?(item, identifier, ddbTableName);
+    var schemaVersion :- HasValidHierarchyVersion?(item, identifier, ddbTableName, bkType);
     :- Need(
          Structure.BranchKeyItem?(item),
          Types.KeyStorageException(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -480,8 +480,6 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
       Structure.BRANCH_KEY_TYPE_PREFIX < newDecryptOnly.EncryptionContext[Structure.TYPE_FIELD],
       Types.KeyStoreAdminException(message := "Invalid Branch Key prefix.")
     );
-    // TODO-Mutations-FF : require Decrypt Only Encryption Context
-    // TODO-Mutations-FF : ensure Decrypt Only Item
 
     return Success(newDecryptOnly);
   }

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/DdbHelper.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/DdbHelper.java
@@ -166,7 +166,6 @@ public class DdbHelper {
     final List<Map<String, AttributeValue>> ddbKeys = QueryForAllBkItemsDDBKeys(
       branchKeyId,
       _tableName,
-      _hierarchyVersion,
       _ddbClient
     );
     return DeleteAllBkKeys(ddbKeys, _tableName, _ddbClient);
@@ -203,21 +202,16 @@ public class DdbHelper {
   public static List<Map<String, AttributeValue>> QueryForAllBkItemsDDBKeys(
     final String branchKeyId,
     @Nullable String tableName,
-    @Nullable String hierarchyVersion,
     @Nullable DynamoDbClient ddbClient
   ) {
     final String _tableName = tableName == null
       ? Fixtures.TEST_KEYSTORE_NAME
       : tableName;
-    final String _hierarchyVersion = hierarchyVersion == null
-      ? "1"
-      : hierarchyVersion;
     final DynamoDbClient _ddbClient = ddbClient == null
       ? Fixtures.ddbClientWest2
       : ddbClient;
     final QueryResponse queryRes = queryForAllBkItems(
       branchKeyId,
-      _hierarchyVersion,
       _tableName,
       _ddbClient
     );
@@ -230,27 +224,20 @@ public class DdbHelper {
 
   private static QueryResponse queryForAllBkItems(
     String branchKeyId,
-    String _hierarchyVersion,
     String _tableName,
     DynamoDbClient _ddbClient
   ) {
     final Map<String, String> ExpressionAttributeNames = new HashMap<>(3, 1);
     ExpressionAttributeNames.put("#pk", Constants.BRANCH_KEY_ID);
-    ExpressionAttributeNames.put("#hv", "hierarchy-version");
     final Map<String, AttributeValue> ExpressionAttributeValues = new HashMap<>(
       3,
       1
     );
     ExpressionAttributeValues.put(":pk", AttributeValue.fromS(branchKeyId));
-    ExpressionAttributeValues.put(
-      ":hv",
-      AttributeValue.fromN(_hierarchyVersion)
-    );
     final QueryRequest queryReq = QueryRequest
       .builder()
       .tableName(_tableName)
       .keyConditionExpression("#pk = :pk")
-      .filterExpression("#hv = :hv")
       .expressionAttributeNames(ExpressionAttributeNames)
       .expressionAttributeValues(ExpressionAttributeValues)
       .build();

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ValidateKeyStoreItem.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ValidateKeyStoreItem.java
@@ -53,7 +53,7 @@ public class ValidateKeyStoreItem {
 
   public static void ValidateBranchKey(String branchKeyId, KeyStore keyStore) {
     final List<Map<String, AttributeValue>> allBKItems =
-      DdbHelper.QueryForAllBkItemsDDBKeys(branchKeyId, null, null, null);
+      DdbHelper.QueryForAllBkItemsDDBKeys(branchKeyId, null, null);
     for (Map<String, AttributeValue> item : allBKItems) {
       validateBranchKeyItem(keyStore, item);
     }

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DoNotVersionTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DoNotVersionTest.java
@@ -74,7 +74,7 @@ public class DoNotVersionTest {
     );
     ValidateKeyStoreItem.ValidateBranchKey(branchKeyId, keyStore);
     final List<Map<String, AttributeValue>> allBKItems =
-      DdbHelper.QueryForAllBkItemsDDBKeys(branchKeyId, null, null, null);
+      DdbHelper.QueryForAllBkItemsDDBKeys(branchKeyId, null, null);
     Assert.assertEquals(allBKItems.size(), 3, "Incorrect number of BK items.");
     DdbHelper.DeleteAllBkKeys(allBKItems, null, null);
   }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
We treat the `hierarchy-version` attribute as, 
as @kessplas put it,
a "schema version".

For Branch Key Items, the schema dictates how to decrypt and validate the cryptographic material.
For Mutation Items, the schema dictates if `hierarchy-version` is in the Mutation Commitment.

I also refactored the Storage Layer's Helpers,
which will help us have better errors in the future.

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
