### PR TITLE
chore(python): add user agent suffix to kms requests

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -372,6 +372,15 @@ module.exports = {
             ),
             countMatches: true,
           },
+
+          // Update the version in ComAmazonawsKms/src/Index.dfy DafnyUserAgentSuffix function
+          {
+            files: ["ComAmazonawsKms/src/Index.dfy"],
+            from: 'var version := ".*"',
+            to: 'var version := "${nextRelease.version}"',
+            results: [CheckResults("ComAmazonawsKms/src/Index.dfy")],
+            countMatches: true,
+          },
         ],
       },
     ],
@@ -389,6 +398,7 @@ module.exports = {
       {
         assets: [
           "CHANGELOG.md",
+          "ComAmazonawsKms/src/Index.dfy",
           ...Object.values(Runtimes).flatMap((r) => Object.keys(r)),
           ...Object.values(Runtimes.net).flatMap((r) => r.assemblyInfo),
           "**/runtimes/python/**/*.dtr",

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 import boto3
 import _dafny
 
@@ -24,15 +26,18 @@ class default__(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazon
     @staticmethod
     def KMSClient(boto_client = None, region = None):
         if boto_client is None:
+            # Generate user agent suffix: AwsCryptographicMPL/Python/{version}
+            runtime = _dafny.Seq("Python")
+            user_agent_suffix = _dafny.string_of(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.DafnyUserAgentSuffix(runtime))
+            
             if region is not None and region in get_available_aws_regions():
-                boto_config = Config(
-                    region_name=region
-                )
+                boto_config = Config(region_name=region, user_agent_extra=user_agent_suffix)
                 boto_client = boto3.client("kms", config=boto_config)
             else:
+                boto_config = Config(user_agent_extra=user_agent_suffix)
+                boto_client = boto3.client("kms", config=boto_config)
                 # If no region is provided,
                 # boto_client will use the default region provided by boto3
-                boto_client = boto3.client("kms")
                 region = boto_client.meta.region_name
         wrapped_client = KMSClientShim(boto_client, region)
         return Wrappers.Result_Success(wrapped_client)

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
@@ -35,9 +35,9 @@ class default__(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazon
                 boto_client = boto3.client("kms", config=boto_config)
             else:
                 boto_config = Config(user_agent_extra=user_agent_suffix)
-                boto_client = boto3.client("kms", config=boto_config)
                 # If no region is provided,
                 # boto_client will use the default region provided by boto3
+                boto_client = boto3.client("kms", config=boto_config)
                 region = boto_client.meta.region_name
         wrapped_client = KMSClientShim(boto_client, region)
         return Wrappers.Result_Success(wrapped_client)

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/Com_Amazonaws_Kms.py
@@ -26,19 +26,23 @@ class default__(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazon
     @staticmethod
     def KMSClient(boto_client = None, region = None):
         if boto_client is None:
-            # Generate user agent suffix: AwsCryptographicMPL/Python/{version}
-            runtime = _dafny.Seq("Python")
-            user_agent_suffix = _dafny.string_of(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.DafnyUserAgentSuffix(runtime))
-            
             if region is not None and region in get_available_aws_regions():
-                boto_config = Config(region_name=region, user_agent_extra=user_agent_suffix)
+                boto_config = Config(region_name=region)
                 boto_client = boto3.client("kms", config=boto_config)
             else:
-                boto_config = Config(user_agent_extra=user_agent_suffix)
                 # If no region is provided,
                 # boto_client will use the default region provided by boto3
-                boto_client = boto3.client("kms", config=boto_config)
+                boto_client = boto3.client("kms")
                 region = boto_client.meta.region_name
+
+        # Generate user agent suffix: AwsCryptographicMPL/Python/{version}
+        runtime = _dafny.Seq("Python")
+        user_agent_suffix = _dafny.string_of(aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.DafnyUserAgentSuffix(runtime))
+        if boto_client.meta.config.user_agent_extra is None:
+            boto_client.meta.config.user_agent_extra = user_agent_suffix
+        elif user_agent_suffix not in boto_client.meta.config.user_agent_extra:
+            boto_client.meta.config.user_agent_extra += " " + user_agent_suffix
+
         wrapped_client = KMSClientShim(boto_client, region)
         return Wrappers.Result_Success(wrapped_client)
     

--- a/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/__init__.py
+++ b/ComAmazonawsKms/runtimes/python/src/aws_cryptography_internal_kms/internaldafny/extern/__init__.py
@@ -1,3 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 from . import (
     Com_Amazonaws_Kms,
 )

--- a/ComAmazonawsKms/src/Index.dfy
+++ b/ComAmazonawsKms/src/Index.dfy
@@ -30,6 +30,7 @@ module {:extern "software.amazon.cryptography.services.kms.internaldafny"} Com.A
 
   function method DafnyUserAgentSuffix(runtime: string): string
   {
+    // This version is automatically updated by semantic-release
     var version := "1.11.0";
     "AwsCryptographicMPL/" + runtime + "/" + version
   }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

Before Change:
      
  `"userAgent": "Boto3/1.40.10 md/Botocore#1.40.10 ua/2.1 os/macos#24.5.0 md/arch#arm64 lang/python#3.12.11 md/pyimpl#CPython m/Z,b,D cfg/retry-mode#legacy Botocore/1.40.10"`

After Change

 `"userAgent": "Boto3/1.40.10 md/Botocore#1.40.10 ua/2.1 os/macos#24.5.0 md/arch#arm64 lang/python#3.12.11 md/pyimpl#CPython m/b,D,Z cfg/retry-mode#legacy Botocore/1.40.10 AwsCryptographicMPL/Python/1.11.0"`

### Squash/merge commit message, if applicable:

```
chore(python): add user agent suffix to kms requests
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
