### PR TITLE
fix(dafny) Ensure branch key operation results are immediately visible to subsequent operations

### DIFF
--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
@@ -187,7 +187,7 @@ module DDBKeystoreOperations {
       Key := dynamoDbKey,
       TableName := tableName,
       AttributesToGet := None,
-      ConsistentRead :=  None,
+      ConsistentRead :=  true,
       ReturnConsumedCapacity := None,
       ProjectionExpression := None,
       ExpressionAttributeNames := None
@@ -255,7 +255,7 @@ module DDBKeystoreOperations {
       Key := dynamoDbKey,
       TableName := tableName,
       AttributesToGet := None,
-      ConsistentRead :=  None,
+      ConsistentRead :=  true,
       ReturnConsumedCapacity := None,
       ProjectionExpression := None,
       ExpressionAttributeNames := None
@@ -326,7 +326,7 @@ module DDBKeystoreOperations {
       Key := dynamoDbKey,
       TableName := tableName,
       AttributesToGet := None,
-      ConsistentRead :=  None,
+      ConsistentRead :=  true,
       ReturnConsumedCapacity := None,
       ProjectionExpression := None,
       ExpressionAttributeNames := None


### PR DESCRIPTION
### Issue #, if available:
CrypTool-5363

### Description of changes:
The results of performing either `Keystore.CreateKey` or `Keystore.VersionKey` on the hierarchical KMS keyring's keystore are not necessarily reflected in the results of calling `Keystore.GetActiveBranchKey`, `Keystore.GetBranchKeyVersion`, or `Keystore.GetBeaconKey` immediately after.  Consequently, performing either `Keystore.CreateKey` or `Keystore.VersionKey` and then immediately an encryption operation which uses the results of that keystore operation may result in an exception if there was no previous branch key or the operation using a now-inactive version of the branch key.

All of this is ultimately caused by the keystore not utilizing ConsistentReads for the DynamoDb GetItem operations -- all operations currently use the default (`ConsistentReads := None`), which is equivalent to it being set to `false`.

### Squash/merge commit message, if applicable:

```
fix(dafny): Ensure branch key operation results are immediately visible to subsequent operations
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
