### PR TITLE
chore(java): set .NET version to 6.0 in release workflow

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -16,6 +16,7 @@ phases:
   install:
     runtime-versions:
       java: corretto8
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny

--- a/codebuild/release/validate-release.yml
+++ b/codebuild/release/validate-release.yml
@@ -15,6 +15,7 @@ phases:
   install:
     runtime-versions:
       java: $JAVA_ENV_VERSION
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny

--- a/codebuild/staging/release-staging.yml
+++ b/codebuild/staging/release-staging.yml
@@ -18,6 +18,7 @@ phases:
   install:
     runtime-versions:
       java: corretto8
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny

--- a/codebuild/staging/validate-staging.yml
+++ b/codebuild/staging/validate-staging.yml
@@ -15,6 +15,7 @@ phases:
   install:
     runtime-versions:
       java: $JAVA_ENV_VERSION
+      dotnet: 6.0
     commands:
       - cd ..
       # Get Dafny


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Setting because it defaults to 5.0 in the release.

Failure:
```
BUILD FAILED in 59s
209 | Makefile:34: warning: overriding recipe for target 'polymorph_rust'
210 | /codebuild/output/src1145001677/src/github.com/aws/aws-cryptographic-material-providers-library/smithy-dafny/SmithyDafnyMakefile.mk:457: warning: ignoring old recipe for target 'polymorph_rust'
211 | dotnet restore runtimes/net/
212 | Determining projects to restore...
213 | /root/.dotnet/sdk/5.0.408/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(141,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 6.0.  Either target .NET 5.0 or lower, or use a version of the .NET SDK that supports .NET 6.0. [/codebuild/output/src1145001677/src/github.com/aws/aws-cryptographic-material-providers-library/StandardLibrary/runtimes/net/STD.csproj]
214 | make: *** [/codebuild/output/src1145001677/src/github.com/aws/aws-cryptographic-material-providers-library/smithy-dafny/SmithyDafnyMakefile.mk:545: setup_net] Error 1
215 | make: Leaving directory '/codebuild/output/src1145001677/src/github.com/aws/aws-cryptographic-material-providers-library/StandardLibrary'
216 |  

```
### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
