### PR TITLE
chore: 1.11.0 [skip ci]

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.10.1")]
+[assembly: AssemblyVersion("1.11.0")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.10.1</Version>
+      <Version>1.11.0</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.10.1"
+version = "1.11.0"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.0"
+aws-cryptography-internal-kms = "1.11.0"
+aws-cryptography-internal-dynamodb = "1.11.0"
+aws-cryptography-internal-primitives = "1.11.0"
 
 # Package testing
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
@@ -1,179 +1,238 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.AwsCryptographyKeyStoreTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsArnParsing]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkMatchForDecrypt]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsUtils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStoreErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KmsArn]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Structure]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KMSKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DDBKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeyStoreTable]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStore]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Materials]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Keyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.MultiKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsMrkAreUnique]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.Constants]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.MaterialWrapping]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CanonicalEncryptionContext]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.MaterialWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.IntermediateKeyWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.EdkWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.ErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.StrictMultiKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsDiscoveryKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.DiscoveryMultiKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsMrkDiscoveryKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.MrkAwareDiscoveryMultiKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsMrkKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.MrkAwareStrictMultiKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.LocalCMC]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.SynchronizedLocalCMC]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.StormTracker]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.StormTrackingCMC]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.CacheConstants]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsHierarchicalKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsRsaKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.EcdhEdkWrapping]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.RawECDHKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
-[options_by_module.AwsKmsEcdhKeyring]
-legacy-module-names = false
-python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawAESKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.Constants]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.EcdhEdkWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.RawECDHKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawRSAKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsDiscoveryKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsEcdhKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.LocalCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.SynchronizedLocalCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.StormTracker]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.StormTrackingCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.CacheConstants]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsHierarchicalKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsMrkDiscoveryKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsMrkKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsRsaKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.MultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.AwsKmsMrkAreUnique]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.StrictMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.DiscoveryMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.MrkAwareDiscoveryMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
+[options_by_module.MrkAwareStrictMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Defaults]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Commitment]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultClientSupplier]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RequiredEncryptionContextCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.10.1")]
+[assembly: AssemblyVersion("1.11.0")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.10.1</Version>
+    <Version>1.11.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.10.1"
+version = "1.11.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.0"
 cryptography = ">=43.0.1, <46"
 
 # Package testing

--- a/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,59 +1,78 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.AwsCryptographyPrimitivesTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternRandom]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Random]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AESEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternDigest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Digest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Signature]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.KdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.RSAEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AtomicPrimitives]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AesKdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)
+
+### Fixes -- All Languages
+
+* **dafny:** bump Dafny libraries for JSON fix ([#1517](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1517)) ([d8679e5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d8679e517ae3bc3b074325f849b5cb6c252c8f18))
+
+### Maintenance -- All Languages
+
+* **dafny:** BK fix to extract encryption context for branch key materials ([#1523](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1523)) ([95856ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95856acd01ad26460a09eb171f2793a3109bfdbd))
+* **dafny:** don't recalculate RSA key on every decrypt ([#1448](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1448)) ([f318912](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f318912eb419140c8e1cb4694b9bf69c3e239967))
+* **dafny:** Make HasSubString generic ([#1549](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1549)) ([6a1017f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6a1017f5f87f39bb8eace9e92704bb2b64b16e65))
+* **dafny:** more using uint64 instead of nat ([#1490](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1490)) ([571e3c5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/571e3c564f1989e3c3df1fd765f4939326bc0893))
+* **dafny:** store privateKey in RawRSAKeyring because some Java code needs it ([#1450](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1450)) ([1c29322](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c293223efb2bc9643a45e482daf37a87eeae197))
+* **dafny:** support for memory size constraints ([#1481](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1481)) ([8d2c2b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8d2c2b5d4e20f89d7bfad75fcd4d149894d390f3))
+* **dafny:** update UInt and MemoryMath as needed for DB-ESDK ([#1488](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1488)) ([49e596b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/49e596b1cd8ce446d0b82074ff48ba0406aa8995))
+
+### Maintenance -- Java
+
+* **java:** migrate to Nexus Central for Maven publishing ([#1553](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1553)) ([7d2fcd3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7d2fcd392eb31f023669e309ab9fc557394e932b))
+
+### Maintenance -- Go
+
+* **go:** implement missing MutableMap::content() ([#1519](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1519)) ([f033b91](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f033b915701eaa53d97019af61b96a51fed43483))
+* **go:** remove print statements from testLotsOfAdding ([#1468](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1468)) ([594383c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/594383c6fa1ed9bb286290a0b67814953c88eef0))
+
+### Maintenance -- Rust
+
+* **rust:** remove print statements from testLotsOfAdding  ([#1469](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1469)) ([9cf1dce](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9cf1dce985d86d83d393e46b7e78697ebda85d90))
+* **rust:** update smithy-dafny, use small-int feature ([#1437](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1437)) ([515995e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/515995e68400e56fc720412fe355e6965715136e))
+
+### Miscellaneous
+
+* add MemoryMath to Index.dfy ([#1484](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1484)) ([3196e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/3196e7d1e51fd6f1f31fca6d90c1c01d437ae830))
+* add MPL CI to principal of KmsKeyForRobbieOnly  ([#1528](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1528)) ([527f69d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/527f69d7c0eb2070406051047dcefbabadc374e4))
+* bump smithy-dafny to latest ([#1375](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1375)) ([d3e7916](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d3e79168a23381973fab90e0c11e5ec0fb8a37fd))
+* CFN for Restricted EC ([#1522](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1522)) ([391fa4c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/391fa4c1163b6722752169181219408660cc9e09))
+* CFN for two new roles to prove prefixing/defixing behavior ([#1538](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1538)) ([e810e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e810e7da19c5242435eb8b9c2a922c56d3a6a966))
+* CFN KMS GDK for HV-2 ([#1464](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1464)) ([cfbaa58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cfbaa58f8976c5d7ff5351c4957b9539fcac7e54))
+* **CI:** Allow local testing ([#1371](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1371)) ([fe18948](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fe189489ee0e21b3d12944673a9a1de756ee0bc9))
+* **CI:** Fix nightly build (mostly) ([#1540](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1540)) ([362ffc1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/362ffc1c8b5adb84af58e783dc5ef696ca103643))
+* **CI:** Fix nightly build workflow ([#1541](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1541)) ([48d69eb](https://github.com/aws/aws-cryptographic-material-providers-library/commit/48d69ebeda1e5167f26ebe8f87a51addab3d9afb))
+* Create KMS keys for HV1 & HV2 branch keys ([#1419](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1419)) ([2f0696d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2f0696dbd06e471f4b0bedea7239ec86ff39a79e))
+* Create Static Key Store table for storing static branch keys ([#1456](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1456)) ([96b8058](https://github.com/aws/aws-cryptographic-material-providers-library/commit/96b80589406a71503d2e87d2cff8968ac95abd71))
+* **dafny:** add tests for multiple utf8 ec entries ([#1424](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1424)) ([131ae58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/131ae583de02cb8352f8a96d69a9e1c84fea7338))
+* **dafny:** restore static test branch key id ([#1404](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1404)) ([377de79](https://github.com/aws/aws-cryptographic-material-providers-library/commit/377de796f001ae21f69ac0e10f57709d0e6fa1ef))
+* **deps:** Extend supported pyca version range ([#1556](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1556)) ([89f47aa](https://github.com/aws/aws-cryptographic-material-providers-library/commit/89f47aa50a98e211a1cb669f8d7294e340f07723))
+* improve performance ([#1286](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1286)) ([d808fd8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d808fd88df92acf64fb9ca0e7c652d72e05fa50a))
+* install polymorph dependencies in github workflows ([#1514](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1514)) ([eb68525](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eb68525d9430ea4dcc355e7f17bef7bafe069035))
+* **Python:** bump pyca to 44.0 ([#1555](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1555)) ([4f4cd87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4f4cd87c5bea38d523aac00947d6678b5ea2b3a0))
+* resolve rust warning ([#1394](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1394)) ([e2fe1a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fe1a4fc79d62c434bdbf72f8713b18ce74071a))
+* specify language in commits ([#1382](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1382)) ([ccd56cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ccd56cfae7c784e3c852d1f4bcc0b7127525f7d8))
+
 ## [1.10.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.0...v1.10.1) (2025-03-27)
 
 This release is available in the following languages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,57 +3,58 @@
 ## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)
 
 This release is available in the following languages:
+
 - Java
 
 ### Fixes -- All Languages
 
-* **dafny:** bump Dafny libraries for JSON fix ([#1517](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1517)) ([d8679e5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d8679e517ae3bc3b074325f849b5cb6c252c8f18))
+- **dafny:** bump Dafny libraries for JSON fix ([#1517](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1517)) ([d8679e5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d8679e517ae3bc3b074325f849b5cb6c252c8f18))
 
 ### Maintenance -- All Languages
 
-* **dafny:** BK fix to extract encryption context for branch key materials ([#1523](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1523)) ([95856ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95856acd01ad26460a09eb171f2793a3109bfdbd))
-* **dafny:** don't recalculate RSA key on every decrypt ([#1448](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1448)) ([f318912](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f318912eb419140c8e1cb4694b9bf69c3e239967))
-* **dafny:** Make HasSubString generic ([#1549](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1549)) ([6a1017f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6a1017f5f87f39bb8eace9e92704bb2b64b16e65))
-* **dafny:** more using uint64 instead of nat ([#1490](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1490)) ([571e3c5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/571e3c564f1989e3c3df1fd765f4939326bc0893))
-* **dafny:** store privateKey in RawRSAKeyring because some Java code needs it ([#1450](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1450)) ([1c29322](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c293223efb2bc9643a45e482daf37a87eeae197))
-* **dafny:** support for memory size constraints ([#1481](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1481)) ([8d2c2b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8d2c2b5d4e20f89d7bfad75fcd4d149894d390f3))
-* **dafny:** update UInt and MemoryMath as needed for DB-ESDK ([#1488](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1488)) ([49e596b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/49e596b1cd8ce446d0b82074ff48ba0406aa8995))
+- **dafny:** BK fix to extract encryption context for branch key materials ([#1523](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1523)) ([95856ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95856acd01ad26460a09eb171f2793a3109bfdbd))
+- **dafny:** don't recalculate RSA key on every decrypt ([#1448](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1448)) ([f318912](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f318912eb419140c8e1cb4694b9bf69c3e239967))
+- **dafny:** Make HasSubString generic ([#1549](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1549)) ([6a1017f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6a1017f5f87f39bb8eace9e92704bb2b64b16e65))
+- **dafny:** more using uint64 instead of nat ([#1490](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1490)) ([571e3c5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/571e3c564f1989e3c3df1fd765f4939326bc0893))
+- **dafny:** store privateKey in RawRSAKeyring because some Java code needs it ([#1450](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1450)) ([1c29322](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c293223efb2bc9643a45e482daf37a87eeae197))
+- **dafny:** support for memory size constraints ([#1481](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1481)) ([8d2c2b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8d2c2b5d4e20f89d7bfad75fcd4d149894d390f3))
+- **dafny:** update UInt and MemoryMath as needed for DB-ESDK ([#1488](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1488)) ([49e596b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/49e596b1cd8ce446d0b82074ff48ba0406aa8995))
 
 ### Maintenance -- Java
 
-* **java:** migrate to Nexus Central for Maven publishing ([#1553](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1553)) ([7d2fcd3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7d2fcd392eb31f023669e309ab9fc557394e932b))
+- **java:** migrate to Nexus Central for Maven publishing ([#1553](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1553)) ([7d2fcd3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7d2fcd392eb31f023669e309ab9fc557394e932b))
 
 ### Maintenance -- Go
 
-* **go:** implement missing MutableMap::content() ([#1519](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1519)) ([f033b91](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f033b915701eaa53d97019af61b96a51fed43483))
-* **go:** remove print statements from testLotsOfAdding ([#1468](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1468)) ([594383c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/594383c6fa1ed9bb286290a0b67814953c88eef0))
+- **go:** implement missing MutableMap::content() ([#1519](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1519)) ([f033b91](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f033b915701eaa53d97019af61b96a51fed43483))
+- **go:** remove print statements from testLotsOfAdding ([#1468](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1468)) ([594383c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/594383c6fa1ed9bb286290a0b67814953c88eef0))
 
 ### Maintenance -- Rust
 
-* **rust:** remove print statements from testLotsOfAdding  ([#1469](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1469)) ([9cf1dce](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9cf1dce985d86d83d393e46b7e78697ebda85d90))
-* **rust:** update smithy-dafny, use small-int feature ([#1437](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1437)) ([515995e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/515995e68400e56fc720412fe355e6965715136e))
+- **rust:** remove print statements from testLotsOfAdding ([#1469](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1469)) ([9cf1dce](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9cf1dce985d86d83d393e46b7e78697ebda85d90))
+- **rust:** update smithy-dafny, use small-int feature ([#1437](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1437)) ([515995e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/515995e68400e56fc720412fe355e6965715136e))
 
 ### Miscellaneous
 
-* add MemoryMath to Index.dfy ([#1484](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1484)) ([3196e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/3196e7d1e51fd6f1f31fca6d90c1c01d437ae830))
-* add MPL CI to principal of KmsKeyForRobbieOnly  ([#1528](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1528)) ([527f69d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/527f69d7c0eb2070406051047dcefbabadc374e4))
-* bump smithy-dafny to latest ([#1375](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1375)) ([d3e7916](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d3e79168a23381973fab90e0c11e5ec0fb8a37fd))
-* CFN for Restricted EC ([#1522](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1522)) ([391fa4c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/391fa4c1163b6722752169181219408660cc9e09))
-* CFN for two new roles to prove prefixing/defixing behavior ([#1538](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1538)) ([e810e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e810e7da19c5242435eb8b9c2a922c56d3a6a966))
-* CFN KMS GDK for HV-2 ([#1464](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1464)) ([cfbaa58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cfbaa58f8976c5d7ff5351c4957b9539fcac7e54))
-* **CI:** Allow local testing ([#1371](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1371)) ([fe18948](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fe189489ee0e21b3d12944673a9a1de756ee0bc9))
-* **CI:** Fix nightly build (mostly) ([#1540](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1540)) ([362ffc1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/362ffc1c8b5adb84af58e783dc5ef696ca103643))
-* **CI:** Fix nightly build workflow ([#1541](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1541)) ([48d69eb](https://github.com/aws/aws-cryptographic-material-providers-library/commit/48d69ebeda1e5167f26ebe8f87a51addab3d9afb))
-* Create KMS keys for HV1 & HV2 branch keys ([#1419](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1419)) ([2f0696d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2f0696dbd06e471f4b0bedea7239ec86ff39a79e))
-* Create Static Key Store table for storing static branch keys ([#1456](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1456)) ([96b8058](https://github.com/aws/aws-cryptographic-material-providers-library/commit/96b80589406a71503d2e87d2cff8968ac95abd71))
-* **dafny:** add tests for multiple utf8 ec entries ([#1424](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1424)) ([131ae58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/131ae583de02cb8352f8a96d69a9e1c84fea7338))
-* **dafny:** restore static test branch key id ([#1404](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1404)) ([377de79](https://github.com/aws/aws-cryptographic-material-providers-library/commit/377de796f001ae21f69ac0e10f57709d0e6fa1ef))
-* **deps:** Extend supported pyca version range ([#1556](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1556)) ([89f47aa](https://github.com/aws/aws-cryptographic-material-providers-library/commit/89f47aa50a98e211a1cb669f8d7294e340f07723))
-* improve performance ([#1286](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1286)) ([d808fd8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d808fd88df92acf64fb9ca0e7c652d72e05fa50a))
-* install polymorph dependencies in github workflows ([#1514](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1514)) ([eb68525](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eb68525d9430ea4dcc355e7f17bef7bafe069035))
-* **Python:** bump pyca to 44.0 ([#1555](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1555)) ([4f4cd87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4f4cd87c5bea38d523aac00947d6678b5ea2b3a0))
-* resolve rust warning ([#1394](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1394)) ([e2fe1a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fe1a4fc79d62c434bdbf72f8713b18ce74071a))
-* specify language in commits ([#1382](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1382)) ([ccd56cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ccd56cfae7c784e3c852d1f4bcc0b7127525f7d8))
+- add MemoryMath to Index.dfy ([#1484](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1484)) ([3196e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/3196e7d1e51fd6f1f31fca6d90c1c01d437ae830))
+- add MPL CI to principal of KmsKeyForRobbieOnly ([#1528](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1528)) ([527f69d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/527f69d7c0eb2070406051047dcefbabadc374e4))
+- bump smithy-dafny to latest ([#1375](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1375)) ([d3e7916](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d3e79168a23381973fab90e0c11e5ec0fb8a37fd))
+- CFN for Restricted EC ([#1522](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1522)) ([391fa4c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/391fa4c1163b6722752169181219408660cc9e09))
+- CFN for two new roles to prove prefixing/defixing behavior ([#1538](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1538)) ([e810e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e810e7da19c5242435eb8b9c2a922c56d3a6a966))
+- CFN KMS GDK for HV-2 ([#1464](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1464)) ([cfbaa58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cfbaa58f8976c5d7ff5351c4957b9539fcac7e54))
+- **CI:** Allow local testing ([#1371](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1371)) ([fe18948](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fe189489ee0e21b3d12944673a9a1de756ee0bc9))
+- **CI:** Fix nightly build (mostly) ([#1540](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1540)) ([362ffc1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/362ffc1c8b5adb84af58e783dc5ef696ca103643))
+- **CI:** Fix nightly build workflow ([#1541](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1541)) ([48d69eb](https://github.com/aws/aws-cryptographic-material-providers-library/commit/48d69ebeda1e5167f26ebe8f87a51addab3d9afb))
+- Create KMS keys for HV1 & HV2 branch keys ([#1419](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1419)) ([2f0696d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2f0696dbd06e471f4b0bedea7239ec86ff39a79e))
+- Create Static Key Store table for storing static branch keys ([#1456](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1456)) ([96b8058](https://github.com/aws/aws-cryptographic-material-providers-library/commit/96b80589406a71503d2e87d2cff8968ac95abd71))
+- **dafny:** add tests for multiple utf8 ec entries ([#1424](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1424)) ([131ae58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/131ae583de02cb8352f8a96d69a9e1c84fea7338))
+- **dafny:** restore static test branch key id ([#1404](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1404)) ([377de79](https://github.com/aws/aws-cryptographic-material-providers-library/commit/377de796f001ae21f69ac0e10f57709d0e6fa1ef))
+- **deps:** Extend supported pyca version range ([#1556](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1556)) ([89f47aa](https://github.com/aws/aws-cryptographic-material-providers-library/commit/89f47aa50a98e211a1cb669f8d7294e340f07723))
+- improve performance ([#1286](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1286)) ([d808fd8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d808fd88df92acf64fb9ca0e7c652d72e05fa50a))
+- install polymorph dependencies in github workflows ([#1514](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1514)) ([eb68525](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eb68525d9430ea4dcc355e7f17bef7bafe069035))
+- **Python:** bump pyca to 44.0 ([#1555](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1555)) ([4f4cd87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4f4cd87c5bea38d523aac00947d6678b5ea2b3a0))
+- resolve rust warning ([#1394](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1394)) ([e2fe1a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fe1a4fc79d62c434bdbf72f8713b18ce74071a))
+- specify language in commits ([#1382](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1382)) ([ccd56cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ccd56cfae7c784e3c852d1f4bcc0b7127525f7d8))
 
 ## [1.10.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.0...v1.10.1) (2025-03-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)
 
+This release is available in the following languages:
+- Java
+
 ### Fixes -- All Languages
 
 * **dafny:** bump Dafny libraries for JSON fix ([#1517](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1517)) ([d8679e5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d8679e517ae3bc3b074325f849b5cb6c252c8f18))

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.10.1")]
+[assembly: AssemblyVersion("1.11.0")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.10.1</Version>
+    <Version>1.11.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.10.1"
+version = "1.11.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.0"
 # Package testing
 
 [tool.poetry.group.test]

--- a/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.ComAmazonawsDynamodbTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Dynamodb"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.10.1</Version>
+    <Version>1.11.0</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.10.1")]
+[assembly: AssemblyVersion("1.11.0")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.10.1"
+version = "1.11.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.0"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.ComAmazonawsKmsTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Kms"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.10.1")]
+[assembly: AssemblyVersion("1.11.0")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.10.1</Version>
+    <Version>1.11.0</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.10.1"
+version = "1.11.0"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,257 +1,346 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.Wrappers]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Relations]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."Seq.MergeSort"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Math]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Seq]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.BoundedInts]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractUnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Unicode]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Functions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeEncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf8EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf16EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FileIO]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GeneralInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Mul]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivMod]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Power]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Logarithm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibraryInterop]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.UInt"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.Sequence"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.String"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibrary]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UUID]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UTF8]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.OsLang]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Time]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Streams]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Sorting]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.SortedSets]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.HexStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetOpt]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FloatCompare]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ConcurrentCall]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64Lemmas]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Actions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DafnyLibraries]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Writers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Cursors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Parsers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Seq"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Vectors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Errors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Grammar"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.Uint16StrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.SpecProperties"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
@@ -1,107 +1,142 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.MplManifestOptions]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllAlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedAbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTestVectorKeysTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.JSONHelpers]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyMaterial]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyrings]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyStores]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyringFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CmmFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeysVectorOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllHierarchy]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.EncryptionContextUtils]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKms]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAware]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAwareDiscovery]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsRsa]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsEcdh]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawAES]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawRSA]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllDefaultCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRequiredEncryptionContextCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllMulti]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WriteJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CompleteVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.ParseJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProvidersMain]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
@@ -1,4 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.9.2.0"
 [options_by_module.TestWrappedMaterialProvidersMain]
 legacy-module-names = false
+rust-sync = false

--- a/project.properties
+++ b/project.properties
@@ -7,4 +7,4 @@
 # And the Dotnet projects include and parse this file.
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.1
-mplVersion=1.10.1-SNAPSHOT
+mplVersion=1.11.0


### PR DESCRIPTION
## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)

### Fixes -- All Languages

* **dafny:** bump Dafny libraries for JSON fix ([#1517](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1517)) ([d8679e5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d8679e517ae3bc3b074325f849b5cb6c252c8f18))

### Maintenance -- All Languages

* **dafny:** BK fix to extract encryption context for branch key materials ([#1523](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1523)) ([95856ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/95856acd01ad26460a09eb171f2793a3109bfdbd))
* **dafny:** don't recalculate RSA key on every decrypt ([#1448](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1448)) ([f318912](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f318912eb419140c8e1cb4694b9bf69c3e239967))
* **dafny:** Make HasSubString generic ([#1549](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1549)) ([6a1017f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6a1017f5f87f39bb8eace9e92704bb2b64b16e65))
* **dafny:** more using uint64 instead of nat ([#1490](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1490)) ([571e3c5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/571e3c564f1989e3c3df1fd765f4939326bc0893))
* **dafny:** store privateKey in RawRSAKeyring because some Java code needs it ([#1450](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1450)) ([1c29322](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c293223efb2bc9643a45e482daf37a87eeae197))
* **dafny:** support for memory size constraints ([#1481](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1481)) ([8d2c2b5](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8d2c2b5d4e20f89d7bfad75fcd4d149894d390f3))
* **dafny:** update UInt and MemoryMath as needed for DB-ESDK ([#1488](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1488)) ([49e596b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/49e596b1cd8ce446d0b82074ff48ba0406aa8995))

### Maintenance -- Java

* **java:** migrate to Nexus Central for Maven publishing ([#1553](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1553)) ([7d2fcd3](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7d2fcd392eb31f023669e309ab9fc557394e932b))

### Maintenance -- Go

* **go:** implement missing MutableMap::content() ([#1519](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1519)) ([f033b91](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f033b915701eaa53d97019af61b96a51fed43483))
* **go:** remove print statements from testLotsOfAdding ([#1468](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1468)) ([594383c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/594383c6fa1ed9bb286290a0b67814953c88eef0))

### Maintenance -- Rust

* **rust:** remove print statements from testLotsOfAdding  ([#1469](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1469)) ([9cf1dce](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9cf1dce985d86d83d393e46b7e78697ebda85d90))
* **rust:** update smithy-dafny, use small-int feature ([#1437](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1437)) ([515995e](https://github.com/aws/aws-cryptographic-material-providers-library/commit/515995e68400e56fc720412fe355e6965715136e))

### Miscellaneous

* add MemoryMath to Index.dfy ([#1484](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1484)) ([3196e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/3196e7d1e51fd6f1f31fca6d90c1c01d437ae830))
* add MPL CI to principal of KmsKeyForRobbieOnly  ([#1528](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1528)) ([527f69d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/527f69d7c0eb2070406051047dcefbabadc374e4))
* bump smithy-dafny to latest ([#1375](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1375)) ([d3e7916](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d3e79168a23381973fab90e0c11e5ec0fb8a37fd))
* CFN for Restricted EC ([#1522](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1522)) ([391fa4c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/391fa4c1163b6722752169181219408660cc9e09))
* CFN for two new roles to prove prefixing/defixing behavior ([#1538](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1538)) ([e810e7d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e810e7da19c5242435eb8b9c2a922c56d3a6a966))
* CFN KMS GDK for HV-2 ([#1464](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1464)) ([cfbaa58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cfbaa58f8976c5d7ff5351c4957b9539fcac7e54))
* **CI:** Allow local testing ([#1371](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1371)) ([fe18948](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fe189489ee0e21b3d12944673a9a1de756ee0bc9))
* **CI:** Fix nightly build (mostly) ([#1540](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1540)) ([362ffc1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/362ffc1c8b5adb84af58e783dc5ef696ca103643))
* **CI:** Fix nightly build workflow ([#1541](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1541)) ([48d69eb](https://github.com/aws/aws-cryptographic-material-providers-library/commit/48d69ebeda1e5167f26ebe8f87a51addab3d9afb))
* Create KMS keys for HV1 & HV2 branch keys ([#1419](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1419)) ([2f0696d](https://github.com/aws/aws-cryptographic-material-providers-library/commit/2f0696dbd06e471f4b0bedea7239ec86ff39a79e))
* Create Static Key Store table for storing static branch keys ([#1456](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1456)) ([96b8058](https://github.com/aws/aws-cryptographic-material-providers-library/commit/96b80589406a71503d2e87d2cff8968ac95abd71))
* **dafny:** add tests for multiple utf8 ec entries ([#1424](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1424)) ([131ae58](https://github.com/aws/aws-cryptographic-material-providers-library/commit/131ae583de02cb8352f8a96d69a9e1c84fea7338))
* **dafny:** restore static test branch key id ([#1404](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1404)) ([377de79](https://github.com/aws/aws-cryptographic-material-providers-library/commit/377de796f001ae21f69ac0e10f57709d0e6fa1ef))
* **deps:** Extend supported pyca version range ([#1556](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1556)) ([89f47aa](https://github.com/aws/aws-cryptographic-material-providers-library/commit/89f47aa50a98e211a1cb669f8d7294e340f07723))
* improve performance ([#1286](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1286)) ([d808fd8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d808fd88df92acf64fb9ca0e7c652d72e05fa50a))
* install polymorph dependencies in github workflows ([#1514](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1514)) ([eb68525](https://github.com/aws/aws-cryptographic-material-providers-library/commit/eb68525d9430ea4dcc355e7f17bef7bafe069035))
* **Python:** bump pyca to 44.0 ([#1555](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1555)) ([4f4cd87](https://github.com/aws/aws-cryptographic-material-providers-library/commit/4f4cd87c5bea38d523aac00947d6678b5ea2b3a0))
* resolve rust warning ([#1394](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1394)) ([e2fe1a4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fe1a4fc79d62c434bdbf72f8713b18ce74071a))
* specify language in commits ([#1382](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1382)) ([ccd56cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ccd56cfae7c784e3c852d1f4bcc0b7127525f7d8))

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
chore: 1.11.0 [skip ci] 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
