### PR TITLE
chore(go): add go 1.25 to CI

### DIFF
--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -28,7 +28,7 @@ jobs:
             AwsCryptographicMaterialProviders,
             TestVectorsAwsCryptographicMaterialProviders,
           ]
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.23", "1.24", "1.25]
         os: [
             # TODO fix Dafny-generated tests on Windows;
             # the sys.path workaround for generated Dafny doesn't work on Windows.

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -28,7 +28,7 @@ jobs:
             AwsCryptographicMaterialProviders,
             TestVectorsAwsCryptographicMaterialProviders,
           ]
-        go-version: ["1.23", "1.24"]
+        go-version: ["1.23", "1.24", "1.25"]
         os: [
             # TODO fix Dafny-generated tests on Windows;
             # the sys.path workaround for generated Dafny doesn't work on Windows.

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -28,7 +28,7 @@ jobs:
             AwsCryptographicMaterialProviders,
             TestVectorsAwsCryptographicMaterialProviders,
           ]
-        go-version: ["1.23", "1.24", "1.25]
+        go-version: ["1.23", "1.24", "1.25"]
         os: [
             # TODO fix Dafny-generated tests on Windows;
             # the sys.path workaround for generated Dafny doesn't work on Windows.


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Go released go 1.25 on 2025-08-12. So, I am adding this test. On ORR, we had decided we will test against same version AWS SDK go does its test on. AWS SDK Go test against all the versions they support. They haven't added 1.25 to their matrix but they will soon.

### Squash/merge commit message, if applicable:

```
chore(go): add go 1.25 to CI 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
