### PR TITLE
chore(go): update go test matrix and clean up setup 

### DIFF
--- a/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
+++ b/.github/actions/install_smithy_dafny_codegen_dependencies/action.yml
@@ -30,16 +30,6 @@ runs:
         python -m pip install --upgrade black
         python -m pip install --upgrade docformatter
 
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: "1.23"
-
-    - name: Install Go imports
-      shell: bash
-      run: |
-        go install golang.org/x/tools/cmd/goimports@latest
-
     # Without this the if-dafny-at-least command includes "Downloading ..." output
     - name: Arbitrary makefile target to force downloading Gradle
       shell: bash

--- a/.github/workflows/library_codegen.yml
+++ b/.github/workflows/library_codegen.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      
+
       - name: Install Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/library_codegen.yml
+++ b/.github/workflows/library_codegen.yml
@@ -61,6 +61,16 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Install Go imports
+        shell: bash
+        run: |
+          go install golang.org/x/tools/cmd/goimports@latest
 
       # even though we just installed dotnet 6, maybe dotnet 8 is out there somewhere
       - name: Create temporary global.json

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -28,7 +28,7 @@ jobs:
             AwsCryptographicMaterialProviders,
             TestVectorsAwsCryptographicMaterialProviders,
           ]
-        go-version: ["1.23"]
+        go-version: ["1.23", "1.24"]
         os: [
             # TODO fix Dafny-generated tests on Windows;
             # the sys.path workaround for generated Dafny doesn't work on Windows.


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- Adds Go 1.24 for CI to run test on. Note: We support minimum 1.23 and latest is 1.24.
- `install_smithy_dafny_codegen_dependencies` github actions runs Go installation for all the runtime but its only Go which needs this installation not all other language. So, remove Go installation from `install_smithy_dafny_codegen_dependencies` and put it in Go specific workflow only.

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
