### PR TITLE
chore(dafny): BKS CreateKey remove redundant EC checks for HV-2

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
@@ -295,7 +295,7 @@ module {:options "/functionSyntax:4" } CreateKeys {
       ));
   }
 
-  @IsolateAssertions method CreateBranchAndBeaconKeysVersion2(
+  method {:isolate_assertions} CreateBranchAndBeaconKeysVersion2(
     nameonly branchKeyIdentifier: string,
     nameonly encryptionContext: map<string, string>,
     nameonly timestamp: string,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/CreateKeys.dfy
@@ -782,7 +782,7 @@ module {:options "/functionSyntax:4" } CreateKeys {
     output := Success(Types.VersionKeyOutput());
   }
 
-  @IsolateAssertions method VersionActiveBranchKeyVersion2(
+  method {:isolate_assertions} VersionActiveBranchKeyVersion2(
     oldActiveItem: Types.EncryptedHierarchicalKey,
     timestamp: string,
     branchKeyVersion: string,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStoreAdmin/src/AwsCryptographyKeyStoreAdminOperations.dfy
@@ -406,7 +406,7 @@ module AwsCryptographyKeyStoreAdminOperations refines AbstractAwsCryptographyKey
 
         var output? := CreateKeys.CreateBranchAndBeaconKeysVersion2(
           branchKeyIdentifier := branchKeyIdentifier,
-          customEncryptionContext := map i <- encodedEncryptionContext :: i.0.value := i.1.value,
+          encryptionContext := map i <- encodedEncryptionContext :: i.0.value := i.1.value,
           timestamp := timestamp,
           branchKeyVersion := branchKeyVersion,
           logicalKeyStoreName := config.logicalKeyStoreName,


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
In Branch Key Creation,
until the Encryption Context 
is passed to `Structure.DecryptOnlyBranchKeyEncryptionContext`,
the Encryption Context is exactly as the customer intended it to be.

Thus, for `hierarchy-version-2`,
we do not need to do any transforms on the Encryption Context
before it is sent to KMS;
in fact, we should ensure that we do not any transforms.

### Squash/merge commit message, if applicable:

```
chore(dafny): remove redundant EC checks
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
