### PR TITLE
chore(dafny): refactor version count for HV-2

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/AdminFixtures.dfy
@@ -267,14 +267,14 @@ module {:options "/functionSyntax:4" } AdminFixtures {
                         TableName := physicalName))));
   }
 
-  // TODO-HV-2-M3-Version: Support Versioning of Happy Case Id along with Create.
+  // TODO-HV-2-Strategy: Support KmsSimple for creating both HV-1 & HV-2 BK's.
   method CreateHappyCaseId(
     nameonly id: string,
     nameonly kmsId: string := Fixtures.keyArn,
     nameonly hierarchyVersion: KeyStoreTypes.HierarchyVersion := KeyStoreTypes.HierarchyVersion.v1,
     nameonly strategy?: Option<Types.KeyManagementStrategy> := None,
     nameonly admin?: Option<Types.IKeyStoreAdminClient> := None,
-    // nameonly versionCount: nat := 3,
+    nameonly versionCount: nat := 3,
     nameonly customEC: KeyStoreTypes.EncryptionContext := Fixtures.RobbieEC
   )
     requires KMS.Types.IsValid_KeyIdType(kmsId)
@@ -311,6 +311,18 @@ module {:options "/functionSyntax:4" } AdminFixtures {
       HierarchyVersion := Some(hierarchyVersion)
     );
     var branchKeyId :- expect admin.CreateKey(input);
+
+    // If you need a new version
+    var inputV := Types.VersionKeyInput(
+      Identifier:= id ,
+      KmsArn:= Types.KmsSymmetricKeyArn.KmsKeyArn(kmsId),
+      Strategy:= Some(strategy)
+    );
+    var versionIndex := 0;
+    while versionIndex < versionCount {
+      var _ :- expect admin.VersionKey(inputV);
+      versionIndex := versionIndex + 1;
+    }
   }
 }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationHappyPath.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutationHappyPath.dfy
@@ -22,8 +22,6 @@ module {:options "/functionSyntax:4" } TestMutationHappyPath {
   const originalKmsId: string := Fixtures.keyArn
   const originalEC: KeyStoreTypes.EncryptionContextString := Fixtures.RobbieECString
 
-  // TODO-HV-2-FF: MutationRoundTripTest could be used by all mutation happy case test.
-  // This is only being used by happycases with terminal hv as 2
   method MutationRoundTripTest(
     ddbClient: DDB.Types.IDynamoDBClient,
     storage: KeyStoreTypes.IKeyStorageInterface,
@@ -46,43 +44,12 @@ module {:options "/functionSyntax:4" } TestMutationHappyPath {
     modifies keyStoreAdminUnderTest.Modifies
     modifies keyStoreTerminal.Modifies
   {
-    match initialHV {
-      case v1 =>
-        Fixtures.CreateHappyCaseId(
-          id := branchKeyIdentifier,
-          versionCount := versionCount
-        );
-      case v2 =>
-        // TODO-HV-2-Version: Once, we support version key for HV2 keys.
-        // Uncomment this to directly create HV2 keys with versions.
-        // AdminFixtures.CreateHappyCaseId(
-        //   id := branchKeyIdentifier,
-        //   // versionCount := versionCount,
-        //   hierarchyVersion := initialHV
-        // );
-        Fixtures.CreateHappyCaseId(
-          id := branchKeyIdentifier,
-          versionCount := versionCount
-        );
-        // TODO-HV-2-Version: Below is Temporary Logic to have HV-2 Key with multiple decrypt-only/version items
-        // Add Mutation Logic Here for Mutating from HV-1 to HV-2
-        var initInput := Types.InitializeMutationInput(
-          Identifier := branchKeyIdentifier,
-          Mutations := Types.Mutations(
-            TerminalHierarchyVersion := Some(initialHV)
-          ),
-          Strategy := Some(strategy),
-          SystemKey := Types.SystemKey.trustStorage(trustStorage := Types.TrustStorage()),
-          DoNotVersion := Some(doNotVersion));
-        var initializeOutput :- expect keyStoreAdminUnderTest.InitializeMutation(initInput);
-        var initializeToken := initializeOutput.MutationToken;
-        var testInput := Types.ApplyMutationInput(
-          MutationToken := initializeToken,
-          PageSize := Some(24),
-          Strategy := Some(strategy),
-          SystemKey := Types.SystemKey.trustStorage(trustStorage := Types.TrustStorage()));
-        var applyOutput :- expect keyStoreAdminUnderTest.ApplyMutation(testInput);
-    }
+    // Create Branch Key with initial HierarchyVersion
+    AdminFixtures.CreateHappyCaseId(
+      id := branchKeyIdentifier,
+      versionCount := versionCount,
+      hierarchyVersion := initialHV
+    );
 
     var initInput := Types.InitializeMutationInput(
       Identifier := branchKeyIdentifier,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutations.dfy
@@ -8,6 +8,7 @@ include "../../src/KeyStoreAdminErrorMessages.dfy"
 include "../AdminFixtures.dfy"
 include "TestMutationHappyPath.dfy"
 
+// TODO-HV-2-Mutate-Version: Add Mutation tests for DoNotVersion = false
 module {:options "/functionSyntax:4" } TestMutations {
   import UUID
   import AdminFixtures

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationAccessDeniedRunner.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationAccessDeniedRunner.java
@@ -4,13 +4,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nonnull;
+
 import org.testng.Assert;
 import software.amazon.awssdk.services.kms.model.KmsException;
 import software.amazon.cryptography.example.DdbHelper;
 import software.amazon.cryptography.example.Fixtures;
 import software.amazon.cryptography.example.hierarchy.AdminProvider;
-import software.amazon.cryptography.keystore.model.HierarchyVersion;
 import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
 import software.amazon.cryptography.keystoreadmin.model.ApplyMutationInput;
 import software.amazon.cryptography.keystoreadmin.model.ApplyMutationOutput;
@@ -30,52 +29,6 @@ public class KmsInFlightMutationAccessDeniedRunner {
   private static final Pattern BRANCH_KEY_TYPE_PATTERN = Pattern.compile(
     "Branch Key Type: ([^;]+)"
   );
-
-  // TODO-HV-2-Version: Version is not supported for HV-2 keys yet.
-  public static void createHappyCaseId(
-    @Nonnull String kmsKeyArn,
-    @Nonnull String branchKeyId,
-    @Nonnull KeyStoreAdmin admin,
-    @Nonnull HierarchyVersion hierarchyVersion
-  ) {
-    // TODO-HV-2-Version: Version is not supported for HV-2 keys yet,
-    //  As a work-a-round, Mutate to HV-2 to have Branch Key with at-least two version items for testing
-    AdminProvider.createHappyCaseId(
-      kmsKeyArn,
-      branchKeyId,
-      admin,
-      HierarchyVersion.v1,
-      1
-    );
-    if (hierarchyVersion == HierarchyVersion.v2) {
-      Mutations mutations = Mutations
-        .builder()
-        .TerminalHierarchyVersion(hierarchyVersion)
-        .build();
-      SystemKey systemKey = SystemKey
-        .builder()
-        .trustStorage(TrustStorage.builder().build())
-        .build();
-      InitializeMutationOutput initOutput = admin.InitializeMutation(
-        InitializeMutationInput
-          .builder()
-          .Mutations(mutations)
-          .Identifier(branchKeyId)
-          .Strategy(AdminProvider.kmsSimpleStrategy(Fixtures.kmsClientWest2))
-          .DoNotVersion(true)
-          .SystemKey(systemKey)
-          .build()
-      );
-      admin.ApplyMutation(
-        ApplyMutationInput
-          .builder()
-          .MutationToken(initOutput.MutationToken())
-          .Strategy(AdminProvider.kmsSimpleStrategy(Fixtures.kmsClientWest2))
-          .SystemKey(systemKey)
-          .build()
-      );
-    }
-  }
 
   public static void runMutationTest(
     String branchKeyId,

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV1Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV1Test.java
@@ -19,11 +19,12 @@ public class KmsInFlightMutationV1ToV1Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -58,11 +59,12 @@ public class KmsInFlightMutationV1ToV1Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -97,11 +99,12 @@ public class KmsInFlightMutationV1ToV1Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -130,11 +133,12 @@ public class KmsInFlightMutationV1ToV1Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV2Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV2Test.java
@@ -19,11 +19,12 @@ public class KmsInFlightMutationV1ToV2Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -59,11 +60,12 @@ public class KmsInFlightMutationV1ToV2Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -99,11 +101,12 @@ public class KmsInFlightMutationV1ToV2Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {
@@ -133,11 +136,12 @@ public class KmsInFlightMutationV1ToV2Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v1
+      HierarchyVersion.v1,
+      1
     );
 
     try {

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV2ToV2Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV2ToV2Test.java
@@ -19,11 +19,12 @@ public class KmsInFlightMutationV2ToV2Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v2
+      HierarchyVersion.v2,
+      1
     );
 
     try {
@@ -58,11 +59,12 @@ public class KmsInFlightMutationV2ToV2Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v2
+      HierarchyVersion.v2,
+      1
     );
 
     try {
@@ -97,11 +99,12 @@ public class KmsInFlightMutationV2ToV2Test {
       "test-mutation-kms-access-in-flight-original-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       MRK_ARN_WEST,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v2
+      HierarchyVersion.v2,
+      1
     );
 
     try {
@@ -130,11 +133,12 @@ public class KmsInFlightMutationV2ToV2Test {
       "test-mutation-kms-access-in-flight-terminal-" +
       UUID.randomUUID().toString();
 
-    KmsInFlightMutationAccessDeniedRunner.createHappyCaseId(
+    AdminProvider.createHappyCaseId(
       POSTAL_HORN_KEY_ARN,
       branchKeyId,
       AdminProvider.admin(),
-      HierarchyVersion.v2
+      HierarchyVersion.v2,
+      1
     );
 
     try {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- Removes the Temporary workaround and updates test helper method to create HV-2 BK's with versions.
### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
