### PR TITLE
chore: clean up submodule URL to remove embedded username

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/dafny-lang/libraries.git 
 [submodule "smithy-dafny"]
 	path = smithy-dafny
-	url = github.com/smithy-lang/smithy-dafny.git
+	url = https://github.com/smithy-lang/smithy-dafny.git
 [submodule "aws-encryption-sdk-specification"]
 	path = aws-encryption-sdk-specification
 	url = https://github.com/awslabs/aws-encryption-sdk-specification.git 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Removing hardcoded username from submodule URL. `smithy-dafny` is public repo so with or without embedded username git and github behaves the same

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
