### PR TITLE
chore(go): Update go release GHA to run in ubuntu 

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -18,7 +18,7 @@ jobs:
 
   go-release:
     needs: get-dafny-version
-    runs-on: macos-13
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -18,7 +18,7 @@ jobs:
 
   go-release:
     needs: get-dafny-version
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -18,7 +18,7 @@ jobs:
 
   go-release:
     needs: get-dafny-version
-    runs-on: ubuntu-latest
+    runs-on: macos-13
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
The reason I want to move to ubuntu is ubuntu is much faster then mac os runner. The jobs in mac os runner gets picked up late in the queue while ubuntu gets picked up sooner.

### Squash/merge commit message, if applicable:

```
chore(go): Update go release GHA to run in ubuntu 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
