### PR TITLE
chore(ci): update to not trigger workflow on PR comments

### DIFF
--- a/.github/workflows/issue-notification.yml
+++ b/.github/workflows/issue-notification.yml
@@ -15,7 +15,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_GHI }}
 
   notify-comment:
-    if: github.event_name == 'issue_comment'
+    if: github.event_name == 'issue_comment' && !github.event.issue.pull_request
     uses: ./.github/workflows/slack-notification.yml
     with:
       message: "New comment on issue `${{ github.event.issue.title }}`. Link: ${{ github.event.comment.html_url }}"


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

`issue_comment` gets triggered in issue comments and PR comments. Updating to not trigger in PR comments. See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
### Squash/merge commit message, if applicable:

```
chore(ci): update to not trigger workflow on PR comments 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
