### PR TITLE
fix: use the windows api function equivalent to rusage

### DIFF
--- a/releases/go/smithy-dafny-standard-library/Time_/externs.go
+++ b/releases/go/smithy-dafny-standard-library/Time_/externs.go
@@ -1,7 +1,6 @@
 package _Time
 
 import (
-	"syscall"
 	"time"
 
 	"github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library/Wrappers"
@@ -37,11 +36,4 @@ func (CompanionStruct_Default___) GetProcessCpuTimeMillis() int64 {
 	return GetProcessCpuTimeMillis()
 }
 
-func GetProcessCpuTimeMillis() int64 {
-	var usage syscall.Rusage
-	err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage)
-	if err != nil {
-		return 0
-	}
-	return (usage.Utime.Nano() + usage.Stime.Nano()) / 1000000
-}
+

--- a/releases/go/smithy-dafny-standard-library/Time_/externs_linux_and_darwin.go
+++ b/releases/go/smithy-dafny-standard-library/Time_/externs_linux_and_darwin.go
@@ -1,0 +1,15 @@
+//go:build !windows
+// +build !windows
+
+package _Time
+
+import "syscall"
+
+func GetProcessCpuTimeMillis() int64 {
+	var usage syscall.Rusage
+	err := syscall.Getrusage(syscall.RUSAGE_SELF, &usage)
+	if err != nil {
+		return 0
+	}
+	return (usage.Utime.Nano() + usage.Stime.Nano()) / 1000000
+}

--- a/releases/go/smithy-dafny-standard-library/Time_/externs_windows.go
+++ b/releases/go/smithy-dafny-standard-library/Time_/externs_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package _Time
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+
+func GetProcessCpuTimeMillis() int64 {
+	windows.GetCurrentProcessId()
+	var proc_handle windows.Handle
+	var err error
+	if proc_handle, err = windows.OpenProcess(windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ, false, uint32(windows.GetCurrentProcessId())); err != nil {
+		return 0
+	}
+	var creation_time, exit_time, kernel_time, user_time *windows.Filetime
+	if err = windows.GetProcessTimes(proc_handle, creation_time, exit_time, kernel_time, user_time); err != nil {
+		return 0
+	}
+	return (int64(kernel_time.Nanoseconds()) + int64(user_time.Nanoseconds())) / 1000000
+}

--- a/releases/go/smithy-dafny-standard-library/go.mod
+++ b/releases/go/smithy-dafny-standard-library/go.mod
@@ -5,3 +5,5 @@ go 1.23.0
 require github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2
 
 require github.com/google/uuid v1.6.0
+
+require golang.org/x/sys v0.32.0 // indirect

--- a/releases/go/smithy-dafny-standard-library/go.sum
+++ b/releases/go/smithy-dafny-standard-library/go.sum
@@ -2,3 +2,5 @@ github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2 h1:g/xAj4F7Zt9wXJ6QjfbfocVi/ZYlAF
 github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2/go.mod h1:l2Tm4N2DKuq3ljONC2vOATeM9PUpXbIc8SgXdwwqEto=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

Building for `GOOS=windows` fails because `/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library/Time_/externs.go` is using `syscall.Rusage` which doesn't exist in the syscall package for windows builds. 

The proposed change moves the offending function `GetProcessCpuTimeMillis` to another file `externs_linux_and_darwin.go` which has a `//go:build !windows` compiler directive so this version of the function is use on non-windows systems. A second file, `externs_windows.go` with the `//go:build windows` compiler directive was added and the same function signature was specified, but it uses `GetProcessTimes` from the windows API to get the same process time information.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
