### PR TITLE
test(Dafny): BKS Integ Test ensure EncCtx is prefixed/unprefixed as expected

### DIFF
--- a/Examples/java/src/main/java/software/amazon/cryptography/example/Fixtures.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/Fixtures.java
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example;
 
-import java.time.Duration;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -45,6 +44,13 @@ public class Fixtures {
     "arn:aws:iam::370957321024:role/Restricted-KMS-HKey-Two-Only";
   public static final String KMS_KEYSTORE_ONLY =
     "arn:aws:iam::370957321024:role/Restricted-KMS-HKey-One-Only";
+  public static final String KMS_HV1_With_Prefixed_Robbie =
+    "arn:aws:iam::370957321024:role/KMS-HV1-With-Prefixed-Robbie";
+  // ^ Restrict to Encryption Context that contains "aws-crypto-ec:Robbie": "Is a Dog."
+  public static final String KMS_HV2_With_Only_Robbie =
+    "arn:aws:iam::370957321024:role/KMS-HV2-Robbie-Only";
+  // ^ Restrict to Encryption Context that is ONLY "Robbie": "Is a Dog."
+
   // Static Branch Key IDs
   public static final String HV2_BRANCH_KEY_ID =
     "4a0c7b92-3703-4209-8961-24b07ab6562b";
@@ -55,7 +61,6 @@ public class Fixtures {
     DefaultCredentialsProvider.create();
   public static final SdkHttpClient httpClient = ApacheHttpClient
     .builder()
-    .connectionTimeToLive(Duration.ofSeconds(5))
     .build();
   public static final DynamoDbClient ddbClientWest2 = DynamoDbClient
     .builder()
@@ -108,6 +113,34 @@ public class Fixtures {
     .credentialsProvider(
       CredentialUtils.credsForRole(
         Fixtures.KMS_KEYSTORE_ONLY,
+        "java-mpl-examples",
+        Region.US_WEST_2,
+        Fixtures.httpClient,
+        Fixtures.defaultCreds
+      )
+    )
+    .region(Region.US_WEST_2)
+    .httpClient(Fixtures.httpClient)
+    .build();
+  public static final KmsClient prefixedRobbiePresent = KmsClient
+    .builder()
+    .credentialsProvider(
+      CredentialUtils.credsForRole(
+        Fixtures.KMS_HV1_With_Prefixed_Robbie,
+        "java-mpl-examples",
+        Region.US_WEST_2,
+        Fixtures.httpClient,
+        Fixtures.defaultCreds
+      )
+    )
+    .region(Region.US_WEST_2)
+    .httpClient(Fixtures.httpClient)
+    .build();
+  public static final KmsClient defixedRobbieOnly = KmsClient
+    .builder()
+    .credentialsProvider(
+      CredentialUtils.credsForRole(
+        Fixtures.KMS_HV2_With_Only_Robbie,
         "java-mpl-examples",
         Region.US_WEST_2,
         Fixtures.httpClient,

--- a/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/KeyStoreProvider.java
+++ b/Examples/java/src/main/java/software/amazon/cryptography/example/hierarchy/KeyStoreProvider.java
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.cryptography.example.hierarchy;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.cryptography.example.Fixtures;
 import software.amazon.cryptography.keystore.KeyStore;
 import software.amazon.cryptography.keystore.model.KMSConfiguration;
@@ -11,7 +13,24 @@ import software.amazon.cryptography.keystore.model.MRDiscovery;
 
 public class KeyStoreProvider {
 
+  /**
+   * Branch Key Store for the default test table with the default KMS Client
+   * @param kmsArn If non-null, creates a strict MRK Branch Key Store;
+   *               otherwise, creates a Discovery Key Store.
+   */
   public static KeyStore keyStore(@Nullable String kmsArn) {
+    return keyStore(kmsArn, Fixtures.kmsClientWest2);
+  }
+
+  /**
+   * @param kmsArn If non-null, creates a strict MRK Branch Key Store;
+   *               otherwise, creates a Discovery Key Store.
+   * @param kmsClient KMS Client used by the Key Store
+   */
+  public static KeyStore keyStore(
+    @Nullable String kmsArn,
+    @Nonnull KmsClient kmsClient
+  ) {
     KMSConfiguration kmsConfiguration;
     if (kmsArn != null) {
       kmsConfiguration = KMSConfiguration.builder().kmsMRKeyArn(kmsArn).build();
@@ -30,7 +49,7 @@ public class KeyStoreProvider {
           .ddbClient(Fixtures.ddbClientWest2)
           .ddbTableName(Fixtures.TEST_KEYSTORE_NAME)
           .logicalKeyStoreName(Fixtures.TEST_LOGICAL_KEYSTORE_NAME)
-          .kmsClient(Fixtures.kmsClientWest2)
+          .kmsClient(kmsClient)
           .kmsConfiguration(kmsConfiguration)
           .build()
       )

--- a/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestEnsureBranchKeyStoreTreatsEncryptionContextPrefixCorrectly.java
+++ b/Examples/java/src/test/java/software/amazon/cryptography/example/hierarchy/mutations/TestEnsureBranchKeyStoreTreatsEncryptionContextPrefixCorrectly.java
@@ -1,0 +1,90 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package software.amazon.cryptography.example.hierarchy.mutations;
+
+import static software.amazon.cryptography.example.Constants.DEFAULT_ENCRYPTION_CONTEXT;
+
+import java.util.UUID;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.cryptography.example.DdbHelper;
+import software.amazon.cryptography.example.Fixtures;
+import software.amazon.cryptography.example.hierarchy.AdminProvider;
+import software.amazon.cryptography.example.hierarchy.CreateKeyExample;
+import software.amazon.cryptography.example.hierarchy.KeyStoreProvider;
+import software.amazon.cryptography.keystore.KeyStore;
+import software.amazon.cryptography.keystore.model.GetActiveBranchKeyInput;
+import software.amazon.cryptography.keystore.model.GetActiveBranchKeyOutput;
+import software.amazon.cryptography.keystore.model.HierarchyVersion;
+
+public class TestEnsureBranchKeyStoreTreatsEncryptionContextPrefixCorrectly {
+
+  static final String testPrefix =
+    "ensure-branch-key-store-treats-ec-prefix-correctly-java-test-";
+
+  protected String createHV1() {
+    final String testBranchKeyId = testPrefix + UUID.randomUUID().toString();
+    CreateKeyExample.CreateKey(
+      Fixtures.KEYSTORE_KMS_ARN,
+      testBranchKeyId,
+      AdminProvider.admin(),
+      HierarchyVersion.v1,
+      DEFAULT_ENCRYPTION_CONTEXT
+    );
+    return testBranchKeyId;
+  }
+
+  protected void checkBranchKey(final String branchKeyId, KmsClient kmsClient) {
+    KeyStore discoveryKeyStore = KeyStoreProvider.keyStore(null, kmsClient);
+    GetActiveBranchKeyOutput getActiveBranchKeyOutput =
+      discoveryKeyStore.GetActiveBranchKey(
+        GetActiveBranchKeyInput
+          .builder()
+          .branchKeyIdentifier(branchKeyId)
+          .build()
+      );
+    Assert.assertEquals(
+      getActiveBranchKeyOutput.branchKeyMaterials().encryptionContext(),
+      DEFAULT_ENCRYPTION_CONTEXT,
+      "Test Branch Key does not have expected encryption context."
+    );
+  }
+
+  protected void mutateToHV2(final String branchKeyId) {
+    MutationKmsSimpleExample.End2End(
+      branchKeyId,
+      Fixtures.POSTAL_HORN_KEY_ARN,
+      HierarchyVersion.v2,
+      DEFAULT_ENCRYPTION_CONTEXT,
+      MutationsProvider.KmsSystemKey(),
+      AdminProvider.admin()
+    );
+  }
+
+  @Test
+  public void testEnsureBranchKeyStoreTreatsEncryptionContextPrefixCorrectly()
+    throws InterruptedException {
+    final String branchKeyId = createHV1();
+    Thread.sleep(5000); // DDB eventual consistency
+    try {
+      // The IAM Role associated with "prefixedRobbiePresent" requires that "aws-crypto-ec:Robbie": "Is a Dog." is present
+      checkBranchKey(branchKeyId, Fixtures.prefixedRobbiePresent);
+      // The IAM Role associated with "defixedRobbieOnly" requires that the Encryption Context ONLY be "Robbie": "Is a Dog."
+      Assert.assertThrows(
+        KmsException.class,
+        () -> checkBranchKey(branchKeyId, Fixtures.defixedRobbieOnly)
+      );
+      mutateToHV2(branchKeyId);
+      Thread.sleep(5000); // DDB eventual consistency
+      checkBranchKey(branchKeyId, Fixtures.defixedRobbieOnly);
+      Assert.assertThrows(
+        KmsException.class,
+        () -> checkBranchKey(branchKeyId, Fixtures.prefixedRobbiePresent)
+      );
+    } finally {
+      DdbHelper.DeleteBranchKey(branchKeyId, Fixtures.TEST_KEYSTORE_NAME, null);
+    }
+  }
+}


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
[Integ Tests use CFN Roles created by this PR](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e810e7da19c5242435eb8b9c2a922c56d3a6a966) to ensure that the Branch Key Store correctly handles EC.

### Squash/merge commit message, if applicable:

```
test(Dafny): BKS Integ Test ensure EncCtx is prefixed/unprefixed as expected
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
