### PR TITLE
chore: fix daily ci

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   getVersions:


### PR DESCRIPTION
library_java_tests needs id-token

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
