### PR TITLE
chore: 1.11.1 [skip ci]

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.11.0")]
+[assembly: AssemblyVersion("1.11.1")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.11.0</Version>
+      <Version>1.11.1</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.11.0"
+version = "1.11.1"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.1"
+aws-cryptography-internal-kms = "1.11.1"
+aws-cryptography-internal-dynamodb = "1.11.1"
+aws-cryptography-internal-primitives = "1.11.1"
 
 # Package testing
 

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.11.0")]
+[assembly: AssemblyVersion("1.11.1")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.0</Version>
+    <Version>1.11.1</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.11.0"
+version = "1.11.1"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["**/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.1"
 cryptography = ">=43.0.1, <46"
 
 # Package testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## [1.11.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.0...v1.11.1) (2025-07-29)
+
+### Maintenance -- All Languages
+
+* **dafny:** add Rust and Go to supported languages  ([#1492](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1492)) ([87ab402](https://github.com/aws/aws-cryptographic-material-providers-library/commit/87ab40233096739f2aa709fdcd948ce7452c7d04))
+* **dafny:** append our user agent in KMS client ([#1564](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1564)) ([03d03ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/03d03ac1f3591885bcc583efb988602ed129c3c5))
+* **dafny:** remove negative test for codebuild runner ([#1603](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1603)) ([8b45e40](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b45e40e9fa081e277837946e53836b308429ee8))
+
+### Maintenance -- Go
+
+* **go:** automate changelog for Go release  ([#1607](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1607)) ([f9eb8e0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f9eb8e0169139946ca46a7a4f0e30abdff7f976e))
+* **go:** update go test matrix and clean up setup  ([#1625](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1625)) ([6baa15c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6baa15ca499603dc4fe5501542d6f45b80d2c244))
+
+### Maintenance -- Rust
+
+* **rust:** update for new version of clippy ([#1606](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1606)) ([ec013f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ec013f6ba85d62ab41db48fec92baca85625e4b9))
+
+### Miscellaneous
+
+* 5 instead of 25 interop decrypt processes ([#1620](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1620)) ([d82696b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d82696b520681eaabd8f9a6c76bd9a208de4d6ac))
+* allow local testing for python ([#1598](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1598)) ([cbfa209](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cbfa209c0b9453fe633a3047e3dcd5db0e7fa728))
+* bump credentials to 2 hours, for python ([#1621](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1621)) ([69991da](https://github.com/aws/aws-cryptographic-material-providers-library/commit/69991da9a26e4422dfdeb8fc95a87a46b0bb3ccc))
+* **cfn:** add trusted policy for optools mpl-python roles ([#1602](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1602)) ([436d939](https://github.com/aws/aws-cryptographic-material-providers-library/commit/436d93951038e4107b36bf1f4cb3a0a5fb870577))
+* **CI:** fix daily CI and add slack notification to it ([#1647](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1647)) ([c546646](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c546646a719b54f880a8aeccc6a6489fcf332070))
+* **CI:** send slack message on new GHI  ([#1632](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1632)) ([e80b7ae](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e80b7aeaf691e956b6177aa24633681dcfe7a7ba))
+* **CI:** Test Rust on Dafny prerelease in nightly build ([#1623](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1623)) ([92070bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/92070bc128da94a24cfb84cc1fdd50f8ce5623f7))
+* **CI:** update to not trigger workflow on PR comments ([#1640](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1640)) ([c62e8cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c62e8cf0bf6b3efa0ae479a57b08ca91ef0306b6))
+* **deps:** bump slackapi/slack-github-action from 2.1.0 to 2.1.1 in /.github/workflows ([#1638](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1638)) ([40b643f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/40b643f9b95e325131a99c7ac5227d0851927980))
+* **Go:** Add Go release script and workflow to run it  ([#1562](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1562)) ([1c563bd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c563bdf8985f4c79b376929faa61496964dc69c))
+
 ## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)
 
 This release is available in the following languages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [1.11.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.0...v1.11.1) (2025-07-29)
 
+This release is available in the following languages:
+- Python
+
 ### Maintenance -- All Languages
 
 * **dafny:** add Rust and Go to supported languages  ([#1492](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1492)) ([87ab402](https://github.com/aws/aws-cryptographic-material-providers-library/commit/87ab40233096739f2aa709fdcd948ce7452c7d04))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,35 +3,36 @@
 ## [1.11.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.0...v1.11.1) (2025-07-29)
 
 This release is available in the following languages:
+
 - Python
 
 ### Maintenance -- All Languages
 
-* **dafny:** add Rust and Go to supported languages  ([#1492](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1492)) ([87ab402](https://github.com/aws/aws-cryptographic-material-providers-library/commit/87ab40233096739f2aa709fdcd948ce7452c7d04))
-* **dafny:** append our user agent in KMS client ([#1564](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1564)) ([03d03ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/03d03ac1f3591885bcc583efb988602ed129c3c5))
-* **dafny:** remove negative test for codebuild runner ([#1603](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1603)) ([8b45e40](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b45e40e9fa081e277837946e53836b308429ee8))
+- **dafny:** add Rust and Go to supported languages ([#1492](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1492)) ([87ab402](https://github.com/aws/aws-cryptographic-material-providers-library/commit/87ab40233096739f2aa709fdcd948ce7452c7d04))
+- **dafny:** append our user agent in KMS client ([#1564](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1564)) ([03d03ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/03d03ac1f3591885bcc583efb988602ed129c3c5))
+- **dafny:** remove negative test for codebuild runner ([#1603](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1603)) ([8b45e40](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b45e40e9fa081e277837946e53836b308429ee8))
 
 ### Maintenance -- Go
 
-* **go:** automate changelog for Go release  ([#1607](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1607)) ([f9eb8e0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f9eb8e0169139946ca46a7a4f0e30abdff7f976e))
-* **go:** update go test matrix and clean up setup  ([#1625](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1625)) ([6baa15c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6baa15ca499603dc4fe5501542d6f45b80d2c244))
+- **go:** automate changelog for Go release ([#1607](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1607)) ([f9eb8e0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f9eb8e0169139946ca46a7a4f0e30abdff7f976e))
+- **go:** update go test matrix and clean up setup ([#1625](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1625)) ([6baa15c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6baa15ca499603dc4fe5501542d6f45b80d2c244))
 
 ### Maintenance -- Rust
 
-* **rust:** update for new version of clippy ([#1606](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1606)) ([ec013f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ec013f6ba85d62ab41db48fec92baca85625e4b9))
+- **rust:** update for new version of clippy ([#1606](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1606)) ([ec013f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ec013f6ba85d62ab41db48fec92baca85625e4b9))
 
 ### Miscellaneous
 
-* 5 instead of 25 interop decrypt processes ([#1620](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1620)) ([d82696b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d82696b520681eaabd8f9a6c76bd9a208de4d6ac))
-* allow local testing for python ([#1598](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1598)) ([cbfa209](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cbfa209c0b9453fe633a3047e3dcd5db0e7fa728))
-* bump credentials to 2 hours, for python ([#1621](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1621)) ([69991da](https://github.com/aws/aws-cryptographic-material-providers-library/commit/69991da9a26e4422dfdeb8fc95a87a46b0bb3ccc))
-* **cfn:** add trusted policy for optools mpl-python roles ([#1602](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1602)) ([436d939](https://github.com/aws/aws-cryptographic-material-providers-library/commit/436d93951038e4107b36bf1f4cb3a0a5fb870577))
-* **CI:** fix daily CI and add slack notification to it ([#1647](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1647)) ([c546646](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c546646a719b54f880a8aeccc6a6489fcf332070))
-* **CI:** send slack message on new GHI  ([#1632](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1632)) ([e80b7ae](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e80b7aeaf691e956b6177aa24633681dcfe7a7ba))
-* **CI:** Test Rust on Dafny prerelease in nightly build ([#1623](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1623)) ([92070bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/92070bc128da94a24cfb84cc1fdd50f8ce5623f7))
-* **CI:** update to not trigger workflow on PR comments ([#1640](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1640)) ([c62e8cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c62e8cf0bf6b3efa0ae479a57b08ca91ef0306b6))
-* **deps:** bump slackapi/slack-github-action from 2.1.0 to 2.1.1 in /.github/workflows ([#1638](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1638)) ([40b643f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/40b643f9b95e325131a99c7ac5227d0851927980))
-* **Go:** Add Go release script and workflow to run it  ([#1562](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1562)) ([1c563bd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c563bdf8985f4c79b376929faa61496964dc69c))
+- 5 instead of 25 interop decrypt processes ([#1620](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1620)) ([d82696b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d82696b520681eaabd8f9a6c76bd9a208de4d6ac))
+- allow local testing for python ([#1598](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1598)) ([cbfa209](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cbfa209c0b9453fe633a3047e3dcd5db0e7fa728))
+- bump credentials to 2 hours, for python ([#1621](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1621)) ([69991da](https://github.com/aws/aws-cryptographic-material-providers-library/commit/69991da9a26e4422dfdeb8fc95a87a46b0bb3ccc))
+- **cfn:** add trusted policy for optools mpl-python roles ([#1602](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1602)) ([436d939](https://github.com/aws/aws-cryptographic-material-providers-library/commit/436d93951038e4107b36bf1f4cb3a0a5fb870577))
+- **CI:** fix daily CI and add slack notification to it ([#1647](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1647)) ([c546646](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c546646a719b54f880a8aeccc6a6489fcf332070))
+- **CI:** send slack message on new GHI ([#1632](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1632)) ([e80b7ae](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e80b7aeaf691e956b6177aa24633681dcfe7a7ba))
+- **CI:** Test Rust on Dafny prerelease in nightly build ([#1623](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1623)) ([92070bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/92070bc128da94a24cfb84cc1fdd50f8ce5623f7))
+- **CI:** update to not trigger workflow on PR comments ([#1640](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1640)) ([c62e8cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c62e8cf0bf6b3efa0ae479a57b08ca91ef0306b6))
+- **deps:** bump slackapi/slack-github-action from 2.1.0 to 2.1.1 in /.github/workflows ([#1638](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1638)) ([40b643f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/40b643f9b95e325131a99c7ac5227d0851927980))
+- **Go:** Add Go release script and workflow to run it ([#1562](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1562)) ([1c563bd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c563bdf8985f4c79b376929faa61496964dc69c))
 
 ## [1.11.0](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.10.1...v1.11.0) (2025-06-17)
 

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.11.0")]
+[assembly: AssemblyVersion("1.11.1")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.0</Version>
+    <Version>1.11.1</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.11.0"
+version = "1.11.1"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.1"
 # Package testing
 
 [tool.poetry.group.test]

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.0</Version>
+    <Version>1.11.1</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.11.0")]
+[assembly: AssemblyVersion("1.11.1")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.11.0"
+version = "1.11.1"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["**/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.1"
 
 # Package testing
 

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.11.0")]
+[assembly: AssemblyVersion("1.11.1")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.11.0</Version>
+    <Version>1.11.1</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.11.0"
+version = "1.11.1"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.1
 dafnyRustVersion=nightly-2025-01-30-7db1e5f
-mplVersion=1.11.0-SNAPSHOT
+mplVersion=1.11.1


### PR DESCRIPTION
## [1.11.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.0...v1.11.1) (2025-07-29)

### Maintenance -- All Languages

* **dafny:** add Rust and Go to supported languages  ([#1492](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1492)) ([87ab402](https://github.com/aws/aws-cryptographic-material-providers-library/commit/87ab40233096739f2aa709fdcd948ce7452c7d04))
* **dafny:** append our user agent in KMS client ([#1564](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1564)) ([03d03ac](https://github.com/aws/aws-cryptographic-material-providers-library/commit/03d03ac1f3591885bcc583efb988602ed129c3c5))
* **dafny:** remove negative test for codebuild runner ([#1603](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1603)) ([8b45e40](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b45e40e9fa081e277837946e53836b308429ee8))

### Maintenance -- Go

* **go:** automate changelog for Go release  ([#1607](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1607)) ([f9eb8e0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/f9eb8e0169139946ca46a7a4f0e30abdff7f976e))
* **go:** update go test matrix and clean up setup  ([#1625](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1625)) ([6baa15c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/6baa15ca499603dc4fe5501542d6f45b80d2c244))

### Maintenance -- Rust

* **rust:** update for new version of clippy ([#1606](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1606)) ([ec013f6](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ec013f6ba85d62ab41db48fec92baca85625e4b9))

### Miscellaneous

* 5 instead of 25 interop decrypt processes ([#1620](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1620)) ([d82696b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/d82696b520681eaabd8f9a6c76bd9a208de4d6ac))
* allow local testing for python ([#1598](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1598)) ([cbfa209](https://github.com/aws/aws-cryptographic-material-providers-library/commit/cbfa209c0b9453fe633a3047e3dcd5db0e7fa728))
* bump credentials to 2 hours, for python ([#1621](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1621)) ([69991da](https://github.com/aws/aws-cryptographic-material-providers-library/commit/69991da9a26e4422dfdeb8fc95a87a46b0bb3ccc))
* **cfn:** add trusted policy for optools mpl-python roles ([#1602](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1602)) ([436d939](https://github.com/aws/aws-cryptographic-material-providers-library/commit/436d93951038e4107b36bf1f4cb3a0a5fb870577))
* **CI:** fix daily CI and add slack notification to it ([#1647](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1647)) ([c546646](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c546646a719b54f880a8aeccc6a6489fcf332070))
* **CI:** send slack message on new GHI  ([#1632](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1632)) ([e80b7ae](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e80b7aeaf691e956b6177aa24633681dcfe7a7ba))
* **CI:** Test Rust on Dafny prerelease in nightly build ([#1623](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1623)) ([92070bc](https://github.com/aws/aws-cryptographic-material-providers-library/commit/92070bc128da94a24cfb84cc1fdd50f8ce5623f7))
* **CI:** update to not trigger workflow on PR comments ([#1640](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1640)) ([c62e8cf](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c62e8cf0bf6b3efa0ae479a57b08ca91ef0306b6))
* **deps:** bump slackapi/slack-github-action from 2.1.0 to 2.1.1 in /.github/workflows ([#1638](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1638)) ([40b643f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/40b643f9b95e325131a99c7ac5227d0851927980))
* **Go:** Add Go release script and workflow to run it  ([#1562](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1562)) ([1c563bd](https://github.com/aws/aws-cryptographic-material-providers-library/commit/1c563bdf8985f4c79b376929faa61496964dc69c))

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
