### PR TITLE
chore(dafny): refine KMS Error mapping correctly to MutationTo/From exception

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/KMSKeystoreOperations.dfy
@@ -1110,25 +1110,19 @@ module {:options "/functionSyntax:4" } KMSKeystoreOperations {
     }
   }
 
-  function ExtractKmsOpaque(
+  function ExtractKmsError(
     error: KmsError
-  ): (opaqueError?: Option<KMS.OpaqueError>)
+  ): (kmsError?: Option<KMS.Error>)
     ensures
       && error.ComAmazonawsKms?
-      && error.ComAmazonawsKms.Opaque?
-      ==> opaqueError?.Some? && opaqueError?.value == error.ComAmazonawsKms
+      ==> kmsError?.Some? && kmsError?.value == error.ComAmazonawsKms
   {
     match error {
       case Opaque(obj) => None
       case KeyManagementException(s) => None
       case BranchKeyCiphertextException(s) => None
       case KeyStoreException(s) => None
-      case ComAmazonawsKms(comAmazonawsKms: KMS.Error) =>
-        match comAmazonawsKms {
-          case Opaque(obj) => Some(comAmazonawsKms)
-          case OpaqueWithText(obj, objMessage) => Some(comAmazonawsKms)
-          case _ => None
-        }
+      case ComAmazonawsKms(comAmazonawsKms: KMS.Error) => Some(comAmazonawsKms)
     }
   }
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationErrorRefinement.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/MutationErrorRefinement.dfy
@@ -36,7 +36,7 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
     nameonly kmsOperation: string := "GenerateDataKeyWithoutPlaintext"
   ): (output: Types.Error)
   {
-    var opaqueKmsError? := KMSKeystoreOperations.ExtractKmsOpaque(error);
+    var kmsError? := KMSKeystoreOperations.ExtractKmsError(error);
     var kmsErrorMessage? := KMSKeystoreOperations.ExtractMessageFromKmsError(error);
     var errorContext := ParsedErrorContext(
                           localOperation := localOperation,
@@ -60,7 +60,7 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
     requires branchKeyItem.Type.ActiveHierarchicalSymmetricVersion?
   {
     //TODO Mutations-FF :: Decrypt/Encrypt Strategy will need to refactor this
-    var opaqueKmsError? := KMSKeystoreOperations.ExtractKmsOpaque(error);
+    var kmsError? := KMSKeystoreOperations.ExtractKmsError(error);
     var kmsErrorMessage? := KMSKeystoreOperations.ExtractMessageFromKmsError(error);
     var errorContext := ParsedErrorContext(
                           localOperation := localOperation,
@@ -84,7 +84,7 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
     requires branchKeyItem.Type.ActiveHierarchicalSymmetricVersion?
   {
     //TODO Mutations-FF :: Decrypt/Encrypt Strategy will need to refactor this
-    var opaqueKmsError? := KMSKeystoreOperations.ExtractKmsOpaque(error);
+    var kmsError? := KMSKeystoreOperations.ExtractKmsError(error);
     var kmsErrorMessage? := KMSKeystoreOperations.ExtractMessageFromKmsError(error);
     var errorContext := ParsedErrorContext(
                           localOperation := localOperation,
@@ -107,7 +107,7 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
   ): (output: Types.Error)
     requires branchKeyItem.Type.HierarchicalSymmetricVersion?
   {
-    var opaqueKmsError? := KMSKeystoreOperations.ExtractKmsOpaque(error);
+    var kmsError? := KMSKeystoreOperations.ExtractKmsError(error);
     var kmsErrorMessage? := KMSKeystoreOperations.ExtractMessageFromKmsError(error);
     var errorContext := ParsedErrorContext(
                           localOperation := localOperation,
@@ -135,7 +135,7 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
     requires kmsOperation == "ReEncrypt" || kmsOperation == "Encrypt" || kmsOperation == "Decrypt"
     requires localOperation == "ApplyMutation" || localOperation == "InitializeMutation"
   {
-    var opaqueKmsError? := KMSKeystoreOperations.ExtractKmsOpaque(error);
+    var kmsError? := KMSKeystoreOperations.ExtractKmsError(error);
     var kmsErrorMessage? := KMSKeystoreOperations.ExtractMessageFromKmsError(error);
     var itemType := match item.Type {
       case ActiveHierarchicalSymmetricVersion(version) => Structure.BRANCH_KEY_ACTIVE_TYPE
@@ -148,8 +148,9 @@ module {:options "/functionSyntax:4" } MutationErrorRefinement {
       identifier := item.Identifier,
       itemType := itemType,
       errorMessage? := kmsErrorMessage?);
-    // if it is an opaque KMS Error, and there is a message, it is KMS.Types.OpaqueWithText
-    var kmsWithMsg: bool := opaqueKmsError?.Some? && kmsErrorMessage?.Some?;
+    // If it is a KMS Error, and there is a message, it is a valid KMS.Types.Error,
+    // This will helps to refine KMS Error to matching KMS Arn
+    var kmsWithMsg: bool := kmsError?.Some? && kmsErrorMessage?.Some?;
     // If kmsWithMsg and we can match the error message based on the KMS Operation
     if (kmsWithMsg) {
       match kmsOperation {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/SystemKeyErrorRefinement.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/SystemKeyErrorRefinement.dfy
@@ -39,7 +39,7 @@ module {:options "/functionSyntax:4" } SystemKeyErrorRefinement {
   //   requires branchKeyItem.Type.ActiveHierarchicalSymmetricVersion?
   // {
   //   //TODO-Mutations-GA :: Better error message
-  //   var opaqueKmsError? := KmsUtils.ExtractKmsOpaque(error);
+  //   var kmsError? := KmsUtils.ExtractKmsError(error);
   //   var kmsErrorMessage? := KmsUtils.ExtractMessageFromKmsError(error);
   //   var errorContext := ParsedErrorContext(
   //                         localOperation := localOperation,

--- a/Examples/java/build.gradle.kts
+++ b/Examples/java/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation("org.slf4j:jcl-over-slf4j:${slf4jVersion}")
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")
+    // https://mvnrepository.com/artifact/org.mockito/mockito-core
+    testImplementation("org.mockito:mockito-core:2.1.0")
 }
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))

--- a/Examples/java/build.gradle.kts
+++ b/Examples/java/build.gradle.kts
@@ -43,8 +43,8 @@ dependencies {
     implementation("org.slf4j:jcl-over-slf4j:${slf4jVersion}")
     // https://mvnrepository.com/artifact/org.testng/testng
     testImplementation("org.testng:testng:7.5")
-    // https://mvnrepository.com/artifact/org.mockito/mockito-core
-    testImplementation("org.mockito:mockito-core:2.1.0")
+    // https://mvnrepository.com/artifact/org.mockito/mockito-inline
+    testImplementation("org.mockito:mockito-inline:4.11.0")
 }
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(8))

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsMutationExceptionTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsMutationExceptionTest.java
@@ -1,0 +1,255 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy.mutations;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.*;
+import software.amazon.cryptography.example.DdbHelper;
+import software.amazon.cryptography.example.Fixtures;
+import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.example.hierarchy.CreateKeyExample;
+import software.amazon.cryptography.keystore.model.HierarchyVersion;
+import software.amazon.cryptography.keystoreadmin.KeyStoreAdmin;
+import software.amazon.cryptography.keystoreadmin.model.*;
+
+public class KmsMutationExceptionTest {
+
+  private static KeyStoreAdmin admin;
+  private static String hv1BranchKeyId;
+  private static String hv2BranchKeyId;
+
+  @BeforeClass
+  public static void setUp() {
+    MockitoAnnotations.initMocks(KmsMutationExceptionTest.class);
+    admin = AdminProvider.admin();
+    String uuid = java.util.UUID.randomUUID().toString();
+    hv1BranchKeyId = "mocked-kms-client-hv-1-" + uuid;
+    hv2BranchKeyId = "mocked-kms-client-hv-2-" + uuid;
+
+    // Create Branch Key with hierarchy-version-1 once for all tests
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      hv1BranchKeyId,
+      admin,
+      HierarchyVersion.v1
+    );
+
+    // Create Branch Key with hierarchy-version-2 once for all tests
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      hv2BranchKeyId,
+      admin,
+      HierarchyVersion.v2
+    );
+  }
+
+  private InitializeMutationInput createMutationInput(
+    String branchKeyId,
+    KeyManagementStrategy strategy
+  ) {
+    return InitializeMutationInput
+      .builder()
+      .Mutations(
+        Mutations.builder().TerminalKmsArn(Fixtures.POSTAL_HORN_KEY_ARN).build()
+      )
+      .Identifier(branchKeyId)
+      .Strategy(strategy)
+      .SystemKey(
+        SystemKey.builder().trustStorage(TrustStorage.builder().build()).build()
+      )
+      .DoNotVersion(true)
+      .build();
+  }
+
+  @Test
+  public void testOriginalKeyDisabledException() {
+    DisabledException exception = DisabledException
+      .builder()
+      .message(
+        String.format("Key '%s' is disabled.", Fixtures.KEYSTORE_KMS_ARN)
+      )
+      .build();
+
+    KmsClient mockKmsClient = mock(KmsClient.class);
+    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
+      .thenThrow(exception);
+    when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenThrow(exception);
+
+    // DecryptEncrypt Strategy with Mocked KmsClient only for Encrypt Client
+    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
+      mockKmsClient,
+      KmsClient.create()
+    );
+
+    // Expect exception for HV1 Branch Keys
+    Assert.expectThrows(
+      MutationFromException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv1BranchKeyId, decryptEncrypt)
+        )
+    );
+
+    // Expect exception for HV2 Branch Keys
+    Assert.expectThrows(
+      MutationFromException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv2BranchKeyId, decryptEncrypt)
+        )
+    );
+  }
+
+  @Test
+  public void testTerminalKeyDisabledException() {
+    DisabledException exception = DisabledException
+      .builder()
+      .message(
+        String.format("Key '%s' is disabled.", Fixtures.POSTAL_HORN_KEY_ARN)
+      )
+      .build();
+
+    KmsClient mockKmsClient = mock(KmsClient.class);
+    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
+      .thenThrow(exception);
+    when(mockKmsClient.encrypt(any(EncryptRequest.class))).thenThrow(exception);
+
+    // Decrypt/Encrypt Strategy
+    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
+      KmsClient.create(),
+      mockKmsClient
+    );
+
+    // Expect exception for HV1 Branch Keys
+    Assert.expectThrows(
+      MutationToException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv1BranchKeyId, decryptEncrypt)
+        )
+    );
+
+    // Expect exception for HV2 Branch Keys
+    Assert.expectThrows(
+      MutationToException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv2BranchKeyId, decryptEncrypt)
+        )
+    );
+  }
+
+  @Test
+  public void testOriginalKeyPendingDeletionException() {
+    KmsInvalidStateException exception = KmsInvalidStateException
+      .builder()
+      .message(
+        String.format(
+          "Key '%s' is pending deletion.",
+          Fixtures.KEYSTORE_KMS_ARN
+        )
+      )
+      .build();
+
+    KmsClient mockKmsClient = mock(KmsClient.class);
+    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
+      .thenThrow(exception);
+    when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenThrow(exception);
+
+    // Decrypt/Encrypt Strategy
+    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
+      mockKmsClient,
+      KmsClient.create()
+    );
+
+    // Expect exception for HV1 Branch Keys
+    Assert.expectThrows(
+      MutationFromException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv1BranchKeyId, decryptEncrypt)
+        )
+    );
+
+    // Expect exception for HV2 Branch Keys
+    Assert.expectThrows(
+      MutationFromException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv2BranchKeyId, decryptEncrypt)
+        )
+    );
+  }
+
+  @Test
+  public void testTerminalKeyPendingDeletionException() {
+    KmsInvalidStateException exception = KmsInvalidStateException
+      .builder()
+      .message(
+        String.format(
+          "Key '%s' is pending deletion.",
+          Fixtures.POSTAL_HORN_KEY_ARN
+        )
+      )
+      .build();
+
+    KmsClient mockKmsClient = mock(KmsClient.class);
+    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
+      .thenThrow(exception);
+    when(mockKmsClient.encrypt(any(EncryptRequest.class))).thenThrow(exception);
+
+    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
+      KmsClient.create(),
+      mockKmsClient
+    );
+
+    // Expect exception for HV1 Branch Keys
+    Assert.expectThrows(
+      MutationToException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv1BranchKeyId, decryptEncrypt)
+        )
+    );
+
+    // Expect exception for HV2 Branch Keys
+    Assert.expectThrows(
+      MutationToException.class,
+      () ->
+        admin.InitializeMutation(
+          createMutationInput(hv2BranchKeyId, decryptEncrypt)
+        )
+    );
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    try {
+      DdbHelper.DeleteBranchKey(
+        hv1BranchKeyId,
+        Fixtures.TEST_KEYSTORE_NAME,
+        null
+      );
+    } catch (Exception e) {
+      // ignore
+    }
+    try {
+      DdbHelper.DeleteBranchKey(
+        hv2BranchKeyId,
+        Fixtures.TEST_KEYSTORE_NAME,
+        null
+      );
+    } catch (Exception e) {
+      //ignore
+    }
+  }
+}

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsMutationExceptionTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsMutationExceptionTest.java
@@ -3,13 +3,9 @@
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import org.mockito.MockitoAnnotations;
+import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.*;
@@ -23,297 +19,356 @@ import software.amazon.cryptography.keystoreadmin.model.*;
 
 public class KmsMutationExceptionTest {
 
-  private static KeyStoreAdmin admin;
-  private static String hv1BranchKeyId;
-  private static String hv2BranchKeyId;
+  /**
+   * Helper method to create a KMS client that throws exceptions for specific KMS ARNs.
+   */
+  private KmsClient createMockKmsClientWithException(
+    String kmsArn,
+    String exceptionMessage
+  ) {
+    // Create the exception
+    DisabledException exception = DisabledException
+      .builder()
+      .message(exceptionMessage)
+      .build();
 
-  @BeforeClass
-  public static void setUp() {
-    MockitoAnnotations.initMocks(KmsMutationExceptionTest.class);
-    admin = AdminProvider.admin();
-    String uuid = java.util.UUID.randomUUID().toString();
-    hv1BranchKeyId = "mocked-kms-client-hv-1-" + uuid;
-    hv2BranchKeyId = "mocked-kms-client-hv-2-" + uuid;
+    // Create a real KMS client to delegate to for normal operations
+    KmsClient realKmsClient = KmsClient.create();
 
-    // Create Branch Key with hierarchy-version-1 once for all tests
+    // Create a spy on the real client (this will use real behavior by default)
+    KmsClient spyKmsClient = Mockito.spy(realKmsClient);
+
+    // Configure for all operations that might use the target KMS ARN
+    // For decrypt operations
+    Mockito
+      .doAnswer(invocation -> {
+        DecryptRequest request = invocation.getArgument(0);
+        if (request.keyId() != null && request.keyId().equals(kmsArn)) {
+          throw exception;
+        }
+        return invocation.callRealMethod();
+      })
+      .when(spyKmsClient)
+      .decrypt(any(DecryptRequest.class));
+
+    // For encrypt operations
+    Mockito
+      .doAnswer(invocation -> {
+        EncryptRequest request = invocation.getArgument(0);
+        if (request.keyId().equals(kmsArn)) {
+          throw exception;
+        }
+        return invocation.callRealMethod();
+      })
+      .when(spyKmsClient)
+      .encrypt(any(EncryptRequest.class));
+
+    // For reEncrypt operations - check both source and destination
+    Mockito
+      .doAnswer(invocation -> {
+        ReEncryptRequest request = invocation.getArgument(0);
+        // Check if either source or destination key matches the target ARN
+        if (
+          (request.sourceKeyId() != null &&
+            request.sourceKeyId().equals(kmsArn)) ||
+          request.destinationKeyId().equals(kmsArn)
+        ) {
+          throw exception;
+        }
+        return invocation.callRealMethod();
+      })
+      .when(spyKmsClient)
+      .reEncrypt(any(ReEncryptRequest.class));
+
+    // For generateDataKey operations
+    Mockito
+      .doAnswer(invocation -> {
+        GenerateDataKeyRequest request = invocation.getArgument(0);
+        if (request.keyId().equals(kmsArn)) {
+          throw exception;
+        }
+        return invocation.callRealMethod();
+      })
+      .when(spyKmsClient)
+      .generateDataKey(any(GenerateDataKeyRequest.class));
+
+    // For generateDataKeyWithoutPlaintext operations
+    Mockito
+      .doAnswer(invocation -> {
+        GenerateDataKeyWithoutPlaintextRequest request = invocation.getArgument(
+          0
+        );
+        if (request.keyId().equals(kmsArn)) {
+          throw exception;
+        }
+        return invocation.callRealMethod();
+      })
+      .when(spyKmsClient)
+      .generateDataKeyWithoutPlaintext(
+        any(GenerateDataKeyWithoutPlaintextRequest.class)
+      );
+
+    return spyKmsClient;
+  }
+
+  /**
+   * Helper method to test a strategy with a disabled key.
+   */
+  private void testStrategyWithDisabledKey(
+    KeyStoreAdmin admin,
+    String branchKeyId,
+    KeyManagementStrategy strategy,
+    Class<? extends Exception> expectedExceptionClass,
+    String disabledKmsArn,
+    Mutations mutations
+  ) {
+    Exception exception = Assert.expectThrows(
+      expectedExceptionClass,
+      () ->
+        admin.InitializeMutation(
+          InitializeMutationInput
+            .builder()
+            .Mutations(mutations)
+            .Identifier(branchKeyId)
+            .Strategy(strategy)
+            .SystemKey(
+              SystemKey
+                .builder()
+                .trustStorage(TrustStorage.builder().build())
+                .build()
+            )
+            .DoNotVersion(true)
+            .build()
+        )
+    );
+    Assert.assertTrue(
+      exception
+        .getMessage()
+        .contains("Key '" + disabledKmsArn + "' is disabled"),
+      "Exception message should contain the disabled key information"
+    );
+  }
+
+  /**
+   * Test original key disabled exception with all three strategies.
+   * This comprehensive test verifies that all strategies handle a disabled original key correctly.
+   */
+  @Test
+  public void testOriginalKeyDisabledWithAllStrategies() {
+    // Create mock client that throws exception for original key
+    final KmsClient mockClient = createMockKmsClientWithException(
+      Fixtures.KEYSTORE_KMS_ARN,
+      String.format("Key '%s' is disabled.", Fixtures.KEYSTORE_KMS_ARN)
+    );
+
+    // Create all three strategies
+    final KeyManagementStrategy kmsSimple = AdminProvider.kmsSimpleStrategy(
+      mockClient
+    );
+    final KeyManagementStrategy reEncrypt = AdminProvider.reEncryptStrategy(
+      mockClient
+    );
+    final KeyManagementStrategy decryptEncrypt =
+      AdminProvider.decryptEncryptStrategy(
+        mockClient, // For decrypt operations (disabled original key)
+        KmsClient.create() // For encrypt operations (normal terminal key)
+      );
+
+    final String uuid = java.util.UUID.randomUUID().toString();
+    final String hv1BranchKeyId = "mocked-kms-client-hv-1-" + uuid;
+    final String hv2BranchKeyId = "mocked-kms-client-hv-2-" + uuid;
+
+    // Key Store Admin
+    final KeyStoreAdmin admin = AdminProvider.admin();
+
+    // Create Branch Keys
     CreateKeyExample.CreateKey(
       Fixtures.KEYSTORE_KMS_ARN,
       hv1BranchKeyId,
       admin,
       HierarchyVersion.v1
     );
-
-    // Create Branch Key with hierarchy-version-2 once for all tests
     CreateKeyExample.CreateKey(
       Fixtures.KEYSTORE_KMS_ARN,
       hv2BranchKeyId,
       admin,
       HierarchyVersion.v2
     );
-  }
 
-  private InitializeMutationInput createMutationInput(
-    String branchKeyId,
-    KeyManagementStrategy strategy
-  ) {
-    return InitializeMutationInput
+    // Mutation Request
+    final Mutations mutations = Mutations
       .builder()
-      .Mutations(
-        Mutations.builder().TerminalKmsArn(Fixtures.POSTAL_HORN_KEY_ARN).build()
-      )
-      .Identifier(branchKeyId)
-      .Strategy(strategy)
-      .SystemKey(
-        SystemKey.builder().trustStorage(TrustStorage.builder().build()).build()
-      )
-      .DoNotVersion(true)
-      .build();
-  }
-
-  @Test
-  public void testOriginalKeyDisabledException() {
-    // Test case: Original KMS key (used for decryption) is disabled
-    // Creates a DisabledException with the original keystore KMS ARN
-    DisabledException exception = DisabledException
-      .builder()
-      .message(
-        String.format("Key '%s' is disabled.", Fixtures.KEYSTORE_KMS_ARN)
-      )
+      .TerminalKmsArn(Fixtures.POSTAL_HORN_KEY_ARN)
       .build();
 
-    // Mock KMS client to throw DisabledException during decrypt and reEncrypt operations
-    // This simulates the original key being disabled
-    KmsClient mockKmsClient = mock(KmsClient.class);
-    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
-      .thenThrow(exception);
-    when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenThrow(exception);
-
-    // Create DecryptEncrypt strategy where:
-    // - Decrypt use the mocked client (simulating disabled original key)
-    // - Encrypt use a regular client
-    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
-      mockKmsClient,
-      KmsClient.create()
-    );
-
-    // Initializing mutation with disabled original key throws MutationFromException
-    // for both hierarchy version branch keys
-    MutationFromException hv1Exception = Assert.expectThrows(
-      MutationFromException.class, // Exception expected when original (FROM) key fails
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv1BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv1Exception
-        .getMessage()
-        .contains("Key '" + Fixtures.KEYSTORE_KMS_ARN + "' is disabled"),
-      "Exception message should contain the disabled key information"
-    );
-
-    MutationFromException hv2Exception = Assert.expectThrows(
+    // Test all strategies with HV1
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      kmsSimple,
       MutationFromException.class,
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv2BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv2Exception
-        .getMessage()
-        .contains("Key '" + Fixtures.KEYSTORE_KMS_ARN + "' is disabled"),
-      "Exception message should contain the disabled key information"
-    );
-  }
-
-  @Test
-  public void testTerminalKeyDisabledException() {
-    // Test case: Terminal KMS key (used for encryption) is disabled
-    // Creates a DisabledException with the terminal (destination) KMS ARN
-    DisabledException exception = DisabledException
-      .builder()
-      .message(
-        String.format("Key '%s' is disabled.", Fixtures.POSTAL_HORN_KEY_ARN)
-      )
-      .build();
-
-    // Mock KMS client to throw DisabledException during encrypt and reEncrypt operations
-    // This simulates the terminal key being disabled
-    KmsClient mockKmsClient = mock(KmsClient.class);
-    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
-      .thenThrow(exception);
-    when(mockKmsClient.encrypt(any(EncryptRequest.class))).thenThrow(exception);
-
-    // Create DecryptEncrypt strategy where:
-    // - Decrypt use regular client
-    // - Encrypt use the mocked client (simulating disabled terminal key)
-    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
-      KmsClient.create(),
-      mockKmsClient
+      Fixtures.KEYSTORE_KMS_ARN,
+      mutations
     );
 
-    // Initializing mutation with disabled terminal key throws MutationToException
-    // for both hierarchy version branch keys
-    MutationToException hv1Exception = Assert.expectThrows(
-      MutationToException.class, // Exception expected when terminal (TO) key fails
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv1BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv1Exception
-        .getMessage()
-        .contains("Key '" + Fixtures.POSTAL_HORN_KEY_ARN + "' is disabled"),
-      "Exception message should contain the disabled key information"
-    );
-
-    MutationToException hv2Exception = Assert.expectThrows(
-      MutationToException.class,
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv2BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv2Exception
-        .getMessage()
-        .contains("Key '" + Fixtures.POSTAL_HORN_KEY_ARN + "' is disabled"),
-      "Exception message should contain the disabled key information"
-    );
-  }
-
-  @Test
-  public void testOriginalKeyPendingDeletionException() {
-    // Test case: Original KMS key (used for decryption) is pending deletion
-    // Creates a KmsInvalidStateException with the original keystore KMS ARN
-    KmsInvalidStateException exception = KmsInvalidStateException
-      .builder()
-      .message(
-        String.format(
-          "Key '%s' is pending deletion.",
-          Fixtures.KEYSTORE_KMS_ARN
-        )
-      )
-      .build();
-
-    // Mock KMS client to throw KmsInvalidStateException during decrypt and reEncrypt operations
-    // This simulates the original key being in pending deletion state
-    KmsClient mockKmsClient = mock(KmsClient.class);
-    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
-      .thenThrow(exception);
-    when(mockKmsClient.decrypt(any(DecryptRequest.class))).thenThrow(exception);
-
-    // Create DecryptEncrypt strategy where:
-    // - Decrypt use the mocked client (simulating original key pending deletion)
-    // - Encrypt use a regular client
-    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
-      mockKmsClient,
-      KmsClient.create()
-    );
-
-    // Initializing mutation with original key pending deletion throws MutationFromException
-    // for both hierarchy version branch keys
-    MutationFromException hv1Exception = Assert.expectThrows(
-      MutationFromException.class, // Exception expected when original (FROM) key fails
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv1BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv1Exception
-        .getMessage()
-        .contains(
-          "Key '" + Fixtures.KEYSTORE_KMS_ARN + "' is pending deletion"
-        ),
-      "Exception message should contain the pending deletion key information"
-    );
-
-    MutationFromException hv2Exception = Assert.expectThrows(
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      reEncrypt,
       MutationFromException.class,
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv2BranchKeyId, decryptEncrypt)
-        )
+      Fixtures.KEYSTORE_KMS_ARN,
+      mutations
     );
-    Assert.assertTrue(
-      hv2Exception
-        .getMessage()
-        .contains(
-          "Key '" + Fixtures.KEYSTORE_KMS_ARN + "' is pending deletion"
-        ),
-      "Exception message should contain the pending deletion key information"
+
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      decryptEncrypt,
+      MutationFromException.class,
+      Fixtures.KEYSTORE_KMS_ARN,
+      mutations
     );
+
+    // Test supported strategies with HV2
+    testStrategyWithDisabledKey(
+      admin,
+      hv2BranchKeyId,
+      kmsSimple,
+      MutationFromException.class,
+      Fixtures.KEYSTORE_KMS_ARN,
+      mutations
+    );
+
+    testStrategyWithDisabledKey(
+      admin,
+      hv2BranchKeyId,
+      decryptEncrypt,
+      MutationFromException.class,
+      Fixtures.KEYSTORE_KMS_ARN,
+      mutations
+    );
+
+    try {
+      DdbHelper.DeleteBranchKey(
+        hv1BranchKeyId,
+        Fixtures.TEST_KEYSTORE_NAME,
+        null
+      );
+    } catch (Exception e) {
+      // ignore
+    }
+    try {
+      DdbHelper.DeleteBranchKey(
+        hv2BranchKeyId,
+        Fixtures.TEST_KEYSTORE_NAME,
+        null
+      );
+    } catch (Exception e) {
+      //ignore
+    }
   }
 
+  /**
+   * Test terminal key disabled exception with all three strategies.
+   * This test verifies that all strategies handle a disabled terminal key correctly.
+   */
   @Test
-  public void testTerminalKeyPendingDeletionException() {
-    // Test case: Terminal KMS key (used for encryption) is pending deletion
-    // Creates a KmsInvalidStateException with the terminal (destination) KMS ARN
-    KmsInvalidStateException exception = KmsInvalidStateException
+  public void testTerminalKeyDisabledWithAllStrategies() {
+    // Create mock client that throws exception for terminal key
+    final KmsClient mockClient = createMockKmsClientWithException(
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      String.format("Key '%s' is disabled.", Fixtures.POSTAL_HORN_KEY_ARN)
+    );
+
+    // Create all three strategies
+    final KeyManagementStrategy kmsSimple = AdminProvider.kmsSimpleStrategy(
+      mockClient
+    );
+    final KeyManagementStrategy reEncrypt = AdminProvider.reEncryptStrategy(
+      mockClient
+    );
+    final KeyManagementStrategy decryptEncrypt =
+      AdminProvider.decryptEncryptStrategy(
+        KmsClient.create(), // For decrypt operations (normal original key)
+        mockClient // For encrypt operations (disabled terminal key)
+      );
+
+    // Create Branch Keys
+    final String uuid = java.util.UUID.randomUUID().toString();
+    final String hv1BranchKeyId = "mocked-kms-client-hv-1-" + uuid;
+    final String hv2BranchKeyId = "mocked-kms-client-hv-2-" + uuid;
+
+    // Key Store Admin
+    final KeyStoreAdmin admin = AdminProvider.admin();
+
+    // Create Branch Keys
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      hv1BranchKeyId,
+      admin,
+      HierarchyVersion.v1
+    );
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      hv2BranchKeyId,
+      admin,
+      HierarchyVersion.v2
+    );
+
+    // Mutation Request
+    final Mutations mutations = Mutations
       .builder()
-      .message(
-        String.format(
-          "Key '%s' is pending deletion.",
-          Fixtures.POSTAL_HORN_KEY_ARN
-        )
-      )
+      .TerminalKmsArn(Fixtures.POSTAL_HORN_KEY_ARN)
       .build();
 
-    // Mock KMS client to throw KmsInvalidStateException during encrypt and reEncrypt operations
-    // This simulates the terminal key being in pending deletion state
-    KmsClient mockKmsClient = mock(KmsClient.class);
-    when(mockKmsClient.reEncrypt(any(ReEncryptRequest.class)))
-      .thenThrow(exception);
-    when(mockKmsClient.encrypt(any(EncryptRequest.class))).thenThrow(exception);
-
-    // Create DecryptEncrypt strategy where:
-    // - Decrypt use regular client
-    // - Encrypt use the mocked client (simulating terminal key pending deletion)
-    KeyManagementStrategy decryptEncrypt = AdminProvider.decryptEncryptStrategy(
-      KmsClient.create(),
-      mockKmsClient
-    );
-
-    // Initializing mutation with terminal key pending deletion throws MutationToException
-    // for both hierarchy version branch keys
-    MutationToException hv1Exception = Assert.expectThrows(
-      MutationToException.class, // Exception expected when terminal (TO) key fails
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv1BranchKeyId, decryptEncrypt)
-        )
-    );
-    Assert.assertTrue(
-      hv1Exception
-        .getMessage()
-        .contains(
-          "Key '" + Fixtures.POSTAL_HORN_KEY_ARN + "' is pending deletion"
-        ),
-      "Exception message should contain the pending deletion key information"
-    );
-
-    MutationToException hv2Exception = Assert.expectThrows(
+    // Test all strategies with HV1
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      kmsSimple,
       MutationToException.class,
-      () ->
-        admin.InitializeMutation(
-          createMutationInput(hv2BranchKeyId, decryptEncrypt)
-        )
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      mutations
     );
-    Assert.assertTrue(
-      hv2Exception
-        .getMessage()
-        .contains(
-          "Key '" + Fixtures.POSTAL_HORN_KEY_ARN + "' is pending deletion"
-        ),
-      "Exception message should contain the pending deletion key information"
-    );
-  }
 
-  @AfterClass
-  public static void tearDown() {
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      reEncrypt,
+      MutationToException.class,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      mutations
+    );
+
+    testStrategyWithDisabledKey(
+      admin,
+      hv1BranchKeyId,
+      decryptEncrypt,
+      MutationToException.class,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      mutations
+    );
+
+    // Test supported strategies with HV2
+    testStrategyWithDisabledKey(
+      admin,
+      hv2BranchKeyId,
+      kmsSimple,
+      MutationToException.class,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      mutations
+    );
+
+    testStrategyWithDisabledKey(
+      admin,
+      hv2BranchKeyId,
+      decryptEncrypt,
+      MutationToException.class,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      mutations
+    );
+    // Note: We don't test ReEncrypt with HV2 as it's not supported
+
     try {
       DdbHelper.DeleteBranchKey(
         hv1BranchKeyId,


### PR DESCRIPTION
…ception

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
