### PR TITLE
chore: Create Static Key Store table for storing static branch keys

### DIFF
--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -23,6 +23,7 @@ Resources:
         - "arn:aws:iam::370957321024:policy/Hierarchical-GitHub-KMS-Key-Policy"
         - "arn:aws:iam::370957321024:policy/PolymorphTestModels-DDB-ReadWriteDelete-us-west-2"
         - "arn:aws:iam::370957321024:policy/ESDK-Dafny-DDB-ReadWriteDelete-us-west-2"
+        - "arn:aws:iam::370957321024:policy/ESDK-Dafny-DDB-ReadOnly-us-west-2"
         - "arn:aws:iam::370957321024:policy/Github-ECDH-KMS"
       AssumeRolePolicyDocument: !Sub |
         {

--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -23,7 +23,7 @@ Resources:
         - "arn:aws:iam::370957321024:policy/Hierarchical-GitHub-KMS-Key-Policy"
         - "arn:aws:iam::370957321024:policy/PolymorphTestModels-DDB-ReadWriteDelete-us-west-2"
         - "arn:aws:iam::370957321024:policy/ESDK-Dafny-DDB-ReadWriteDelete-us-west-2"
-        - "arn:aws:iam::370957321024:policy/ESDK-Dafny-DDB-ReadOnly-us-west-2"
+        - "arn:aws:iam::370957321024:policy/ESDK-Dafny-DDB-KeyStoreStaticTable-ReadOnly-us-west-2"
         - "arn:aws:iam::370957321024:policy/Github-ECDH-KMS"
       AssumeRolePolicyDocument: !Sub |
         {

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -14,6 +14,10 @@ Parameters:
     Type: String
     Description: Key Store DynamoDB Table Name
     Default: KeyStoreDdbTable
+  KeyStoreStaticTable:
+    Type: String
+    Description: Key Store Static Table Name
+    Default: KeyStoreStaticTable
   ProjectName:
     Type: String
     Description: A prefix that will be applied to any names
@@ -102,6 +106,42 @@ Resources:
               KeyType: "RANGE"
           Projection:
             ProjectionType: "ALL"
+
+  # Static Key Store table for storing static branch keys
+  KeyStoreStaticTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "branch-key-id"
+          AttributeType: "S"
+        - AttributeName: "type"
+          AttributeType: "S"
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: "branch-key-id"
+          KeyType: "HASH"
+        - AttributeName: "type"
+          KeyType: "RANGE"
+      TableName: !Ref KeyStoreStaticTable
+
+  StaticKeyStoreTableReadOnly:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      Description: "Allow Read-Only access to Static Key Store Table"
+      ManagedPolicyName: !Sub "${ProjectName}-DDB-ReadOnly-${AWS::Region}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+              - dynamodb:Query
+              - dynamodb:BatchGetItem
+              - dynamodb:Scan
+            Resource:
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreStaticTable}"
+              - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${KeyStoreStaticTable}/index/*"
 
   # This policy SHOULD be given to:
   #  - aws/private-aws-encryption-sdk-dafny-staging
@@ -371,6 +411,7 @@ Resources:
         - !Ref RSAKMSUsage
         - "arn:aws:iam::370957321024:policy/PolymorphTestModels-DDB-ReadWriteDelete-us-west-2"
         - !Ref HierarchicalKeyringTestTableUsage
+        - !Ref StaticKeyStoreTableReadOnly
       AssumeRolePolicyDocument: !Sub |
         {
           "Version": "2012-10-17",   

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -108,7 +108,7 @@ Resources:
             ProjectionType: "ALL"
 
   # Static Key Store table for storing static branch keys
-  KeyStoreStaticTable:
+  KeyStoreTestStaticTable:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:

--- a/cfn/ESDK-Hierarchy-CI.yaml
+++ b/cfn/ESDK-Hierarchy-CI.yaml
@@ -128,7 +128,7 @@ Resources:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
       Description: "Allow Read-Only access to Static Key Store Table"
-      ManagedPolicyName: !Sub "${ProjectName}-DDB-ReadOnly-${AWS::Region}"
+      ManagedPolicyName: !Sub "${ProjectName}-DDB-${KeyStoreStaticTable}-ReadOnly-${AWS::Region}"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- Creates KeyStoreStaticTable DynamoDB table 
- Creates StaticKeyStoreTableReadOnly IAM policy for read-only access
- Updated GitHub CI role to use read-only policy

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
