### PR TITLE
chore(java): migrate to Nexus Central for Maven publishing

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -184,8 +184,8 @@ nexusPublishing {
     // https://github.com/gradle-nexus/publish-plugin/
     repositories {
         sonatype {
-            nexusUrl.set(uri("https://aws.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://aws.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("SONA_USERNAME"))
             password.set(System.getenv("SONA_PASSWORD"))
         }

--- a/cfn/CB.yml
+++ b/cfn/CB.yml
@@ -236,6 +236,7 @@ Resources:
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-Credentials-WgJanS",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Team-Account-0tWvZm",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-User-Token-zK61bM",
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Central-Portal-XrYUs2",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Github/aws-crypto-tools-ci-bot-AGUB3U"
               ],
               "Action": "secretsmanager:GetSecretValue"

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -9,8 +9,8 @@ env:
   secrets-manager:
     GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
     GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
-    SONA_USERNAME: Sonatype-User-Token:username
-    SONA_PASSWORD: Sonatype-User-Token:password
+    SONA_USERNAME: Sonatype-Central-Portal:Username
+    SONA_PASSWORD: Sonatype-Central-Portal:Password
 
 phases:
   install:


### PR DESCRIPTION
### Issue if available: 

n/a

### Description of changes: 

Need to migrate how we publish to Maven. See https://github.com/aws/aws-encryption-sdk-java/pull/2117/files in the ESDK. This project uses Gradle though so the change is slightly different. 

**NOTE** I couldn't find a way to enable [auto publish](https://central.sonatype.org/publish/publish-portal-maven/#automatic-publishing) in the Gradle plugin, so the release may require additional steps. 

### Squash/merge commit message, if applicable:

```
chore(java): migrate to Nexus Central for Maven publishing

Deployed CB.yaml change via change set ID:
arn:aws:cloudformation:us-west-2:587316601012:changeSet/AWS-MPL-Java-Staging-Maybe-Nexus-2025-06-10/04f37e32-a5a6-45f3-916a-b061bc145e27

To Stack:
arn:aws:cloudformation:us-west-2:587316601012:stack/AWS-MPL-Java-Staging/193816b0-f98b-11ed-95bb-0a13e345bcb7
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
