### PR TITLE
chore: update changelog 1.11.2

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.MaterialProviders")]
 
 // This should be kept in sync with the version number in MPL.csproj
-[assembly: AssemblyVersion("1.11.1")]
+[assembly: AssemblyVersion("1.11.2")]

--- a/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
+++ b/AwsCryptographicMaterialProviders/runtimes/net/MPL.csproj
@@ -5,7 +5,7 @@
       <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
       <IsPackable>true</IsPackable>
       
-      <Version>1.11.1</Version>
+      <Version>1.11.2</Version>
       
       <AssemblyName>AWS.Cryptography.MaterialProviders</AssemblyName>
       <PackageId>AWS.Cryptography.MaterialProviders</PackageId>

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsDynamodbTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Dynamodb"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsKmsTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Kms"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,59 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.AwsCryptographyPrimitivesTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternRandom]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Random]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AESEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternDigest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Digest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Signature]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.KdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.RSAEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ECDH]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AtomicPrimitives]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AesKdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/docs/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsDynamodbTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Dynamodb"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsKmsTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Kms"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,59 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.AwsCryptographyPrimitivesTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternRandom]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Random]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AESEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternDigest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Digest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Signature]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.KdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.RSAEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ECDH]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AtomicPrimitives]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AesKdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py312-dafnytests/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsDynamodbTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Dynamodb"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsKmsTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Kms"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,59 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.AwsCryptographyPrimitivesTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternRandom]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Random]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AESEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternDigest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Digest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Signature]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.KdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.RSAEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ECDH]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AtomicPrimitives]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AesKdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographicMaterialProviders/runtimes/python/.tox/py313-dafnytests/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptographic-material-providers"
-version = "1.11.1"
+version = "1.11.2"
 description = "AWS Cryptographic Material Providers Library for Python"
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,10 +13,10 @@ readme = "README.rst"
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-aws-cryptography-internal-kms = {path = "../../../ComAmazonawsKms/runtimes/python"}
-aws-cryptography-internal-dynamodb = {path = "../../../ComAmazonawsDynamodb/runtimes/python"}
-aws-cryptography-internal-primitives = {path = "../../../AwsCryptographyPrimitives/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.2"
+aws-cryptography-internal-kms = "1.11.2"
+aws-cryptography-internal-dynamodb = "1.11.2"
+aws-cryptography-internal-primitives = "1.11.2"
 
 # Package testing
 

--- a/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
+++ b/AwsCryptographyPrimitives/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.AwsCryptographyPrimitives")]
 
 // This should be kept in sync with the version number in Crypto.csproj
-[assembly: AssemblyVersion("1.11.1")]
+[assembly: AssemblyVersion("1.11.2")]

--- a/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
+++ b/AwsCryptographyPrimitives/runtimes/net/Crypto.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.AwsCryptographyPrimitives</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.AwsCryptographyPrimitives</PackageId>

--- a/AwsCryptographyPrimitives/runtimes/python/.tox/build/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/AwsCryptographyPrimitives/runtimes/python/.tox/build/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-primitives"
-version = "1.11.1"
+version = "1.11.2"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -12,7 +12,7 @@ include = ["src/aws_cryptography_primitives/internaldafny/generated/*.py"]
 
 [tool.poetry.dependencies]
 python = "^3.11.0"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.2"
 cryptography = ">=43.0.1, <46"
 
 # Package testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## [1.11.2](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.1...v1.11.2) (2025-08-14)
+
+### Maintenance -- All Languages
+
+* **dafny:** add new SearchAndReplaceWhole and friends ([#1680](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1680)) ([74e98c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/74e98c10184c27bc57ba5b77386872466213f91f))
+
+### Maintenance -- Python
+
+* **python:** add user agent suffix to kms requests ([740fc32](https://github.com/aws/aws-cryptographic-material-providers-library/commit/740fc327d26a93595a61b6736f74a940fc8b60cd))
+* **python:** allow local testing ([#1651](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1651)) ([8b221c4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b221c41252d269e472b93e3a54e9ede06cf0adf))
+* **python:** exclude generated tests from project distribution ([#1627](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1627)) ([505eee0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/505eee0072d6390e23d855fa303dde9eeb031706))
+* **python:** tests for OpaqueWithText ([#1656](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1656)) ([25e1219](https://github.com/aws/aws-cryptographic-material-providers-library/commit/25e121974106cab8386058be29a1072cb50bb193))
+
+### Maintenance -- Go
+
+* **go:** Release dynamodb Go module 0.2.1 ([#1671](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1671)) ([c82e136](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c82e136380e00a3a300f24df805d5a66d4a52a4e))
+* **go:** Release kms Go module 0.2.1 ([#1667](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1667)) ([dd8cdf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/dd8cdf15dce8d918478cdeb8c81431318ef6eafd))
+* **go:** Release mpl Go module 0.2.1 ([#1672](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1672)) ([9bc43c0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9bc43c059fa820c298d8269b8fa316704c39703e))
+* **go:** Release primitives Go module 0.2.1 ([#1669](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1669)) ([dca265f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/dca265fbb3ad8818f53fe66af91bde496fe7c29b))
+* **go:** Release smithy-dafny-standard-library Go module 0.2.1  ([#1666](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1666)) ([fa3f98b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fa3f98b84cdd56be61d348c72d1b8701a17109a8))
+* **go:** remove create pull request step in go release workflow ([#1681](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1681)) ([7eafe88](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7eafe8890ef7626adc04c591a3359c80d7097d47))
+* **go:** update Go release script for ESDK and DB-ESDK ([#1653](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1653)) ([ea64f20](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ea64f204d18280ff7b30dfb17f5375e40bf0ff45))
+* **go:** update release script  ([#1676](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1676)) ([34f9689](https://github.com/aws/aws-cryptographic-material-providers-library/commit/34f96890eb966108e86fdda9840b17c916edd3c2))
+* **go:** Update release script to cd to right directory  ([#1679](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1679)) ([952c42f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/952c42f1c7cfad57cc9ea0115c2a0cb38164ead7))
+
+### Miscellaneous
+
+* bump smithy-dafny ([#1657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1657)) ([e2fb76c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fb76cfaf5201dab2fcfc145b46a688d27b2f14))
+* **CI:** update slack notification to include link of GHA run  ([#1659](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1659)) ([c6e2c20](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c6e2c203ec976c5488e08c79e378bc4b34da4b4e))
+* update semantic-release to bump user agent version ([8a1faf8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a1faf855663149a70b908b085a97c5a9d6bdf91))
+
 ## [1.11.1](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.0...v1.11.1) (2025-07-29)
 
 This release is available in the following languages:

--- a/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsDynamodb/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsDynamodb")]
 
 // This should be kept in sync with the version number in ComAmazonawsDynamodb.csproj
-[assembly: AssemblyVersion("1.11.1")]
+[assembly: AssemblyVersion("1.11.2")]

--- a/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
+++ b/ComAmazonawsDynamodb/runtimes/net/ComAmazonawsDynamodb.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsDynamodb</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsDynamodb</PackageId>

--- a/ComAmazonawsDynamodb/runtimes/python/.tox/build/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/ComAmazonawsDynamodb/runtimes/python/.tox/build/lib/python3.13/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
+++ b/ComAmazonawsDynamodb/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-dynamodb"
-version = "1.11.1"
+version = "1.11.2"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["src/aws_cryptography_internal_dynamodb/internaldafny/generated/*.py"
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.2"
 # Package testing
 
 [tool.poetry.group.test]

--- a/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
+++ b/ComAmazonawsKms/runtimes/net/AWS-KMS.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
     
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
 
     <AssemblyName>AWS.Cryptography.Internal.ComAmazonawsKms</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.ComAmazonawsKms</PackageId>

--- a/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
+++ b/ComAmazonawsKms/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.ComAmazonawsKms")]
 
 // This should be kept in sync with the version number in AWS-KMS.csproj
-[assembly: AssemblyVersion("1.11.1")]
+[assembly: AssemblyVersion("1.11.2")]

--- a/ComAmazonawsKms/runtimes/python/pyproject.toml
+++ b/ComAmazonawsKms/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-kms"
-version = "1.11.1"
+version = "1.11.2"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [
@@ -13,7 +13,7 @@ include = ["src/aws_cryptography_internal_kms/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 boto3 = "^1.35.42"
-aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
+aws-cryptography-internal-standard-library = "1.11.2"
 
 # Package testing
 

--- a/ComAmazonawsKms/src/Index.dfy
+++ b/ComAmazonawsKms/src/Index.dfy
@@ -31,7 +31,7 @@ module {:extern "software.amazon.cryptography.services.kms.internaldafny"} Com.A
   function method DafnyUserAgentSuffix(runtime: string): string
   {
     // This version is automatically updated by semantic-release
-    var version := "1.11.0";
+    var version := "1.11.2";
     "AwsCryptographicMPL/" + runtime + "/" + version
   }
 }

--- a/StandardLibrary/runtimes/net/AssemblyInfo.cs
+++ b/StandardLibrary/runtimes/net/AssemblyInfo.cs
@@ -3,4 +3,4 @@ using System.Reflection;
 [assembly: AssemblyTitle("AWS.Cryptography.Internal.StandardLibrary")]
 
 // This should be kept in sync with the version number in STD.csproj
-[assembly: AssemblyVersion("1.11.1")]
+[assembly: AssemblyVersion("1.11.2")]

--- a/StandardLibrary/runtimes/net/STD.csproj
+++ b/StandardLibrary/runtimes/net/STD.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>true</IsPackable>
   
-    <Version>1.11.1</Version>
+    <Version>1.11.2</Version>
     
     <AssemblyName>AWS.Cryptography.Internal.StandardLibrary</AssemblyName>
     <PackageId>AWS.Cryptography.Internal.StandardLibrary</PackageId>

--- a/StandardLibrary/runtimes/python/pyproject.toml
+++ b/StandardLibrary/runtimes/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-cryptography-internal-standard-library"
-version = "1.11.1"
+version = "1.11.2"
 description = ""
 authors = ["AWS Crypto Tools <aws-crypto-tools@amazon.com>"]
 packages = [

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptographic_material_providers/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,179 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.AwsCryptographyKeyStoreTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyKeyStoreOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyKeyStoreService]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsCryptographyMaterialProvidersTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsArnParsing]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsMrkMatchForDecrypt]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsUtils]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.KeyStoreErrorMessages]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.KmsArn]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Structure]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.KMSKeystoreOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.DDBKeystoreOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.CreateKeys]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.CreateKeyStoreTable]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.GetKeys]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsCryptographyKeyStoreOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.KeyStore]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyMaterialProvidersOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyMaterialProvidersService]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AlgorithmSuites]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Materials]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Keyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.CanonicalEncryptionContext]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.MaterialWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.IntermediateKeyWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.EdkWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.ErrorMessages]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.RawAESKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Constants]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.EcdhEdkWrapping]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.RawECDHKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.RawRSAKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsDiscoveryKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsEcdhKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.LocalCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.SynchronizedLocalCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.StormTracker]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.StormTrackingCMC]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.CacheConstants]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsHierarchicalKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsMrkDiscoveryKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsMrkKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsRsaKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.MultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsKmsMrkAreUnique]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.StrictMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.DiscoveryMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.MrkAwareDiscoveryMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.MrkAwareStrictMultiKeyring]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.CMM]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Defaults]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Commitment]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.DefaultCMM]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.DefaultClientSupplier]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.Utils]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.RequiredEncryptionContextCMM]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.AwsCryptographyMaterialProvidersOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"
+[options_by_module.MaterialProviders]
+legacy-module-names = false
+python-module-name = "aws_cryptographic_material_providers.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_internal_dynamodb/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsDynamodbTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsDynamodbOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Dynamodb"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_dynamodb.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_internal_kms/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,14 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.ComAmazonawsKmsTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module.AbstractComAmazonawsKmsOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"
+[options_by_module."Com.Amazonaws.Kms"]
+legacy-module-names = false
+python-module-name = "aws_cryptography_internal_kms.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/aws_cryptography_primitives/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,59 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.AwsCryptographyPrimitivesTypes]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AbstractAwsCryptographyPrimitivesService]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternRandom]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Random]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AESEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ExternDigest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Digest]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHMAC]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.HKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.WrappedHKDF]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.Signature]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.KdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.RSAEncryption]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.ECDH]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AwsCryptographyPrimitivesOperations]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AtomicPrimitives]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"
+[options_by_module.AesKdfCtr]
+legacy-module-names = false
+python-module-name = "aws_cryptography_primitives.internaldafny.generated"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/.venv/lib/python3.12/site-packages/smithy_dafny_standard_library/internaldafny/generated/dafny_src-py.dtr
@@ -1,0 +1,260 @@
+file_format_version = "1.0"
+dafny_version = "4.9.0.0"
+[options_by_module.Wrappers]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Relations]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."Seq.MergeSort"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Math]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Seq]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.BoundedInts]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.AbstractUnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Unicode]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Functions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeEncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf8EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Utf16EncodingForm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UnicodeStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FileIO]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GeneralInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.MulInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Mul]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternalsNonlinear]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ModInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivInternals]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DivMod]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Power]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Logarithm]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibraryInterop]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.UInt"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.MemoryMath"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.Sequence"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."StandardLibrary.String"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.StandardLibrary]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UUID]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.UTF8]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.OsLang]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Time]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Streams]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Sorting]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.SortedSets]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.HexStrings]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.GetOpt]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.FloatCompare]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.ConcurrentCall]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Base64Lemmas]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.Actions]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module.DafnyLibraries]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Views.Writers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Lexers.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Cursors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Parsers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.ParametricEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str.CharStrEscaping"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Str"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Seq"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Utils.Vectors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Errors"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Grammar"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.Uint16StrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer.ByteStrConversion"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.Spec"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ConcreteSyntax.SpecProperties"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Serializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Core"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.SequenceParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Sequences"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Strings"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Numbers"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ObjectParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Objects"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.ArrayParams"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Arrays"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Constants"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.Values"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.Deserializer"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.ZeroCopy.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"
+[options_by_module."JSON.API"]
+legacy-module-names = false
+python-module-name = "smithy_dafny_standard_library.internaldafny.generated"

--- a/project.properties
+++ b/project.properties
@@ -8,4 +8,4 @@
 dafnyVersion=4.9.0
 dafnyVerifyVersion=4.9.1
 dafnyRustVersion=nightly-2025-01-30-7db1e5f
-mplVersion=1.11.1-SNAPSHOT
+mplVersion=1.11.2


### PR DESCRIPTION
## [1.11.2](https://github.com/aws/aws-cryptographic-material-providers-library/compare/v1.11.1...v1.11.2) (2025-08-14)

### Maintenance -- All Languages

* **dafny:** add new SearchAndReplaceWhole and friends ([#1680](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1680)) ([74e98c1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/74e98c10184c27bc57ba5b77386872466213f91f))

### Maintenance -- Python

* **python:** add user agent suffix to kms requests ([740fc32](https://github.com/aws/aws-cryptographic-material-providers-library/commit/740fc327d26a93595a61b6736f74a940fc8b60cd))
* **python:** allow local testing ([#1651](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1651)) ([8b221c4](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8b221c41252d269e472b93e3a54e9ede06cf0adf))
* **python:** exclude generated tests from project distribution ([#1627](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1627)) ([505eee0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/505eee0072d6390e23d855fa303dde9eeb031706))
* **python:** tests for OpaqueWithText ([#1656](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1656)) ([25e1219](https://github.com/aws/aws-cryptographic-material-providers-library/commit/25e121974106cab8386058be29a1072cb50bb193))

### Maintenance -- Go

* **go:** Release dynamodb Go module 0.2.1 ([#1671](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1671)) ([c82e136](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c82e136380e00a3a300f24df805d5a66d4a52a4e))
* **go:** Release kms Go module 0.2.1 ([#1667](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1667)) ([dd8cdf1](https://github.com/aws/aws-cryptographic-material-providers-library/commit/dd8cdf15dce8d918478cdeb8c81431318ef6eafd))
* **go:** Release mpl Go module 0.2.1 ([#1672](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1672)) ([9bc43c0](https://github.com/aws/aws-cryptographic-material-providers-library/commit/9bc43c059fa820c298d8269b8fa316704c39703e))
* **go:** Release primitives Go module 0.2.1 ([#1669](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1669)) ([dca265f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/dca265fbb3ad8818f53fe66af91bde496fe7c29b))
* **go:** Release smithy-dafny-standard-library Go module 0.2.1  ([#1666](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1666)) ([fa3f98b](https://github.com/aws/aws-cryptographic-material-providers-library/commit/fa3f98b84cdd56be61d348c72d1b8701a17109a8))
* **go:** remove create pull request step in go release workflow ([#1681](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1681)) ([7eafe88](https://github.com/aws/aws-cryptographic-material-providers-library/commit/7eafe8890ef7626adc04c591a3359c80d7097d47))
* **go:** update Go release script for ESDK and DB-ESDK ([#1653](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1653)) ([ea64f20](https://github.com/aws/aws-cryptographic-material-providers-library/commit/ea64f204d18280ff7b30dfb17f5375e40bf0ff45))
* **go:** update release script  ([#1676](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1676)) ([34f9689](https://github.com/aws/aws-cryptographic-material-providers-library/commit/34f96890eb966108e86fdda9840b17c916edd3c2))
* **go:** Update release script to cd to right directory  ([#1679](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1679)) ([952c42f](https://github.com/aws/aws-cryptographic-material-providers-library/commit/952c42f1c7cfad57cc9ea0115c2a0cb38164ead7))

### Miscellaneous

* bump smithy-dafny ([#1657](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1657)) ([e2fb76c](https://github.com/aws/aws-cryptographic-material-providers-library/commit/e2fb76cfaf5201dab2fcfc145b46a688d27b2f14))
* **CI:** update slack notification to include link of GHA run  ([#1659](https://github.com/aws/aws-cryptographic-material-providers-library/issues/1659)) ([c6e2c20](https://github.com/aws/aws-cryptographic-material-providers-library/commit/c6e2c203ec976c5488e08c79e378bc4b34da4b4e))
* update semantic-release to bump user agent version ([8a1faf8](https://github.com/aws/aws-cryptographic-material-providers-library/commit/8a1faf855663149a70b908b085a97c5a9d6bdf91))

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
