### PR TITLE
test(Dafny): Java Integ Test for Escape Chars

### DIFF
--- a/Examples/java/src/main/java/software/amazon/cryptography/example/Constants.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/Constants.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example;
 
 import java.util.Map;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/DdbHelper.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/DdbHelper.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example;
 
 import java.util.HashMap;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/KeyStoreProvider.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/KeyStoreProvider.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy;
 
 import javax.annotation.Nullable;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationKmsSimpleExample.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationKmsSimpleExample.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import javax.annotation.Nonnull;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationKmsSimpleExample.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationKmsSimpleExample.java
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
+import java.util.Map;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import software.amazon.cryptography.example.hierarchy.AdminProvider;
@@ -28,6 +29,7 @@ public class MutationKmsSimpleExample {
     @Nonnull final String branchKeyId,
     @Nonnull final String terminalKmsArn,
     @Nullable final HierarchyVersion terminalHierarchyVersion,
+    @Nullable Map<String, String> terminalEncryptionContext,
     @Nonnull final SystemKey systemKey,
     @Nullable final KeyStoreAdmin admin
   ) {
@@ -37,7 +39,8 @@ public class MutationKmsSimpleExample {
       .build();
     Mutations mutations = MutationsProvider.defaultMutation(
       terminalKmsArn,
-      terminalHierarchyVersion
+      terminalHierarchyVersion,
+      terminalEncryptionContext
     );
     final KeyStoreAdmin _admin = admin == null ? AdminProvider.admin() : admin;
     InitializeMutationInput initInput = InitializeMutationInput

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
+import static software.amazon.cryptography.example.Constants.DEFAULT_ENCRYPTION_CONTEXT;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.MapUtils;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.cryptography.example.DdbHelper;
@@ -23,7 +27,6 @@ import software.amazon.cryptography.keystoreadmin.model.InitializeMutationInput;
 import software.amazon.cryptography.keystoreadmin.model.InitializeMutationOutput;
 import software.amazon.cryptography.keystoreadmin.model.KeyManagementStrategy;
 import software.amazon.cryptography.keystoreadmin.model.KmsSymmetricEncryption;
-import software.amazon.cryptography.keystoreadmin.model.KmsSymmetricKeyArn;
 import software.amazon.cryptography.keystoreadmin.model.MutatedBranchKeyItem;
 import software.amazon.cryptography.keystoreadmin.model.MutationToken;
 import software.amazon.cryptography.keystoreadmin.model.Mutations;
@@ -46,8 +49,19 @@ public class MutationsProvider {
     @Nonnull final String terminalKmsArn,
     @Nullable final HierarchyVersion terminalHierarchyVersion
   ) {
-    HashMap<String, String> terminalEC = new HashMap<>(2, 1);
-    terminalEC.put("Robbie", "is a dog.");
+    return defaultMutation(terminalKmsArn, terminalHierarchyVersion, null);
+  }
+
+  public static Mutations defaultMutation(
+    @Nonnull final String terminalKmsArn,
+    @Nullable final HierarchyVersion terminalHierarchyVersion,
+    @Nullable Map<String, String> terminalEncryptionContext
+  ) {
+    final Map<String, String> terminalEC =
+      // prettier-ignore
+      MapUtils.isEmpty(terminalEncryptionContext)
+        ? DEFAULT_ENCRYPTION_CONTEXT
+        : terminalEncryptionContext;
     return Mutations
       .builder()
       .TerminalEncryptionContext(terminalEC)

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsProvider.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import java.util.Collections;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsSystemKeyTrustExample.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/MutationsSystemKeyTrustExample.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.hierarchy.mutations.MutationsProvider.executeInitialize;

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/ScanForInFlightMutations.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/mutations/ScanForInFlightMutations.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import java.util.ArrayList;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ExampleTests.java
@@ -133,6 +133,7 @@ public class ExampleTests {
         branchKeyId,
         Fixtures.POSTAL_HORN_KEY_ARN,
         terminalHVersion,
+        null,
         MutationsProvider.KmsSystemKey(),
         AdminProvider.admin()
       );

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/StaticMutation.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/StaticMutation.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy;
 
 import java.util.Collections;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ValidateKeyStoreItem.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/ValidateKeyStoreItem.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy;
 
 import java.util.List;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/ConcurrentConditionCheckWriteTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/ConcurrentConditionCheckWriteTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.concurrent;
 
 import java.text.DateFormat;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/StorageVersionReadConcurrencyTests.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/StorageVersionReadConcurrencyTests.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.concurrent;
 
 import static software.amazon.cryptography.example.hierarchy.concurrent.StorageWriteReadConcurrencyTests.createKeyStore;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/StorageWriteReadConcurrencyTests.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/StorageWriteReadConcurrencyTests.java
@@ -1,7 +1,7 @@
-package software.amazon.cryptography.example.hierarchy.concurrent;
-
 // Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy.concurrent;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.*;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/testng-parallel.xml
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/concurrent/testng-parallel.xml
@@ -1,3 +1,5 @@
+<!--Copyright Amazon.com Inc. or its affiliates. All Rights Reserved. -->
+<!--SPDX-License-Identifier: Apache-2.0-->
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 <suite name="Mixed Parallel and Sequential Suite">
   <test name="Parallel Tests" parallel="methods" thread-count="2">

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DescribeMutationTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DescribeMutationTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.hierarchy.mutations.DescribeMutationExample.Example;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DoNotVersionTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/DoNotVersionTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.hierarchy.mutations.MutationsProvider.executeInitialize;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationAccessDeniedRunner.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationAccessDeniedRunner.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import java.util.ArrayList;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV1Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV1Test.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV2Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV1ToV2Test.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV2ToV2Test.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/KmsInFlightMutationV2ToV2Test.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.Fixtures.MRK_ARN_WEST;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/ScanForInFlightMutationsTest.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/ScanForInFlightMutationsTest.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import org.testng.annotations.Test;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyKMSExample.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyKMSExample.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import org.testng.annotations.Test;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyTrustStorage.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationSystemKeyTrustStorage.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import org.testng.annotations.Test;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationToHV2ProperlyHandlesEmptyEncryptionContextKey.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationToHV2ProperlyHandlesEmptyEncryptionContextKey.java
@@ -78,6 +78,7 @@ public class TestMutationToHV2ProperlyHandlesEmptyEncryptionContextKey {
       branchKeyId,
       Fixtures.POSTAL_HORN_KEY_ARN,
       HierarchyVersion.v2,
+      null,
       MutationsProvider.TrustStorage(),
       AdminProvider.admin()
     );

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationToHV2ProperlyHandlesEmptyEncryptionContextKey.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationToHV2ProperlyHandlesEmptyEncryptionContextKey.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import java.util.Collections;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsSystemKeyKMSTamper.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsSystemKeyKMSTamper.java
@@ -1,3 +1,5 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
 import static software.amazon.cryptography.example.hierarchy.mutations.MutationsProvider.executeInitialize;

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy.mutations;
 
+import static software.amazon.cryptography.example.Constants.DEFAULT_ENCRYPTION_CONTEXT;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -18,7 +19,72 @@ import software.amazon.cryptography.keystore.KeyStore;
 import software.amazon.cryptography.keystore.model.GetActiveBranchKeyInput;
 import software.amazon.cryptography.keystore.model.GetActiveBranchKeyOutput;
 import software.amazon.cryptography.keystore.model.HierarchyVersion;
-import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
 
 public class TestMutationsWithEscapeCharactersInEC {
+
+  static final String testPrefix =
+    "mutations-with-escape-characters-in-ec-java-test-";
+  private static final Map<String, String> encryptionContext;
+
+  static {
+    Map<String, String> _encryptionContext = new HashMap<>(
+      DEFAULT_ENCRYPTION_CONTEXT
+    );
+    _encryptionContext.put("\n\n\u0007", "escape-characters-plus-bell");
+    encryptionContext = Collections.unmodifiableMap(_encryptionContext);
+  }
+
+  protected String createHV1WithEscapeCharactersInEC() {
+    final String testBranchKeyId = testPrefix + UUID.randomUUID().toString();
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      testBranchKeyId,
+      AdminProvider.admin(),
+      HierarchyVersion.v1,
+      encryptionContext
+    );
+    return testBranchKeyId;
+  }
+
+  protected void checkBranchKey(final String branchKeyId) {
+    KeyStore discoveryKeyStore = KeyStoreProvider.keyStore(null);
+    GetActiveBranchKeyOutput getActiveBranchKeyOutput =
+      discoveryKeyStore.GetActiveBranchKey(
+        GetActiveBranchKeyInput
+          .builder()
+          .branchKeyIdentifier(branchKeyId)
+          .build()
+      );
+    Assert.assertEquals(
+      getActiveBranchKeyOutput.branchKeyMaterials().encryptionContext(),
+      encryptionContext,
+      "Test Branch Key does not have expected encryption context."
+    );
+  }
+
+  protected void mutateToHV2(final String branchKeyId) {
+    MutationKmsSimpleExample.End2End(
+      branchKeyId,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      HierarchyVersion.v2,
+      null,
+      MutationsProvider.KmsSystemKey(),
+      AdminProvider.admin()
+    );
+  }
+
+  @Test
+  public void testMutationsWithEscapeCharactersInEC()
+    throws InterruptedException {
+    final String branchKeyId = createHV1WithEscapeCharactersInEC();
+    Thread.sleep(5000); // DDB eventual consistency
+    try {
+      checkBranchKey(branchKeyId);
+      mutateToHV2(branchKeyId);
+      Thread.sleep(5000); // DDB eventual consistency
+      checkBranchKey(branchKeyId);
+    } finally {
+      DdbHelper.DeleteBranchKey(branchKeyId, Fixtures.TEST_KEYSTORE_NAME, null);
+    }
+  }
 }

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
@@ -67,7 +67,7 @@ public class TestMutationsWithEscapeCharactersInEC {
       branchKeyId,
       Fixtures.POSTAL_HORN_KEY_ARN,
       HierarchyVersion.v2,
-      null,
+      encryptionContext,
       MutationsProvider.KmsSystemKey(),
       AdminProvider.admin()
     );

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestMutationsWithEscapeCharactersInEC.java
@@ -1,0 +1,24 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy.mutations;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import software.amazon.cryptography.example.DdbHelper;
+import software.amazon.cryptography.example.Fixtures;
+import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.example.hierarchy.CreateKeyExample;
+import software.amazon.cryptography.example.hierarchy.KeyStoreProvider;
+import software.amazon.cryptography.keystore.KeyStore;
+import software.amazon.cryptography.keystore.model.GetActiveBranchKeyInput;
+import software.amazon.cryptography.keystore.model.GetActiveBranchKeyOutput;
+import software.amazon.cryptography.keystore.model.HierarchyVersion;
+import software.amazon.cryptography.keystoreadmin.model.KeyStoreAdminException;
+
+public class TestMutationsWithEscapeCharactersInEC {
+}


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- Added a bunch of copyright headers to Java code that was missing them
- Java Integ test for JSON handling of Escape characters

### Squash/merge commit message, if applicable:

```
test(Dafny): Java Integ Test for Escape Chars
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
