### PR TITLE
chore(release): 1.7.6 [skip ci]

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/AwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -18,7 +18,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.5-SNAPSHOT"
+version = "1.7.6"
 description = "AWS Cryptographic Material Providers Library"
 
 java {

--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.7.5")]
+[assembly: AssemblyVersion("1.7.6")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.7.5</Version>
+      <Version>1.7.6</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.8.0"
+version = "1.7.6"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.7.6"
+aws-cryptography-internal-kms = "1.7.6"
+aws-cryptography-internal-dynamodb = "1.7.6"
+aws-cryptography-internal-primitives = "1.7.6"
 
 # Package testing
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
@@ -1,179 +1,238 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.AwsCryptographyKeyStoreTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyKeyStoreService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsArnParsing]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkMatchForDecrypt]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsUtils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStoreErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KmsArn]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Structure]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KMSKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DDBKeystoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateKeyStoreTable]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetKeys]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyKeyStoreOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyStore]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Materials]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Keyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkAreUnique]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Constants]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MaterialWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CanonicalEncryptionContext]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.IntermediateKeyWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.EdkWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.ErrorMessages]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StrictMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsDiscoveryKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DiscoveryMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkDiscoveryKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MrkAwareDiscoveryMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsMrkKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MrkAwareStrictMultiKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.LocalCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.SynchronizedLocalCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StormTracker]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.StormTrackingCMC]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CacheConstants]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsHierarchicalKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsRsaKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.EcdhEdkWrapping]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawECDHKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsKmsEcdhKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawAESKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RawRSAKeyring]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.CMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Defaults]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Commitment]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.DefaultClientSupplier]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utils]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.RequiredEncryptionContextCMM]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false
 [options_by_module.MaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+rust-sync = false

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.7.5")]
+[assembly: AssemblyVersion("1.7.6")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.8.0"
+version = "1.7.6"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.7.6"
 cryptography = "^43.0.1"
 
 # Package testing

--- a/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographyPrimitives/runtimes/python/src/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,59 +1,78 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.AwsCryptographyPrimitivesTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyPrimitivesService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternRandom]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Random]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AESEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ExternDigest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Digest]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHMAC]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.HKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedHKDF]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.Signature]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.KdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.RSAEncryption]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.ECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyPrimitivesOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AtomicPrimitives]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false
 [options_by_module.AesKdfCtr]
 legacy-module-names = false
 python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+rust-sync = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.7.6](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.5...v1.7.6) (2025-07-23)
+
+
+### Bug Fixes
+
+* **dotnet:** resolve AWS SDK Dependency to less than v4 ([#1629](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1629)) ([60e46cd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/60e46cde52b17c803b406324a1bc1cd1335c2b6b))
+
 ## [1.7.5](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.4...v1.7.5) (2025-01-30)
 
 This release is available in the following languages:

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.7.5")]
+[assembly: AssemblyVersion("1.7.6")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.8.0"
+version = "1.7.6"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.7.6"
 # Package testing
 
 [tool.poetry.group.test]

--- a/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsDynamodb/runtimes/python/src/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.ComAmazonawsDynamodbTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsDynamodbOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Dynamodb"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+rust-sync = false

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.7.5")]
+[assembly: AssemblyVersion("1.7.6")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.8.0"
+version = "1.7.6"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.7.6"
 
 # Package testing
 

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,14 +1,18 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.ComAmazonawsKmsTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractComAmazonawsKmsOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false
 [options_by_module."Com.Amazonaws.Kms"]
 legacy-module-names = false
 python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+rust-sync = false

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.7.5")]
+[assembly: AssemblyVersion("1.7.6")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.7.5</Version>
+    <Version>1.7.6</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.8.0"
+version = "1.7.6"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/StandardLibrary/runtimes/python/src/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,251 +1,334 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.Wrappers]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Relations]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."Seq.MergeSort"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Math]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Seq]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.BoundedInts]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractUnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Unicode]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Functions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeEncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf8EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Utf16EncodingForm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UnicodeStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FileIO]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GeneralInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.MulInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Mul]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternalsNonlinear]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ModInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivInternals]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DivMod]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Power]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Logarithm]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibraryInterop]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.UInt"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."StandardLibrary.String"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.StandardLibrary]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UUID]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.UTF8]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Time]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Streams]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Sorting]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.SortedSets]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.HexStrings]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.GetOpt]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.FloatCompare]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.ConcurrentCall]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Base64Lemmas]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.Actions]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module.DafnyLibraries]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Views.Writers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Lexers.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Cursors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Parsers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.ParametricEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str.CharStrEscaping"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Str"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Seq"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Utils.Vectors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Errors"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Grammar"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.Uint16StrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer.ByteStrConversion"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.Spec"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ConcreteSyntax.SpecProperties"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Serializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Core"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.Values"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.Deserializer"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.ZeroCopy.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false
 [options_by_module."JSON.API"]
 legacy-module-names = false
 python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/build.gradle.kts
@@ -20,7 +20,7 @@ var props = Properties().apply {
 var dafnyVersion = props.getProperty("dafnyVersion")
 
 group = "software.amazon.cryptography"
-version = "1.7.5-SNAPSHOT"
+version = "1.7.6"
 description = "TestAwsCryptographicMaterialProviders"
 
 java {

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/internaldafny/generated/dafny_src-py.dtr
@@ -1,104 +1,138 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.MplManifestOptions]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllAlgorithmSuites]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedAbstractAwsCryptographyMaterialProvidersService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProviders]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AwsCryptographyMaterialProvidersTestVectorKeysTypes]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AbstractAwsCryptographyMaterialProvidersTestVectorKeysService]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.JSONHelpers]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyMaterial]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyrings]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CreateStaticKeyStores]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyringFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CmmFromKeyDescription]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeysVectorOperations]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.KeyVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllHierarchy]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKms]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAware]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsMrkAwareDiscovery]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsRsa]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllKmsEcdh]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawAES]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawRSA]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRawECDH]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllDefaultCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllRequiredEncryptionContextCmm]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.AllMulti]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WriteJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.CompleteVectors]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.ParseJsonManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.TestManifests]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false
 [options_by_module.WrappedMaterialProvidersMain]
 legacy-module-names = false
 python-module-name = "aws_cryptography_materialproviders_test_vectors.internaldafny.generated"
+rust-sync = false

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/test/internaldafny/generated/dafny_test-py.dtr
@@ -1,4 +1,5 @@
 file_format_version = "1.0"
-dafny_version = "4.9.0.0"
+dafny_version = "4.10.0.0"
 [options_by_module.TestWrappedMaterialProvidersMain]
 legacy-module-names = false
+rust-sync = false


### PR DESCRIPTION
## [1.7.6](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.7.5...v1.7.6) (2025-07-23)

### Bug Fixes

* **dotnet:** resolve AWS SDK Dependency to less than v4 ([#1629](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1629)) ([60e46cd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/60e46cde52b17c803b406324a1bc1cd1335c2b6b))


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
