### PR TITLE
chore(CD): update java codebuild to use Ubuntu standard:6.0 image

### DIFF
--- a/cfn/CB.yml
+++ b/cfn/CB.yml
@@ -55,7 +55,7 @@ Resources:
         Type: NO_CACHE
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
-        Image: "aws/codebuild/standard:5.0"
+        Image: "aws/codebuild/standard:6.0"
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: false
         Type: LINUX_CONTAINER

--- a/cfn/net/CB-Release.yml
+++ b/cfn/net/CB-Release.yml
@@ -53,7 +53,7 @@ Resources:
         Type: NO_CACHE
       Environment:
         ComputeType: BUILD_GENERAL1_LARGE
-        Image: "aws/codebuild/standard:5.0"
+        Image: "aws/codebuild/standard:6.0"
         ImagePullCredentialsType: CODEBUILD
         PrivilegedMode: false
         Type: LINUX_CONTAINER

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -13,7 +13,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto8
           JAVA_NUMERIC_VERSION: 8
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     - identifier: validate_staging_corretto8
       depend-on:
@@ -23,7 +23,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto8
           JAVA_NUMERIC_VERSION: 8
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     - identifier: validate_staging_corretto11
       depend-on:
@@ -33,7 +33,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto11
           JAVA_NUMERIC_VERSION: 11
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     - identifier: validate_staging_corretto17
       depend-on:
@@ -55,7 +55,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto8
           JAVA_NUMERIC_VERSION: 8
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     ## The following steps are expected to fail; since maven central takes time to
     ## update its index. For now, a manual download of the jar is needed to assert artifacts are
@@ -68,7 +68,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto8
           JAVA_NUMERIC_VERSION: 8
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     - identifier: validate_release_corretto11
       depend-on:
@@ -78,7 +78,7 @@ batch:
         variables:
           JAVA_ENV_VERSION: corretto11
           JAVA_NUMERIC_VERSION: 11
-        image: aws/codebuild/standard:5.0
+        image: aws/codebuild/standard:6.0
 
     - identifier: validate_release_corretto17
       depend-on:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Dotnet 6.0 is not supported in Ubuntu standard:5.0 but supported on Ubuntu standard:6.0 

https://docs.aws.amazon.com/codebuild/latest/userguide/available-runtimes.html
### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
