### PR TITLE
chore(dafny): update makefile to only use prettier 3.5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ format_java_misc-check:
 	npx prettier --plugin=prettier-plugin-java . --check
 
 setup_prettier:
-	npm i --no-save prettier@3 prettier-plugin-java@2.5
+	npm i --no-save prettier@3.5.3 prettier-plugin-java@2.5
 
 polymorph_code_gen:
 	$(foreach PROJECT, $(PROJECTS), \


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
prettier 3.6.0 has a breaking change.

### Squash/merge commit message, if applicable:

```
chore: update makefile to only use prettier 3.5.3
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
