### PR TITLE
chore(CI): Fix nightly build (mostly)

### DIFF
--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -43,6 +43,7 @@ runs:
         go-version: ${{ matrix.go-version }}
 
     - name: Install Go imports
+      shell: bash
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
 

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -13,7 +13,7 @@ runs:
       with:
         distribution: "corretto"
         java-version: "17"
-    
+
     - name: Install smithy-dafny-codegen dependencies locally
       shell: bash
       run: |
@@ -40,7 +40,8 @@ runs:
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
 
-    - name: Force Gradle download?
+    # Without this the if-dafny-at-least command includes "Downloading ..." output
+    - name: Arbitrary makefile target to force downloading Gradle
       shell: bash
       run: |
         make -C StandardLibrary setup_net

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -40,7 +40,7 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version: "1.23"
 
     - name: Install Go imports
       shell: bash

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -14,17 +14,10 @@ runs:
         distribution: "corretto"
         java-version: "17"
     
-    - name: Install smithy-dafny-codegen Rust dependencies locally
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: :codegen-client:pTML :codegen-core:pTML :rust-runtime:pTML
-        build-root-directory: smithy-dafny/smithy-dafny-codegen-modules/smithy-rs
-
-    - name: Install smithy-dafny-codegen Python dependencies locally
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: :smithy-python-codegen:pTML
-        build-root-directory: smithy-dafny/codegen/smithy-dafny-codegen-modules/smithy-python/codegen
+    - name: Install smithy-dafny-codegen dependencies locally
+      shell: bash
+      run: |
+        make -C smithy-dafny mvn_local_deploy_polymorph_dependencies
 
     - name: Setup Python, black, and docformatter for code formatting
       uses: actions/setup-python@v4
@@ -46,7 +39,3 @@ runs:
       shell: bash
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
-
-      
-
-    

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -39,3 +39,8 @@ runs:
       shell: bash
       run: |
         go install golang.org/x/tools/cmd/goimports@latest
+
+    - name: Force Gradle download?
+      shell: bash
+      run: |
+        make -C StandardLibrary setup_net

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -8,6 +8,12 @@ description: "Install Java package dependencies required to run Smithy-Dafny cod
 runs:
   using: "composite"
   steps:
+    - name: Setup Java 17 for codegen
+      uses: actions/setup-java@v3
+      with:
+        distribution: "corretto"
+        java-version: "17"
+    
     - name: Install smithy-dafny-codegen Rust dependencies locally
       uses: gradle/gradle-build-action@v2
       with:
@@ -31,12 +37,6 @@ runs:
         python -m pip install --upgrade black
         python -m pip install --upgrade docformatter
 
-    - name: Setup Java 17 for codegen
-      uses: actions/setup-java@v3
-      with:
-        distribution: "corretto"
-        java-version: "17"
-    
     - name: Install Go
       uses: actions/setup-go@v5
       with:

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -30,3 +30,22 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade black
         python -m pip install --upgrade docformatter
+
+    - name: Setup Java 17 for codegen
+      uses: actions/setup-java@v3
+      with:
+        distribution: "corretto"
+        java-version: "17"
+    
+    - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+    - name: Install Go imports
+      run: |
+        go install golang.org/x/tools/cmd/goimports@latest
+
+      
+
+    

--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -38,9 +38,9 @@ runs:
         java-version: "17"
     
     - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
 
     - name: Install Go imports
       run: |

--- a/.github/actions/polymorph_codegen/action.yml
+++ b/.github/actions/polymorph_codegen/action.yml
@@ -46,12 +46,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Java 17 for codegen
-      uses: actions/setup-java@v3
-      with:
-        distribution: "corretto"
-        java-version: "17"
-
     - name: Install Smithy-Dafny codegen dependencies
       uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 

--- a/.github/workflows/library_codegen.yml
+++ b/.github/workflows/library_codegen.yml
@@ -66,21 +66,6 @@ jobs:
       - name: Create temporary global.json
         run: echo '{"sdk":{"rollForward":"latestFeature","version":"6.0.0"}}' > ./global.json
 
-      - name: Setup Java 17 for codegen
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "17"
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-
-      - name: Install Go imports
-        run: |
-          go install golang.org/x/tools/cmd/goimports@latest
-
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 

--- a/.github/workflows/library_codegen.yml
+++ b/.github/workflows/library_codegen.yml
@@ -66,9 +66,6 @@ jobs:
       - name: Create temporary global.json
         run: echo '{"sdk":{"rollForward":"latestFeature","version":"6.0.0"}}' > ./global.json
 
-      - name: Install Smithy-Dafny codegen dependencies
-        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
-
       - uses: ./.github/actions/polymorph_codegen
         with:
           dafny: ${{ env.DAFNY_VERSION }}

--- a/.github/workflows/library_dafny_verification.yml
+++ b/.github/workflows/library_dafny_verification.yml
@@ -53,7 +53,6 @@ jobs:
           dafny-version: ${{ inputs.dafny }}
 
       - name: Install Smithy-Dafny codegen dependencies
-        if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       - name: Regenerate code using smithy-dafny if necessary

--- a/.github/workflows/library_format.yml
+++ b/.github/workflows/library_format.yml
@@ -54,7 +54,6 @@ jobs:
           dafny-version: ${{ inputs.dafny }}
 
       - name: Install Smithy-Dafny codegen dependencies
-        if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       - name: Regenerate code using smithy-dafny if necessary

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -83,6 +83,9 @@ jobs:
         run: |
           go install golang.org/x/tools/cmd/goimports@latest
 
+      - name: Install Smithy-Dafny codegen dependencies
+        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+      
       - name: Build ${{ matrix.library }} implementation
         working-directory: ./${{ matrix.library }}
         run: |

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Setup Java 17 for codegen
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "17"
-  
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
-      
+
       - name: Build ${{ matrix.library }} implementation
         working-directory: ./${{ matrix.library }}
         run: |

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
+      - name: Setup Java 17 for codegen
+        uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "17"
+  
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -297,6 +297,9 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
+      - name: Install Smithy-Dafny codegen dependencies
+        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+  
       - name: Regenerate code using smithy-dafny if necessary
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -310,7 +310,7 @@ jobs:
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen
         with:
-          dafny: ${{ inputs.dafny }}
+          dafny: ${{ env.DAFNY_VERSION }}
           library: ${{ matrix.library }}
           diff-generated-code: false
 

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -116,7 +116,7 @@ jobs:
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen
         with:
-          dafny: ${{ inputs.dafny }}
+          dafny: ${{ env.DAFNY_VERSION }}
           library: ${{ matrix.library }}
           diff-generated-code: false
 
@@ -299,7 +299,7 @@ jobs:
 
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
-  
+
       - name: Regenerate code using smithy-dafny if necessary
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -109,8 +109,7 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Regenerate code using smithy-dafny if necessary
-        if: ${{ inputs.regenerate-code }}
+      - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       - name: Regenerate code using smithy-dafny if necessary
@@ -148,10 +147,6 @@ jobs:
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_python
-
-      - name: Install Smithy-Dafny codegen dependencies
-        if: matrix.language == 'rust'
-        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       # We do not check in Rust polymorph code
       - name: Run make polymorph_rust
@@ -302,10 +297,6 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Install Smithy-Dafny codegen dependencies
-        if: ${{ inputs.regenerate-code }}
-        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
-
       - name: Regenerate code using smithy-dafny if necessary
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/polymorph_codegen
@@ -341,10 +332,6 @@ jobs:
           # This works because `node` is installed by default on GHA runners
           CORES=$(node -e 'console.log(os.cpus().length)')
           make transpile_python
-
-      - name: Install Smithy-Dafny codegen dependencies
-        if: matrix.decrypting_language == 'rust'
-        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       # TODO: Remove this after checking in Rust polymorph code
       - name: Run make polymorph_rust

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -65,6 +65,12 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
+      - name: Setup Java 17 for codegen
+        uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "17"
+          
       - name: Install Smithy-Dafny codegen dependencies
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -65,12 +65,6 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Setup Java 17 for codegen
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "17"
-          
       - name: Install Smithy-Dafny codegen dependencies
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -66,7 +66,6 @@ jobs:
           dafny-version: ${{ inputs.dafny }}
 
       - name: Install Smithy-Dafny codegen dependencies
-        if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       - name: Regenerate code using smithy-dafny if necessary

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -68,6 +68,12 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
+      - name: Setup Java 17 for codegen
+        uses: actions/setup-java@v3
+        with:
+          distribution: "corretto"
+          java-version: "17"
+
       - name: Install Smithy-Dafny codegen dependencies
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -68,12 +68,6 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Setup Java 17 for codegen
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "17"
-
       - name: Install Smithy-Dafny codegen dependencies
         if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -69,7 +69,6 @@ jobs:
           dafny-version: ${{ inputs.dafny }}
 
       - name: Install Smithy-Dafny codegen dependencies
-        if: ${{ inputs.regenerate-code }}
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
 
       - name: Regenerate code using smithy-dafny if necessary

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -78,6 +78,9 @@ jobs:
           pip install --upgrade tox
           pip install poetry
 
+      - name: Install Smithy-Dafny codegen dependencies
+        uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
+        
       - name: Build ${{ matrix.library }} implementation
         working-directory: ./${{ matrix.library }}
         run: |

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install Smithy-Dafny codegen dependencies
         uses: ./.github/actions/install_smithy_dafny_codegen_dependencies
-        
+
       - name: Build ${{ matrix.library }} implementation
         working-directory: ./${{ matrix.library }}
         run: |

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Dafny
         uses: ./.github/actions/setup_dafny
         with:
-          dafny-version: ${{ inputs.dafny }}
+          dafny-version: nightly-2025-01-30-7db1e5f
 
       - name: Setup NASM for Windows (aws-lc-sys)
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -64,12 +64,6 @@ jobs:
         with:
           dafny-version: ${{ inputs.dafny }}
 
-      - name: Setup Java 17 for codegen
-        uses: actions/setup-java@v3
-        with:
-          distribution: "corretto"
-          java-version: "17"
-
       - name: Setup NASM for Windows (aws-lc-sys)
         if: matrix.os == 'windows-latest'
         uses: ilammy/setup-nasm@v1

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Dafny
         uses: ./.github/actions/setup_dafny
         with:
-          dafny-version: nightly-2025-01-30-7db1e5f
+          dafny-version: ${{ inputs.dafny }}
 
       - name: Setup Java 17 for codegen
         uses: actions/setup-java@v3

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -15,13 +15,9 @@ jobs:
     # Don't run the cron builds on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'
     uses: ./.github/workflows/dafny_version.yaml
-  dafny-nightly-format:
-    # Don't run the cron builds on forks
-    if: github.event_name != 'schedule' || github.repository_owner == 'aws'
-    uses: ./.github/workflows/library_format.yml
-    with:
-      dafny: "nightly-latest"
-      regenerate-code: true
+  # Don't run library_format.yml as new versions of Dafny
+  # often change auto-formatting slightly,
+  # so we often failures that aren't really meaningful.
   dafny-nightly-verification:
     # Don't run the cron builds on forks
     if: github.event_name != 'schedule' || github.repository_owner == 'aws'


### PR DESCRIPTION
### Description of changes:

* Updated `smithy-dafny` to pick up the change to pass `--enforce-determinism` for newer Dafnies: https://github.com/smithy-lang/smithy-dafny/pull/789
* Moved codgen CLI dependencies such as Java 17 into the common `install_smithy_dafny_codegen_dependencies/action.yml` workflow
* Made workflows always call this action, since the shared makefile now calls the codegen CLI `if-dafny-at-least` command
* Disabled checking formatting in the nightly, since that often hits false positives.

Manual build against Dafny's `nightly-latest` (just before removing `library_format.yml` from nightly): https://github.com/aws/aws-cryptographic-material-providers-library/actions/runs/15200158182

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
