### PR TITLE
chore(go): update Go release script for ESDK and DB-ESDK

### DIFF
--- a/scripts/go-release-automation.sh
+++ b/scripts/go-release-automation.sh
@@ -69,7 +69,7 @@ run_release_script() {
   run_go_tools
 
   # Replacement directives are removed to get package from go pkg instead of local copy
-  # We need to copy `go.mod` otherwise without it this script will not work in the first release because all the go tools used in this script works only when there is a `go.mod` in the directory.
+  # We need to copy `go.mod` otherwise without it this script will not work in the first release because all the go tools used in this script works only when there is a `go.mod` in the directory. Removing replacement directives helps in automating copying of `go.mod`.
   echo "Removing all replace directives from go.mod..."
   go mod edit -json | jq -r '.Replace[].Old.Path' | xargs -n1 go mod edit -dropreplace
 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
- The plan is DB-ESDK, ESDK and MPL will use the script in MPL so that we don't have to maintain in 3 places. I need to remove the script that's already checked in DB-ESDK and make DB-ESDK use the script in MPL.

- Tested by triggering the workflow: https://github.com/aws/aws-cryptographic-material-providers-library/actions/runs/16627856159



### Squash/merge commit message, if applicable:

```
chore(go): update Go release script for ESDK and DB-ESDK
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
