### PR TITLE
chore(dafny): support kms simple for v1 to v1 mutations

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
@@ -528,6 +528,8 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
     return Success(decryptResponse);
   }
 
+  // TODO-HV-2-Mutate-Version: Can be removed in favor of Mutations.ReEncryptHierarchicalKey()
+  // or refactor Mutations.ReEncryptHierarchicalKey to use this Method.
   method MutateViaDecryptEncryptOnInitializeMutation(
     ciphertext: seq<uint8>,
     sourceEncryptionContext: Structure.BranchKeyContext,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KmsUtils.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KmsUtils.dfy
@@ -50,18 +50,17 @@ module {:options "/functionSyntax:4" } KmsUtils {
       case reEncrypt(km) => multiset(km.kmsClient.Modifies)
       case kmsSimple(km) => multiset(km.kmsClient.Modifies)
 
-    // TODO-HV-2-Strategy :: Support KmsSimple for HV-1 Mutations
     // Determines if this key manager strategy supports Mutations for HV1 branch keys
     // For HV1 Mutations:
     // - Supports reEncrypt
     // - Supports decryptEncrypt
-    // - Does not support kmsSimple
+    // - Supports kmsSimple
     predicate SupportHV1()
     {
       match this
       case decryptEncrypt(kmD, kmE) => true
       case reEncrypt(km) => true
-      case kmsSimple(km) => false
+      case kmsSimple(km) => true
     }
     // Determines if this key manager strategy supports Mutations for HV2 branch keys
     // For HV2 Mutations:

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -788,6 +788,11 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
     var ActiveEncryptionContext := Structure.ActiveBranchKeyEncryptionContext(newDecryptOnly.EncryptionContext);
 
     var newActive;
+    // TODO-HV-2-Mutate-Version: At present, Rotate when terminal hierarchy version is 2 is not yet fully supported.
+    :- Need(
+      localInput.mutationToApply.Terminal.hierarchyVersion.v1?,
+      Types.KeyStoreAdminException(message := "Rotation when terminal hierarchy version is 2 is not yet supported.")
+    );
     if (localInput.input.keyManagerStrategy.decryptEncrypt?) {
       newActive :- Mutations.NewActiveItemForDecryptEncrypt(
         item := newDecryptOnly,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -344,7 +344,7 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
     );
     // TODO-HV-2-Mutate-Version: At present, Rotate when terminal hierarchy version is 2 is not yet fully supported.
     :- Need(
-      MutationToApply.Terminal.hierarchyVersion.v1?,
+      (!input.DoNotVersion) ==> MutationToApply.Terminal.hierarchyVersion.v1?,
       Types.KeyStoreAdminException(message := "Rotation when terminal hierarchy version is 2 is not yet supported.")
     );
     assert MutationToApply.Original.customEncryptionContext.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES;

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/InitializeMutation.dfy
@@ -342,7 +342,11 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
           KeyStoreAdminErrorMessages.UNSUPPORTED_KEY_MANAGEMENT_STRATEGY_MUTATIONS
       )
     );
-
+    // TODO-HV-2-Mutate-Version: At present, Rotate when terminal hierarchy version is 2 is not yet fully supported.
+    :- Need(
+      MutationToApply.Terminal.hierarchyVersion.v1?,
+      Types.KeyStoreAdminException(message := "Rotation when terminal hierarchy version is 2 is not yet supported.")
+    );
     assert MutationToApply.Original.customEncryptionContext.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES;
     assert MutationToApply.Terminal.customEncryptionContext.Keys !! Structure.BRANCH_KEY_RESTRICTED_FIELD_NAMES;
     assert MutationToApply.ValidState();
@@ -788,11 +792,6 @@ module {:options "/functionSyntax:4" } InternalInitializeMutation {
     var ActiveEncryptionContext := Structure.ActiveBranchKeyEncryptionContext(newDecryptOnly.EncryptionContext);
 
     var newActive;
-    // TODO-HV-2-Mutate-Version: At present, Rotate when terminal hierarchy version is 2 is not yet fully supported.
-    :- Need(
-      localInput.mutationToApply.Terminal.hierarchyVersion.v1?,
-      Types.KeyStoreAdminException(message := "Rotation when terminal hierarchy version is 2 is not yet supported.")
-    );
     if (localInput.input.keyManagerStrategy.decryptEncrypt?) {
       newActive :- Mutations.NewActiveItemForDecryptEncrypt(
         item := newDecryptOnly,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/KeyStoreAdminErrorMessages.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/KeyStoreAdminErrorMessages.dfy
@@ -10,12 +10,11 @@ module {:options "/functionSyntax:4" } KeyStoreAdminErrorMessages {
     + " For versioning branch keys,"
     + " KeyManagementStrategy.AwsKmsDecryptEncrypt is not supported"
 
-  // TODO-HV-2-Strategy :: Support KmsSimple for HV-1 Mutations
   const UNSUPPORTED_KEY_MANAGEMENT_STRATEGY_MUTATIONS :=
     "Unsupported KeyManagementStrategy."
-    + " Only KeyManagementStrategy.AwsKmsReEncrypt and KeyManagementStrategy.AwsKmsDecryptEncrypt"
-    + " is allowed when terminal hierarchical version is 1."
-    + " Only KeyManagementStrategy.AwsKmsDecryptEncrypt and KeyManagementStrategy.kmsSimple is"
+    + " KeyManagementStrategy.AwsKmsSimple, KeyManagementStrategy.AwsKmsReEncrypt and KeyManagementStrategy.AwsKmsDecryptEncrypt"
+    + " are allowed when terminal hierarchical version is 1."
+    + " Only KeyManagementStrategy.AwsKmsDecryptEncrypt and KeyManagementStrategy.AwsKmsSimple is"
     + " allowed when terminal hierarchical version is 2."
 
   const UNSUPPORTED_KEY_MANAGEMENT_STRATEGY_MUTATIONS_HV_2: string :=

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Mutations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/Mutations.dfy
@@ -299,6 +299,8 @@ module {:options "/functionSyntax:4" } Mutations {
     }
   }
 
+  // TODO-HV-2-Mutate-Version: Can be removed in favor of Mutations.ReEncryptHierarchicalKey()
+  // or refactor Mutations.ReEncryptHierarchicalKey to use this Method.
   method {:isolate_asserations} NewActiveItemForDecryptEncrypt(
     nameonly item: Types.AwsCryptographyKeyStoreTypes.EncryptedHierarchicalKey,
     nameonly terminalKmsArn: string,
@@ -375,6 +377,8 @@ module {:options "/functionSyntax:4" } Mutations {
     }
   }
 
+  // Re-encrypts branch key items when Terminal Hierarchy Version is 1.
+  // Does not support Terminal Hierarchy Version 2 operations.
   method {:isolate_assertions} ReEncryptHierarchicalKey(
     nameonly input: ReEncryptHierarchicalKeyInput,
     nameonly localOperation: string := "ApplyMutation",

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutateHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutateHierarchyVersion.dfy
@@ -59,36 +59,70 @@ module {:options "/functionSyntax:4" } TestMutateHierarchyVersion {
       "Incorrect error message. Should have had `" + KeyStoreAdminErrorMessages.UNSUPPORTED_KEY_MANAGEMENT_STRATEGY_MUTATIONS + "`";
   }
 
-  method {:test} TestHV1toHV1HappyCaseReEncrypt() {
+  method {:test} TestHV1toHV1HappyCaseReEncryptMutate() {
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
     var strategy :- expect AdminFixtures.DefaultKeyManagerStrategy(
       kmsClient?:=Some(kmsClient)
     );
-    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient);
+    var doNotVersionOnMutate := true;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
   }
 
-  method {:test} TestHV1toHV1HappyCaseKmsSimple() {
+  method {:test} TestHV1toHV1HappyCaseKmsSimpleMutate() {
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
     var strategy :- expect AdminFixtures.SimpleKeyManagerStrategy(
       kmsClient?:=Some(kmsClient)
     );
-    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient);
+    var doNotVersionOnMutate := true;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
   }
 
-  method {:test} TestHV1toHV1HappyCaseDecryptEncrypt() {
+  method {:test} TestHV1toHV1HappyCaseDecryptEncryptMutate() {
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();
     var strategy :- expect AdminFixtures.DecryptEncrypKeyManagerStrategy(
       decryptKmsClient?:=Some(kmsClient),
       encryptKmsClient?:=Some(kmsClient)
     );
-    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient);
+    var doNotVersionOnMutate := true;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
+  }
+
+  method {:test} TestHV1toHV1HappyCaseReEncryptRotate() {
+    var ddbClient :- expect Fixtures.ProvideDDBClient();
+    var kmsClient :- expect Fixtures.ProvideKMSClient();
+    var strategy :- expect AdminFixtures.DefaultKeyManagerStrategy(
+      kmsClient?:=Some(kmsClient)
+    );
+    var doNotVersionOnMutate := false;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
+  }
+
+  method {:test} TestHV1toHV1HappyCaseKmsSimpleRotate() {
+    var ddbClient :- expect Fixtures.ProvideDDBClient();
+    var kmsClient :- expect Fixtures.ProvideKMSClient();
+    var strategy :- expect AdminFixtures.SimpleKeyManagerStrategy(
+      kmsClient?:=Some(kmsClient)
+    );
+    var doNotVersionOnMutate := false;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
+  }
+
+  method {:test} TestHV1toHV1HappyCaseDecryptEncryptRotate() {
+    var ddbClient :- expect Fixtures.ProvideDDBClient();
+    var kmsClient :- expect Fixtures.ProvideKMSClient();
+    var strategy :- expect AdminFixtures.DecryptEncrypKeyManagerStrategy(
+      decryptKmsClient?:=Some(kmsClient),
+      encryptKmsClient?:=Some(kmsClient)
+    );
+    var doNotVersionOnMutate := false;
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient, doNotVersionOnMutate);
   }
 
   const happyCaseIdHV1toHV1 := "test-mutate-hv1-to-hv1"
-  method TestHV1toHV1HappyCase(strategy: Types.KeyManagementStrategy, ddbClient: DDB.Types.IDynamoDBClient, kmsClient: KMS.Types.IKMSClient)
+  method TestHV1toHV1HappyCase(strategy: Types.KeyManagementStrategy, ddbClient: DDB.Types.IDynamoDBClient, kmsClient: KMS.Types.IKMSClient, doNotVersionOnMutate : bool)
     requires ddbClient.ValidState() && kmsClient.ValidState()
     modifies ddbClient.Modifies, kmsClient.Modifies
   {
@@ -112,7 +146,7 @@ module {:options "/functionSyntax:4" } TestMutateHierarchyVersion {
       mutationsRequest := mutationsRequestChangeHVAndEC,
       versionCount := 1,
       initialHV := KeyStoreTypes.HierarchyVersion.v1,
-      doNotVersion := true
+      doNotVersion := doNotVersionOnMutate
     );
 
     // Test HV2 mutating for kmsArn
@@ -135,7 +169,7 @@ module {:options "/functionSyntax:4" } TestMutateHierarchyVersion {
       mutationsRequest := mutationsRequestChangeHVAndKmsArn,
       versionCount := 1,
       initialHV := KeyStoreTypes.HierarchyVersion.v1,
-      doNotVersion := true
+      doNotVersion := doNotVersionOnMutate
     );
 
     // Test HV2 mutating for EC and kmsArn
@@ -159,7 +193,7 @@ module {:options "/functionSyntax:4" } TestMutateHierarchyVersion {
       mutationsRequest := mutationsRequestChangeHVKmsArnAndEC,
       versionCount := 1,
       initialHV := KeyStoreTypes.HierarchyVersion.v1,
-      doNotVersion := true
+      doNotVersion := doNotVersionOnMutate
     );
   }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutateHierarchyVersion.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/Mutations/TestMutateHierarchyVersion.dfy
@@ -68,6 +68,15 @@ module {:options "/functionSyntax:4" } TestMutateHierarchyVersion {
     TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient);
   }
 
+  method {:test} TestHV1toHV1HappyCaseKmsSimple() {
+    var ddbClient :- expect Fixtures.ProvideDDBClient();
+    var kmsClient :- expect Fixtures.ProvideKMSClient();
+    var strategy :- expect AdminFixtures.SimpleKeyManagerStrategy(
+      kmsClient?:=Some(kmsClient)
+    );
+    TestHV1toHV1HappyCase(strategy, ddbClient, kmsClient);
+  }
+
   method {:test} TestHV1toHV1HappyCaseDecryptEncrypt() {
     var ddbClient :- expect Fixtures.ProvideDDBClient();
     var kmsClient :- expect Fixtures.ProvideKMSClient();

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/TestAdminHV1Only.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/test/TestAdminHV1Only.dfy
@@ -56,34 +56,6 @@ module {:options "/functionSyntax:4" } TestAdminHV1Only {
     expect initializeOutput.error == Types.Error.UnsupportedFeatureException(message:=KeyStoreAdminErrorMessages.UNSUPPORTED_DOWNGRADE_HV);
   }
 
-  // TODO-HV-2-M2 : Probably make this a happy test?
-  const testMutateForHV1WithAwsKmsSimpleFailsCaseId := "dafny-initialize-mutation-hv-1-simpleKms-rejection"
-  method {:test} TestMutateForHV1WithAwsKmsSimpleFails()
-  {
-    var uuid :- expect UUID.GenerateUUID();
-    var testId := testMutateForHV1WithAwsKmsSimpleFailsCaseId + "-" + uuid;
-    var ddbClient :- expect Fixtures.ProvideDDBClient();
-    var kmsClient :- expect Fixtures.ProvideKMSClient();
-    var underTest :- expect AdminFixtures.DefaultAdmin(ddbClient?:=Some(ddbClient));
-    var simpleStrategy :- expect AdminFixtures.SimpleKeyManagerStrategy(kmsClient?:=Some(kmsClient));
-    var systemKey := Types.SystemKey.trustStorage(trustStorage := Types.TrustStorage());
-    Fixtures.CreateHappyCaseId(id:=testId);
-
-    var mutationsRequest := Types.Mutations(
-      TerminalKmsArn := Some(Fixtures.postalHornKeyArn),
-      TerminalHierarchyVersion := Some(KeyStoreTypes.v1)
-    );
-    var initInput := Types.InitializeMutationInput(
-      Identifier := testId,
-      Mutations := mutationsRequest,
-      Strategy := Some(simpleStrategy),
-      SystemKey := systemKey,
-      DoNotVersion := Some(true));
-    var initializeOutput := underTest.InitializeMutation(initInput);
-    var _ := CleanupItems.DeleteBranchKey(Identifier:=testId, ddbClient:=ddbClient);
-    expect initializeOutput.Failure?, "Should have failed to InitializeMutation for HV-1 with Simple.";
-  }
-
   // TODO-HV-2-M3 : Probably make this a happy test?
   const testMutateInitEncountersHV2FailsCaseId := "dafny-initialize-mutation-encounters-hv-2-rejection"
   const logPrefix := "\n" + testMutateInitEncountersHV2FailsCaseId + " :: "


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
