### PR TITLE
chore(go): Run daily CI with latest dependencies 

### DIFF
--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: |
           make purge_polymorph_code
-      
+
       - name: Use latest minor or patch releases
         # if: github.event_name == 'schedule'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -94,6 +94,13 @@ jobs:
         shell: bash
         run: |
           make purge_polymorph_code
+      
+      - name: Use latest minor or patch releases
+        # if: github.event_name == 'schedule'
+        working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
+        shell: bash
+        run: |
+          go get -u
 
       - name: Test ${{ matrix.library }}
         working-directory: ./${{ matrix.library }}

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -96,7 +96,7 @@ jobs:
           make purge_polymorph_code
 
       - name: Use latest minor or patch releases
-        if: github.event_name == 'schedule'
+        # if: github.event_name == 'schedule'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -96,7 +96,7 @@ jobs:
           make purge_polymorph_code
 
       - name: Use latest minor or patch releases
-        # if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -100,7 +100,7 @@ jobs:
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |
-          go get -u
+          go get -u ./...
 
       - name: Test ${{ matrix.library }}
         working-directory: ./${{ matrix.library }}

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -183,7 +183,7 @@ jobs:
           make purge_polymorph_code
 
       - name: Use latest minor or patch releases
-        # if: github.event_name == 'schedule'
+        if: matrix.language == 'go'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -182,6 +182,13 @@ jobs:
         run: |
           make purge_polymorph_code
 
+      - name: Use latest minor or patch releases
+        # if: github.event_name == 'schedule'
+        working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
+        shell: bash
+        run: |
+          go get -u
+
       - name: Setup gradle
         if: matrix.language == 'java'
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -187,7 +187,7 @@ jobs:
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |
-          go get -u
+          go get -u ./...
 
       - name: Setup gradle
         if: matrix.language == 'java'

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -183,7 +183,7 @@ jobs:
           make purge_polymorph_code
 
       - name: Use latest minor or patch releases
-        if: matrix.language == 'go'
+        if: matrix.language == 'go' && github.event_name == 'schedule'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -183,7 +183,7 @@ jobs:
           make purge_polymorph_code
 
       - name: Use latest minor or patch releases
-        if: matrix.language == 'go' && github.event_name == 'schedule'
+        if: matrix.language == 'go'
         working-directory: ./${{ matrix.library }}/runtimes/go/TestsFromDafny-go
         shell: bash
         run: |

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/go.mod
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/go.mod
@@ -34,10 +34,9 @@ require (
 )
 
 replace (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb v0.0.0 => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms v0.0.0 => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives v0.0.0 => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
-
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/
 )
 
-replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/go.mod
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/go.mod
@@ -2,16 +2,15 @@ module github.com/aws/aws-cryptographic-material-providers-library/releases/go/m
 
 go 1.23.0
 
-replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl v0.0.0 => ../ImplementationFromDafny-go
 
 replace (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb v0.0.0 => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms v0.0.0 => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives v0.0.0 => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
-
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl => ../ImplementationFromDafny-go
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/
 )
 
-replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/
 
 require (
 	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb v0.0.0

--- a/AwsCryptographyPrimitives/runtimes/go/TestsFromDafny-go/go.mod
+++ b/AwsCryptographyPrimitives/runtimes/go/TestsFromDafny-go/go.mod
@@ -2,7 +2,7 @@ module github.com/aws/aws-cryptographic-material-providers-library/releases/go/p
 
 go 1.23.0
 
-replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives v0.0.0 => ../ImplementationFromDafny-go
+replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives => ../ImplementationFromDafny-go
 
 require github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.2.0
 

--- a/StandardLibrary/runtimes/go/TestsFromDafny-go/go.mod
+++ b/StandardLibrary/runtimes/go/TestsFromDafny-go/go.mod
@@ -5,7 +5,7 @@ go 1.23.0
 replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../ImplementationFromDafny-go
 
 require (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.2.0
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.0.0
 	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.10.1
 )
 

--- a/StandardLibrary/runtimes/go/TestsFromDafny-go/go.mod
+++ b/StandardLibrary/runtimes/go/TestsFromDafny-go/go.mod
@@ -2,11 +2,11 @@ module github.com/aws/aws-cryptographic-material-providers-library/releases/go/s
 
 go 1.23.0
 
-replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.0.0 => ../ImplementationFromDafny-go
+replace github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../ImplementationFromDafny-go
 
 require (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.0.0
-	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.9.2
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library v0.2.0
+	github.com/dafny-lang/DafnyRuntimeGo/v4 v4.10.1
 )
 
 require github.com/google/uuid v1.6.0 // indirect

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/go.mod
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/go.mod
@@ -3,10 +3,10 @@ module github.com/aws/aws-cryptographic-material-providers-library/testvectors
 go 1.23.2
 
 replace (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb v0.0.0 => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms v0.0.0 => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl v0.0.0 => ../../../../AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives v0.0.0 => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl => ../../../../AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
 	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/
 )
 

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/go.mod
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/go.mod
@@ -3,12 +3,12 @@ module github.com/aws/aws-cryptographic-material-providers-library/testvectors/t
 go 1.23.2
 
 replace (
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb v0.0.0 => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms v0.0.0 => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl v0.0.0 => ../../../../AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives v0.0.0 => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/dynamodb => ../../../../ComAmazonawsDynamodb/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/kms => ../../../../ComAmazonawsKms/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/mpl => ../../../../AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/
+	github.com/aws/aws-cryptographic-material-providers-library/releases/go/primitives => ../../../../AwsCryptographyPrimitives/runtimes/go/ImplementationFromDafny-go/
 	github.com/aws/aws-cryptographic-material-providers-library/releases/go/smithy-dafny-standard-library => ../../../../StandardLibrary/runtimes/go/ImplementationFromDafny-go/
-	github.com/aws/aws-cryptographic-material-providers-library/testvectors v0.0.0 => ../ImplementationFromDafny-go
+	github.com/aws/aws-cryptographic-material-providers-library/testvectors => ../ImplementationFromDafny-go
 )
 
 require (


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

As a test, I ran it in pull request. See it download the latest dependencies to run the test with it: https://github.com/aws/aws-cryptographic-material-providers-library/actions/runs/16633485155/job/47068679820?pr=1652

Read about go get here: https://go.dev/ref/mod#go-get

### Squash/merge commit message, if applicable:

```
chore(go): Run daily CI with latest dependencies 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
