### PR TITLE
chore(CI): add setup_net for python release workflow

### DIFF
--- a/AwsCryptographicMaterialProviders/codebuild/release-python/prod-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/prod-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/test-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/AwsCryptographicMaterialProviders/codebuild/release-python/validate.yml
+++ b/AwsCryptographicMaterialProviders/codebuild/release-python/validate.yml
@@ -15,6 +15,7 @@ phases:
       - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -25,6 +26,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Check out tests for release commit
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/AwsCryptographyPrimitives/codebuild/release-python/prod-release.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/prod-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/AwsCryptographyPrimitives/codebuild/release-python/test-release.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/test-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/AwsCryptographyPrimitives/codebuild/release-python/validate.yml
+++ b/AwsCryptographyPrimitives/codebuild/release-python/validate.yml
@@ -10,6 +10,7 @@ phases:
       - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -20,6 +21,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Check out tests for release commit
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsDynamodb/codebuild/release-python/prod-release.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/prod-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsDynamodb/codebuild/release-python/test-release.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/test-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsDynamodb/codebuild/release-python/validate.yml
+++ b/ComAmazonawsDynamodb/codebuild/release-python/validate.yml
@@ -10,6 +10,7 @@ phases:
       - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -20,6 +21,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Check out tests for release commit
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsKms/codebuild/release-python/prod-release.yml
+++ b/ComAmazonawsKms/codebuild/release-python/prod-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsKms/codebuild/release-python/test-release.yml
+++ b/ComAmazonawsKms/codebuild/release-python/test-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/ComAmazonawsKms/codebuild/release-python/validate.yml
+++ b/ComAmazonawsKms/codebuild/release-python/validate.yml
@@ -10,6 +10,7 @@ phases:
       - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -20,6 +21,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Check out tests for release commit
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/StandardLibrary/codebuild/release-python/prod-release.yml
+++ b/StandardLibrary/codebuild/release-python/prod-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/StandardLibrary/codebuild/release-python/test-release.yml
+++ b/StandardLibrary/codebuild/release-python/test-release.yml
@@ -14,6 +14,7 @@ phases:
       - pip install --upgrade pip
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -24,6 +25,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Assert that project version is the expected released version
       - git fetch --tags
       - git checkout $COMMIT_ID

--- a/StandardLibrary/codebuild/release-python/validate.yml
+++ b/StandardLibrary/codebuild/release-python/validate.yml
@@ -10,6 +10,7 @@ phases:
       - pip install "tox < 4.0"
     runtime-versions:
       python: latest
+      dotnet: 6.0
   pre_build:
     commands:
       # Get Dafny
@@ -20,6 +21,8 @@ phases:
       - export PATH="$PWD/dafny:$PATH"
       # Switch back to the main directory
       - cd aws-cryptographic-material-providers-library
+      # Without this the if-dafny-at-least command includes "Downloading ..." output
+      - make -C StandardLibrary setup_net
       # Check out tests for release commit
       - git fetch --tags
       - git checkout $COMMIT_ID


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Related PR https://github.com/aws/aws-cryptographic-material-providers-library/pull/1570
```
ind ./dafny/**/src/ ./src/ -name 'Index.dfy' | sed -e 's/^/include "/' -e 's/$/"/' | dafny \
translate py \
    --stdin \
    --no-verify \
    --cores:2 \
    Downloading https://services.gradle.org/distributions/gradle-7.6-bin.zip ...........10%............20%...........30%............40%............50%...........60%............70%............80%...........90%............100% \
    --optimize-erasable-datatype-wrapper:false \
    --unicode-char:false \
    --function-syntax:3 \
    --output runtimes/python/dafny_src \
    --allow-warnings --allow-external-contracts \
     \
    --python-module-name=smithy_dafny_standard_library.internaldafny.generated \
      \
      \
     \
    
find: ‘./dafny/**/src/’: No such file or directory
*** Error: Command-line argument 'Downloading' is neither a recognized option nor a filename with a supported extension (.dfy, .py).
make: *** [/codebuild/output/src1443334564/src/github.com/aws/aws-cryptographic-material-providers-library/smithy-dafny/SmithyDafnyMakefile.mk:204: transpile_implementation] Error 1
```

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
