### PR TITLE
chore(CI): add command to setup net in release workflow

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -28,8 +28,8 @@ phases:
       - curl https://services.gradle.org/distributions/gradle-7.6-all.zip -L -o gradle.zip
       - unzip -qq gradle.zip && rm gradle.zip
       - export PATH="$PWD/gradle-7.6/bin:$PATH"
-      - make -C StandardLibrary setup_net
       - cd aws-cryptographic-material-providers-library/
+      - make -C StandardLibrary setup_net
   pre_build:
     commands:
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-Release --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz

--- a/codebuild/release/validate-release.yml
+++ b/codebuild/release/validate-release.yml
@@ -27,8 +27,8 @@ phases:
       - curl https://services.gradle.org/distributions/gradle-7.6-all.zip -L -o gradle.zip
       - unzip -qq gradle.zip && rm gradle.zip
       - export PATH="$PWD/gradle-7.6/bin:$PATH"
-      - make -C StandardLibrary setup_net
       - cd aws-cryptographic-material-providers-library/
+      - make -C StandardLibrary setup_net
   pre_build:
     commands:
       # Get CI Creds to be able to call MPL TestVectors

--- a/codebuild/staging/release-staging.yml
+++ b/codebuild/staging/release-staging.yml
@@ -30,8 +30,8 @@ phases:
       - curl https://services.gradle.org/distributions/gradle-7.6-all.zip -L -o gradle.zip
       - unzip -qq gradle.zip && rm gradle.zip
       - export PATH="$PWD/gradle-7.6/bin:$PATH"
-      - make -C StandardLibrary setup_net
       - cd aws-cryptographic-material-providers-library/
+      - make -C StandardLibrary setup_net
   pre_build:
     commands:
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain crypto-tools-internal --domain-owner 587316601012 --region us-east-1 --query authorizationToken --output text)

--- a/codebuild/staging/validate-staging.yml
+++ b/codebuild/staging/validate-staging.yml
@@ -27,8 +27,8 @@ phases:
       - curl https://services.gradle.org/distributions/gradle-7.6-all.zip -L -o gradle.zip
       - unzip -qq gradle.zip && rm gradle.zip
       - export PATH="$PWD/gradle-7.6/bin:$PATH"
-      - make -C StandardLibrary setup_net
       - cd aws-cryptographic-material-providers-library/
+      - make -C StandardLibrary setup_net
   pre_build:
     commands:
       # Get published CA MPL jar


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This command was recently added in my CI [workflow](https://github.com/aws/aws-cryptographic-material-providers-library/blob/main/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml#L44) in setup smithy dafny deps workflow. Without this command, the codebuild for release ran:
```
2025-06-18T16:20:51.371Z | find ./dafny/**/src/ ./src/ -name 'Index.dfy' \| sed -e 's/^/include "/' -e 's/$/"/' \| dafny \
-- | --
  | 2025-06-18T16:20:51.371Z | translate java \
  | 2025-06-18T16:20:51.371Z | --stdin \
  | 2025-06-18T16:20:51.371Z | --no-verify \
  | 2025-06-18T16:20:51.371Z | --cores:2 \
  | 2025-06-18T16:20:51.371Z | Downloading https://services.gradle.org/distributions/gradle-7.6-bin.zip ...........10%............20%...........30%............40%............50%...........60%............70%............80%...........90%............100% \
  | 2025-06-18T16:20:51.371Z | --optimize-erasable-datatype-wrapper:false \
  | 2025-06-18T16:20:51.371Z | --unicode-char:false \
  | 2025-06-18T16:20:51.371Z | --function-syntax:3 \
  | 2025-06-18T16:20:51.371Z | --output runtimes/java/ImplementationFromDafny \
  | 2025-06-18T16:20:51.371Z | --allow-warnings --compile-suffix --legacy-data-constructors --legacy-module-names --allow-external-contracts \
  | 2025-06-18T16:20:51.371Z | \
  | 2025-06-18T16:20:51.371Z | \
  | 2025-06-18T16:20:51.371Z | --library:/codebuild/output/src3845613992/src/github.com/aws/aws-cryptographic-material-providers-library/StandardLibrary/src/Index.dfy \
  | 2025-06-18T16:20:51.371Z | \
  | 2025-06-18T16:20:51.371Z | \
  | 2025-06-18T16:20:51.371Z | --library:/codebuild/output/src3845613992/src/github.com/aws/aws-cryptographic-material-providers-library/AwsCryptographyPrimitives/src/Index.dfy --library:/codebuild/output/src3845613992/src/github.com/aws/aws-cryptographic-material-providers-library/ComAmazonawsKms/src/Index.dfy --library:/codebuild/output/src3845613992/src/github.com/aws/aws-cryptographic-material-providers-library/ComAmazonawsDynamodb/src/Index.dfy
  | 2025-06-18T16:20:51.371Z | find: ‘./src/’: No such file or directory
  | 2025-06-18T16:20:51.371Z | *** Error: Command-line argument 'Downloading' is neither a recognized option nor a filename with a supported extension (.dfy, .java).


```


### Squash/merge commit message, if applicable:

```
chore(CI): add command to setup net in release workflow file 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
