### PR TITLE
chore(cfn): add trusted policy for optools mpl-python roles

### DIFF
--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -55,6 +55,8 @@ Resources:
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Java-service-role-release",
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-DotNet-service-role-release",
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-ESDK-DotNet-service-role-release",
+                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-prod-service-role"
+                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-test-service-role"
                     "arn:aws:iam::370957321024:role/ToolsDevelopment"
                   ]
                 }

--- a/cfn/CI.yaml
+++ b/cfn/CI.yaml
@@ -55,8 +55,8 @@ Resources:
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Java-service-role-release",
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-DotNet-service-role-release",
                     "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-ESDK-DotNet-service-role-release",
-                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-prod-service-role"
-                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-test-service-role"
+                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-prod-service-role",
+                    "arn:aws:iam::587316601012:role/service-role/codebuild-AWS-MPL-Python-test-service-role",
                     "arn:aws:iam::370957321024:role/ToolsDevelopment"
                   ]
                 }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

MPL-Python release validation failed with 
```
An error occurred (AccessDenied) when calling the AssumeRole operation: User: arn:aws:sts::587316601012:assumed-role/codebuild-AWS-MPL-Python-test-service-role/AWSCodeBuild-98c5174f-9905-4a31-b66f-a2f020c8add5 is not authorized to perform: sts:AssumeRole on resource: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
```

### Squash/merge commit message, if applicable:

```
chore(cfn): add trusted policy for optools mpl-python roles
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
