### PR TITLE
chore(dafny): bump libraries submodule to latest commit 

### DIFF
--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -19,7 +19,8 @@ jobs:
     strategy:
       matrix:
         library: [TestVectorsAwsCryptographicMaterialProviders]
-        os: [
+        os:
+          [
             # https://taskei.amazon.dev/tasks/CrypTool-5283
             # windows-latest,
             ubuntu-22.04,

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/test/Fixtures.dfy
@@ -61,17 +61,17 @@ module Fixtures {
 
   const branchKeyStoreName := "KeyStoreDdbTable"
   const logicalKeyStoreName := branchKeyStoreName
-  const branchKeyId := "75789115-1deb-4fe3-a2ec-be9e885d1945"
-  const branchKeyIdActiveVersion := "fed7ad33-0774-4f97-aa5e-6c766fc8af9f"
-
-  const branchKeyIdWithEC := "4bb57643-07c1-419e-92ad-0df0df149d7c"
+  const branchKeyId := "3f43a9af-08c5-4317-b694-3d3e883dcaef"
+  const branchKeyIdActiveVersion := "a4905627-4b7f-4272-a847-f50dae245737"
   // This is branchKeyIdActiveVersion above, as utf8bytes
   const branchKeyIdActiveVersionUtf8Bytes: seq<uint8> := [
-    102, 101, 100, 55,  97, 100,  51, 51,  45,
-    48,  55,  55, 52,  45,  52, 102, 57,  55,
-    45,  97,  97, 53, 101,  45,  54, 99,  55,
-    54,  54, 102, 99,  56,  97, 102, 57, 102
+    97, 52, 57, 48, 53, 54, 50, 55, 45, 52,
+    98, 55, 102, 45, 52, 50, 55, 50, 45, 97,
+    56, 52, 55, 45, 102, 53, 48, 100, 97, 101,
+    50, 52, 53, 55, 51, 55
   ]
+  const branchKeyIdWithEC := "4bb57643-07c1-419e-92ad-0df0df149d7c"
+
   // THESE ARE TESTING RESOURCES DO NOT USE IN A PRODUCTION ENVIRONMENT
   const keyArn := "arn:aws:kms:us-west-2:370957321024:key/9d989aa2-2f9c-438c-a745-cc57d3ad0126"
   const keyId := "9d989aa2-2f9c-438c-a745-cc57d3ad0126"


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- bumping to get the fix for Unicode handling in JSON (Commit: [fd67943663b201f789aa7a24b9c9d8ff192a6cb1](https://github.com/dafny-lang/libraries/commit/fd67943663b201f789aa7a24b9c9d8ff192a6cb1))
- I also cherrypicked [377de796f001ae21f69ac0e10f57709d0e6fa1ef](https://github.com/aws/aws-cryptographic-material-providers-library/commit/377de796f001ae21f69ac0e10f57709d0e6fa1ef) as the fixture in mutations/mutatons was not updated and the test will fail without it.
- did formatting as well.
### Squash/merge commit message, if applicable:

```
chore(dafny): bump libraries submodule to latest commit 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
