### PR TITLE
chore(CI): send slack message on new GHI 

### DIFF
--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -1,11 +1,18 @@
 name: Issue Created Notification
 on:
+  push:
   issues:
     types: [opened, reopened]
   issue_comment:
     types: [created]
 
 jobs:
+  push-check:
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      message: "test"
+    secrets:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
   notify-issue:
     if: github.event_name == 'issues'
     uses: ./.github/workflows/slack-notification.yml

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -10,7 +10,7 @@ jobs:
   push-check:
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: "test message"
+      message: "test"
     secrets:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
   notify-issue:

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -12,12 +12,12 @@ jobs:
     with:
       message: "New github issue: ${{ github.event.issue.html_url }}"
     secrets:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
-        
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
+
   notify-comment:
     if: github.event_name == 'issue_comment'
     uses: ./.github/workflows/slack-notification.yml
     with:
       message: "New comment on issue: ${{ github.event.comment.html_url }}"
     secrets:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -1,0 +1,23 @@
+name: Issue Created Notification
+on:
+  issues:
+    types: [opened, reopened]
+  issue_comment:
+    types: [created]
+
+jobs:
+  notify-issue:
+    if: github.event_name == 'issues'
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      message: "New github issue: ${{ github.event.issue.html_url }}"
+    secrets:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
+        
+  notify-comment:
+    if: github.event_name == 'issue_comment'
+    uses: ./.github/workflows/slack-notification.yml
+    with:
+      message: "New comment on issue: ${{ github.event.comment.html_url }}"
+    secrets:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -10,7 +10,7 @@ jobs:
   push-check:
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: "test"
+      message: "test message"
     secrets:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
   notify-issue:

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -1,18 +1,11 @@
 name: Issue Created Notification
 on:
-  push:
   issues:
     types: [opened, reopened]
   issue_comment:
     types: [created]
 
 jobs:
-  push-check:
-    uses: ./.github/workflows/slack-notification.yml
-    with:
-      message: "test"
-    secrets:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
   notify-issue:
     if: github.event_name == 'issues'
     uses: ./.github/workflows/slack-notification.yml

--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event_name == 'issues'
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: "New github issue: ${{ github.event.issue.html_url }}"
+      message: "New github issue `${{ github.event.issue.title }}`. Link: ${{ github.event.issue.html_url }}"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
 
@@ -18,6 +18,6 @@ jobs:
     if: github.event_name == 'issue_comment'
     uses: ./.github/workflows/slack-notification.yml
     with:
-      message: "New comment on issue: ${{ github.event.comment.html_url }}"
+      message: "New comment on issue `${{ github.event.issue.title }}`. Link: ${{ github.event.comment.html_url }}"
     secrets:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -1,0 +1,24 @@
+name: Slack Notification
+on:
+  workflow_call:
+    inputs:
+      message:
+        required: true
+        type: string
+        description: "Message to send to Slack"
+    secrets:
+        SLACK_WEBHOOK_URL:
+            required: true
+            description: "Slack webhook URL"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send message to Slack
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          payload: |
+            {"message": "${{ inputs.message }}"}
+          webhook-type: webhook-trigger

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -7,9 +7,9 @@ on:
         type: string
         description: "Message to send to Slack"
     secrets:
-        SLACK_WEBHOOK_URL:
-            required: true
-            description: "Slack webhook URL"
+      SLACK_WEBHOOK_URL:
+        required: true
+        description: "Slack webhook URL"
 
 jobs:
   notify:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Workflow (which starts on [issue](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issues)) is only triggered when workflow is on default branch. But, to test if it works I have triggered on push the workflow in commit [535c19d](https://github.com/aws/aws-cryptographic-material-providers-library/pull/1632/commits/535c19dc032fe1324005d1a003673f3aa6e33bea).

My plan is to add everyone to the channel, once its merged and I test it.

### Squash/merge commit message, if applicable:

```
chore(CI): send slack message on new GHI 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
