### PR TITLE
fix: Updated pytz version range to include 2025 releases

### DIFF
--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -16,7 +16,7 @@ include = [
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-pytz = ">=2023.3.post1, <2025.0.0"
+pytz = ">=2023.3.post1, <2026.0.0"
 # TODO: Longer-term, write something to pull this in from the project's project.properties file
 DafnyRuntimePython = "4.9.0"
 


### PR DESCRIPTION
### Issue #, if available: #1641

### Description of changes:

Update the pytz version range to include 2025 releases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
