### PR TITLE
feat: Add GetBranchKeyVersions and GetCacheIdentifier APIs for customer

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -72,8 +72,11 @@ jobs:
 
       - name: Get release directory name
         id: release-dir
+        env:
+          PROJECT_NAME: ${{ github.event.inputs.project-name }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          RELEASE_DIR_NAME=$(./scripts/go-release-automation.sh get_release_dir_name "${{ github.event.inputs.project-name }}" "${{ github.event.inputs.version }}")
+          RELEASE_DIR_NAME=$(./scripts/go-release-automation.sh get_release_dir_name "$PROJECT_NAME" "$VERSION")
           echo "releaseDirName=$RELEASE_DIR_NAME" >> $GITHUB_OUTPUT
 
       - name: Generate a changelog
@@ -83,9 +86,12 @@ jobs:
           args: --bump -u --prepend releases/go/${{ steps.release-dir.outputs.releaseDirName }}/CHANGELOG.md
 
       - name: Run Go release automation script
+        env:
+          PROJECT_NAME: ${{ github.event.inputs.project-name }}
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           chmod +x ./scripts/go-release-automation.sh
-          ./scripts/go-release-automation.sh run_release_script ${{ github.event.inputs.project-name }} ${{ github.event.inputs.version }}
+          ./scripts/go-release-automation.sh run_release_script "$PROJECT_NAME" "$VERSION"
 
       - name: print diff between development and release directory
         run: |

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/AwsCryptographyMaterialProvidersTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/AwsCryptographyMaterialProvidersTypes.dfy
@@ -15,7 +15,7 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
   import AwsCryptographyPrimitivesTypes
   import ComAmazonawsDynamodbTypes
   import ComAmazonawsKmsTypes
-  // Generic helpers for verification of mock/unit tests.
+    // Generic helpers for verification of mock/unit tests.
   datatype DafnyCallEvent<I, O> = DafnyCallEvent(input: I, output: O)
 
   // Begin Generated Types

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/AwsCryptographyMaterialProvidersTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/AwsCryptographyMaterialProvidersTypes.dfy
@@ -15,7 +15,7 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
   import AwsCryptographyPrimitivesTypes
   import ComAmazonawsDynamodbTypes
   import ComAmazonawsKmsTypes
-    // Generic helpers for verification of mock/unit tests.
+  // Generic helpers for verification of mock/unit tests.
   datatype DafnyCallEvent<I, O> = DafnyCallEvent(input: I, output: O)
 
   // Begin Generated Types
@@ -71,6 +71,7 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
       ValidAlgorithmSuiteInfo := [];
       ValidateCommitmentPolicyOnEncrypt := [];
       ValidateCommitmentPolicyOnDecrypt := [];
+      GetCacheIdentifier := [];
     }
     ghost var CreateAwsKmsKeyring: seq<DafnyCallEvent<CreateAwsKmsKeyringInput, Result<IKeyring, Error>>>
     ghost var CreateAwsKmsDiscoveryKeyring: seq<DafnyCallEvent<CreateAwsKmsDiscoveryKeyringInput, Result<IKeyring, Error>>>
@@ -101,6 +102,7 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
     ghost var ValidAlgorithmSuiteInfo: seq<DafnyCallEvent<AlgorithmSuiteInfo, Result<(), Error>>>
     ghost var ValidateCommitmentPolicyOnEncrypt: seq<DafnyCallEvent<ValidateCommitmentPolicyOnEncryptInput, Result<(), Error>>>
     ghost var ValidateCommitmentPolicyOnDecrypt: seq<DafnyCallEvent<ValidateCommitmentPolicyOnDecryptInput, Result<(), Error>>>
+    ghost var GetCacheIdentifier: seq<DafnyCallEvent<GetCacheIdentifierInput, Result<GetCacheIdentifierOutput, Error>>>
   }
   trait {:termination false} IAwsCryptographicMaterialProvidersClient
   {
@@ -727,6 +729,25 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
     function method ValidateCommitmentPolicyOnDecrypt ( input: ValidateCommitmentPolicyOnDecryptInput )
       : (output: Result<(), Error>)
     // Functions that are transparent do not need ensures
+
+    predicate GetCacheIdentifierEnsuresPublicly(input: GetCacheIdentifierInput , output: Result<GetCacheIdentifierOutput, Error>)
+    // The public method to be called by library consumers
+    method GetCacheIdentifier ( input: GetCacheIdentifierInput )
+      returns (output: Result<GetCacheIdentifierOutput, Error>)
+      requires
+        && ValidState()
+        && input.keyring.ValidState()
+        && input.keyring.Modifies !! {History}
+      modifies Modifies - {History} ,
+               input.keyring.Modifies ,
+               History`GetCacheIdentifier
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History} ,
+                input.keyring.Modifies
+      ensures
+        && ValidState()
+      ensures GetCacheIdentifierEnsuresPublicly(input, output)
+      ensures History.GetCacheIdentifier == old(History.GetCacheIdentifier) + [DafnyCallEvent(input, output)]
 
   }
   class IBranchKeyIdSupplierCallHistory {
@@ -1384,6 +1405,14 @@ module {:extern "software.amazon.cryptography.materialproviders.internaldafny.ty
     nameonly expiryTime: PositiveLong ,
     nameonly messagesUsed: PositiveInteger ,
     nameonly bytesUsed: PositiveInteger
+  )
+  datatype GetCacheIdentifierInput = | GetCacheIdentifierInput (
+    nameonly keyring: IKeyring ,
+    nameonly branchKeyId: string ,
+    nameonly branchKeyVersion: Option<string> := Option.None
+  )
+  datatype GetCacheIdentifierOutput = | GetCacheIdentifierOutput (
+    nameonly identifier: seq<uint8>
   )
   datatype GetClientInput = | GetClientInput (
     nameonly region: Region
@@ -2492,6 +2521,30 @@ abstract module AbstractAwsCryptographyMaterialProvidersService
       Operations.ValidateCommitmentPolicyOnDecrypt(config, input)
     }
 
+    predicate GetCacheIdentifierEnsuresPublicly(input: GetCacheIdentifierInput , output: Result<GetCacheIdentifierOutput, Error>)
+    {Operations.GetCacheIdentifierEnsuresPublicly(input, output)}
+    // The public method to be called by library consumers
+    method GetCacheIdentifier ( input: GetCacheIdentifierInput )
+      returns (output: Result<GetCacheIdentifierOutput, Error>)
+      requires
+        && ValidState()
+        && input.keyring.ValidState()
+        && input.keyring.Modifies !! {History}
+      modifies Modifies - {History} ,
+               input.keyring.Modifies ,
+               History`GetCacheIdentifier
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History} ,
+                input.keyring.Modifies
+      ensures
+        && ValidState()
+      ensures GetCacheIdentifierEnsuresPublicly(input, output)
+      ensures History.GetCacheIdentifier == old(History.GetCacheIdentifier) + [DafnyCallEvent(input, output)]
+    {
+      output := Operations.GetCacheIdentifier(config, input);
+      History.GetCacheIdentifier := History.GetCacheIdentifier + [DafnyCallEvent(input, output)];
+    }
+
   }
 }
 abstract module AbstractAwsCryptographyMaterialProvidersOperations {
@@ -3110,4 +3163,23 @@ abstract module AbstractAwsCryptographyMaterialProvidersOperations {
   function method ValidateCommitmentPolicyOnDecrypt ( config: InternalConfig , input: ValidateCommitmentPolicyOnDecryptInput )
     : (output: Result<(), Error>)
   // Functions that are transparent do not need ensures
+
+
+  predicate GetCacheIdentifierEnsuresPublicly(input: GetCacheIdentifierInput , output: Result<GetCacheIdentifierOutput, Error>)
+  // The private method to be refined by the library developer
+
+
+  method GetCacheIdentifier ( config: InternalConfig , input: GetCacheIdentifierInput )
+    returns (output: Result<GetCacheIdentifierOutput, Error>)
+    requires
+      && ValidInternalConfig?(config)
+      && input.keyring.ValidState()
+    modifies ModifiesInternalConfig(config) ,
+             input.keyring.Modifies
+    // Dafny will skip type parameters when generating a default decreases clause.
+    decreases ModifiesInternalConfig(config) ,
+              input.keyring.Modifies
+    ensures
+      && ValidInternalConfig?(config)
+    ensures GetCacheIdentifierEnsuresPublicly(input, output)
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/material-provider.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/Model/material-provider.smithy
@@ -72,11 +72,43 @@ service AwsCryptographicMaterialProviders {
     // Commitment
     ValidateCommitmentPolicyOnEncrypt,
     ValidateCommitmentPolicyOnDecrypt,
+
+    // Cache Utilities
+    GetCacheIdentifier,
   ],
   errors: [AwsCryptographicMaterialProvidersException],
 }
 
 structure MaterialProvidersConfig {}
+
+// Cache Utilities
+
+@documentation("Computes the cache entry identifier used internally by the Hierarchical Keyring. Requires the keyring to be a Hierarchical Keyring.")
+operation GetCacheIdentifier {
+  input: GetCacheIdentifierInput,
+  output: GetCacheIdentifierOutput
+}
+
+@documentation("Inputs for computing a cache identifier.")
+structure GetCacheIdentifierInput {
+  @required
+  @documentation("The Hierarchical Keyring whose internal state is used to compute the cache identifier.")
+  keyring: KeyringReference,
+
+  @required
+  @documentation("The branch key identifier.")
+  branchKeyId: String,
+
+  @documentation("The branch key version. If provided, computes the decrypt-path cache identifier. If omitted, computes the encrypt-path cache identifier.")
+  branchKeyVersion: String,
+}
+
+@documentation("Outputs for computing a cache identifier.")
+structure GetCacheIdentifierOutput {
+  @required
+  @documentation("The computed cache entry identifier.")
+  identifier: Blob,
+}
 
 // Errors
 

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
@@ -964,7 +964,7 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
   method GetCacheIdentifier(config: InternalConfig, input: GetCacheIdentifierInput)
     returns (output: Result<GetCacheIdentifierOutput, Error>)
   {
-    // The keyring must be a Hierarchical Keyring
+      // The keyring must be a Hierarchical Keyring
     :- Need(
       input.keyring is AwsKmsHierarchicalKeyring.AwsKmsHierarchicalKeyring,
       Types.AwsCryptographicMaterialProvidersException(
@@ -975,8 +975,8 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
 
     var branchKeyIdUtf8 :- UTF8.Encode(input.branchKeyId)
     .MapFailure(e => Types.AwsCryptographicMaterialProvidersException(
-      message := "Could not UTF-8 Encode Branch Key ID: " + e
-    ));
+                    message := "Could not UTF-8 Encode Branch Key ID: " + e
+                  ));
 
     if input.branchKeyVersion.Some? {
       // Decrypt-path cache ID

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/AwsCryptographyMaterialProvidersOperations.dfy
@@ -958,4 +958,37 @@ module AwsCryptographyMaterialProvidersOperations refines AbstractAwsCryptograph
     Success(())
   }
 
+  predicate GetCacheIdentifierEnsuresPublicly(input: GetCacheIdentifierInput, output: Result<GetCacheIdentifierOutput, Error>)
+  {true}
+
+  method GetCacheIdentifier(config: InternalConfig, input: GetCacheIdentifierInput)
+    returns (output: Result<GetCacheIdentifierOutput, Error>)
+  {
+    // The keyring must be a Hierarchical Keyring
+    :- Need(
+      input.keyring is AwsKmsHierarchicalKeyring.AwsKmsHierarchicalKeyring,
+      Types.AwsCryptographicMaterialProvidersException(
+        message := "GetCacheIdentifier requires a Hierarchical Keyring.")
+    );
+
+    var hkr := input.keyring as AwsKmsHierarchicalKeyring.AwsKmsHierarchicalKeyring;
+
+    var branchKeyIdUtf8 :- UTF8.Encode(input.branchKeyId)
+    .MapFailure(e => Types.AwsCryptographicMaterialProvidersException(
+      message := "Could not UTF-8 Encode Branch Key ID: " + e
+    ));
+
+    if input.branchKeyVersion.Some? {
+      // Decrypt-path cache ID
+      var cacheId := hkr.ComputeDecryptCacheId(branchKeyIdUtf8, input.branchKeyVersion.value);
+      var id :- cacheId;
+      output := Success(GetCacheIdentifierOutput(identifier := id));
+    } else {
+      // Encrypt-path cache ID
+      var cacheId := hkr.GetActiveCacheId(input.branchKeyId, branchKeyIdUtf8, config.crypto);
+      var id :- cacheId;
+      output := Success(GetCacheIdentifierOutput(identifier := id));
+    }
+  }
+
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -563,8 +563,8 @@ module AwsKmsHierarchicalKeyring {
       var identifier := resourceId + NULL_BYTE + scopeId + NULL_BYTE + partitionIdBytes + NULL_BYTE + suffix;
 
       var maybeCacheDigest := Digest.Digest(Crypto.DigestInput(
-        digestAlgorithm := hashAlgorithm, message := identifier
-      ));
+                                              digestAlgorithm := hashAlgorithm, message := identifier
+                                            ));
       var cacheDigest :- maybeCacheDigest.MapFailure(e => Types.AwsCryptographyPrimitives(e));
 
       return Success(cacheDigest);

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographicMaterialProviders/src/Keyrings/AwsKms/AwsKmsHierarchicalKeyring.dfy
@@ -544,6 +544,31 @@ module AwsKmsHierarchicalKeyring {
         return Success(getCacheOutput.value.materials.BranchKey);
       }
     }
+
+    method ComputeDecryptCacheId(branchKeyIdUtf8: seq<uint8>, branchKeyVersion: string)
+      returns (res: Result<seq<uint8>, Types.Error>)
+      requires ValidState()
+    {
+      var hashAlgorithm := Crypto.DigestAlgorithm.SHA_384;
+      var resourceId : seq<uint8> := RESOURCE_ID_HIERARCHICAL_KEYRING;
+      var scopeId : seq<uint8> := SCOPE_ID_DECRYPT;
+
+      :- Need(
+        UTF8.IsASCIIString(branchKeyVersion),
+        E("Unable to represent version as an ASCII string.")
+      );
+      var versionBytes :- UTF8.Encode(branchKeyVersion).MapFailure(e => Types.AwsCryptographicMaterialProvidersException(message := e));
+
+      var suffix : seq<uint8> := logicalKeyStoreNameBytes + NULL_BYTE + branchKeyIdUtf8 + NULL_BYTE + versionBytes;
+      var identifier := resourceId + NULL_BYTE + scopeId + NULL_BYTE + partitionIdBytes + NULL_BYTE + suffix;
+
+      var maybeCacheDigest := Digest.Digest(Crypto.DigestInput(
+        digestAlgorithm := hashAlgorithm, message := identifier
+      ));
+      var cacheDigest :- maybeCacheDigest.MapFailure(e => Types.AwsCryptographyPrimitives(e));
+
+      return Success(cacheDigest);
+    }
   }
 
   method DeriveEncryptionKeyFromBranchKey(

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -11,7 +11,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
   import opened UTF8
   import ComAmazonawsDynamodbTypes
   import ComAmazonawsKmsTypes
-  // Generic helpers for verification of mock/unit tests.
+    // Generic helpers for verification of mock/unit tests.
   datatype DafnyCallEvent<I, O> = DafnyCallEvent(input: I, output: O)
 
   // Begin Generated Types

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/AwsCryptographyKeyStoreTypes.dfy
@@ -11,7 +11,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
   import opened UTF8
   import ComAmazonawsDynamodbTypes
   import ComAmazonawsKmsTypes
-    // Generic helpers for verification of mock/unit tests.
+  // Generic helpers for verification of mock/unit tests.
   datatype DafnyCallEvent<I, O> = DafnyCallEvent(input: I, output: O)
 
   // Begin Generated Types
@@ -28,6 +28,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     nameonly encryptionContext: EncryptionContext ,
     nameonly branchKey: Secret
   )
+  type BranchKeyMaterialsList = seq<BranchKeyMaterials>
   datatype CreateKeyInput = | CreateKeyInput (
     nameonly branchKeyIdentifier: Option<string> := Option.None ,
     nameonly encryptionContext: Option<EncryptionContext> := Option.None
@@ -64,6 +65,13 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
   datatype GetBranchKeyVersionOutput = | GetBranchKeyVersionOutput (
     nameonly branchKeyMaterials: BranchKeyMaterials
   )
+  datatype GetBranchKeyVersionsInput = | GetBranchKeyVersionsInput (
+    nameonly branchKeyIdentifier: string ,
+    nameonly count: int32
+  )
+  datatype GetBranchKeyVersionsOutput = | GetBranchKeyVersionsOutput (
+    nameonly branchKeyMaterials: BranchKeyMaterialsList
+  )
   datatype GetKeyStoreInfoOutput = | GetKeyStoreInfoOutput (
     nameonly keyStoreId: string ,
     nameonly keyStoreName: ComAmazonawsDynamodbTypes.TableName ,
@@ -82,6 +90,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
       GetActiveBranchKey := [];
       GetBranchKeyVersion := [];
       GetBeaconKey := [];
+      GetBranchKeyVersions := [];
     }
     ghost var GetKeyStoreInfo: seq<DafnyCallEvent<(), Result<GetKeyStoreInfoOutput, Error>>>
     ghost var CreateKeyStore: seq<DafnyCallEvent<CreateKeyStoreInput, Result<CreateKeyStoreOutput, Error>>>
@@ -90,6 +99,7 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
     ghost var GetActiveBranchKey: seq<DafnyCallEvent<GetActiveBranchKeyInput, Result<GetActiveBranchKeyOutput, Error>>>
     ghost var GetBranchKeyVersion: seq<DafnyCallEvent<GetBranchKeyVersionInput, Result<GetBranchKeyVersionOutput, Error>>>
     ghost var GetBeaconKey: seq<DafnyCallEvent<GetBeaconKeyInput, Result<GetBeaconKeyOutput, Error>>>
+    ghost var GetBranchKeyVersions: seq<DafnyCallEvent<GetBranchKeyVersionsInput, Result<GetBranchKeyVersionsOutput, Error>>>
   }
   trait {:termination false} IKeyStoreClient
   {
@@ -222,6 +232,21 @@ module {:extern "software.amazon.cryptography.keystore.internaldafny.types" } Aw
         && ValidState()
       ensures GetBeaconKeyEnsuresPublicly(input, output)
       ensures History.GetBeaconKey == old(History.GetBeaconKey) + [DafnyCallEvent(input, output)]
+
+    predicate GetBranchKeyVersionsEnsuresPublicly(input: GetBranchKeyVersionsInput , output: Result<GetBranchKeyVersionsOutput, Error>)
+    // The public method to be called by library consumers
+    method GetBranchKeyVersions ( input: GetBranchKeyVersionsInput )
+      returns (output: Result<GetBranchKeyVersionsOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetBranchKeyVersions
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetBranchKeyVersionsEnsuresPublicly(input, output)
+      ensures History.GetBranchKeyVersions == old(History.GetBranchKeyVersions) + [DafnyCallEvent(input, output)]
 
   }
   datatype KeyStoreConfig = | KeyStoreConfig (
@@ -492,6 +517,26 @@ abstract module AbstractAwsCryptographyKeyStoreService
       History.GetBeaconKey := History.GetBeaconKey + [DafnyCallEvent(input, output)];
     }
 
+    predicate GetBranchKeyVersionsEnsuresPublicly(input: GetBranchKeyVersionsInput , output: Result<GetBranchKeyVersionsOutput, Error>)
+    {Operations.GetBranchKeyVersionsEnsuresPublicly(input, output)}
+    // The public method to be called by library consumers
+    method GetBranchKeyVersions ( input: GetBranchKeyVersionsInput )
+      returns (output: Result<GetBranchKeyVersionsOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetBranchKeyVersions
+      // Dafny will skip type parameters when generating a default decreases clause.
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetBranchKeyVersionsEnsuresPublicly(input, output)
+      ensures History.GetBranchKeyVersions == old(History.GetBranchKeyVersions) + [DafnyCallEvent(input, output)]
+    {
+      output := Operations.GetBranchKeyVersions(config, input);
+      History.GetBranchKeyVersions := History.GetBranchKeyVersions + [DafnyCallEvent(input, output)];
+    }
+
   }
 }
 abstract module AbstractAwsCryptographyKeyStoreOperations {
@@ -612,4 +657,20 @@ abstract module AbstractAwsCryptographyKeyStoreOperations {
     ensures
       && ValidInternalConfig?(config)
     ensures GetBeaconKeyEnsuresPublicly(input, output)
+
+
+  predicate GetBranchKeyVersionsEnsuresPublicly(input: GetBranchKeyVersionsInput , output: Result<GetBranchKeyVersionsOutput, Error>)
+  // The private method to be refined by the library developer
+
+
+  method GetBranchKeyVersions ( config: InternalConfig , input: GetBranchKeyVersionsInput )
+    returns (output: Result<GetBranchKeyVersionsOutput, Error>)
+    requires
+      && ValidInternalConfig?(config)
+    modifies ModifiesInternalConfig(config)
+    // Dafny will skip type parameters when generating a default decreases clause.
+    decreases ModifiesInternalConfig(config)
+    ensures
+      && ValidInternalConfig?(config)
+    ensures GetBranchKeyVersionsEnsuresPublicly(input, output)
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/Model/KeyStore.smithy
@@ -57,7 +57,8 @@ service KeyStore {
     VersionKey,
     GetActiveBranchKey,
     GetBranchKeyVersion,
-    GetBeaconKey
+    GetBeaconKey,
+    GetBranchKeyVersions
   ],
   errors: [KeyStoreException]
 }
@@ -306,6 +307,34 @@ structure GetBeaconKeyOutput {
   @required
   @javadoc("The materials for the Beacon Key.")
   beaconKeyMaterials: BeaconKeyMaterials,
+}
+
+@javadoc("Queries DynamoDB for branch key versions and decrypts each via KMS.")
+operation GetBranchKeyVersions {
+  input: GetBranchKeyVersionsInput,
+  output: GetBranchKeyVersionsOutput
+}
+
+@javadoc("Inputs for getting branch key versions.")
+structure GetBranchKeyVersionsInput {
+  @required
+  @javadoc("The identifier of the Branch Key to get versions for.")
+  branchKeyIdentifier: String,
+
+  @required
+  @javadoc("The maximum number of versions to retrieve.")
+  count: Integer
+}
+
+@javadoc("Outputs for getting branch key versions.")
+structure GetBranchKeyVersionsOutput {
+  @required
+  @javadoc("The list of decrypted branch key materials.")
+  branchKeyMaterials: BranchKeyMaterialsList
+}
+
+list BranchKeyMaterialsList {
+  member: BranchKeyMaterials
 }
 
 list GrantTokenList {

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
@@ -180,11 +180,11 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
                 && i.0.Success?
                 && i.1.Success?
                 && DDB.IsValid_AttributeName(Structure.ENCRYPTION_CONTEXT_PREFIX + i.0.value)
-                   // Dafny requires that I *prove* that k == Encode(Decode(k))
-                   // Since UTF8 can be lossy in some implementations
-                   // this is the simplest...
-                   // A prove that ValidUTF8Seq(i) ==> Decode(i).Success?
-                   // would improve the situation
+                // Dafny requires that I *prove* that k == Encode(Decode(k))
+                // Since UTF8 can be lossy in some implementations
+                // this is the simplest...
+                // A prove that ValidUTF8Seq(i) ==> Decode(i).Success?
+                // would improve the situation
                 && var encoded := UTF8.Encode(i.0.value);
                 && encoded.Success?
                 && i.2 == encoded.value
@@ -322,7 +322,7 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
       config.ddbClient
     );
     output := Success(GetBranchKeyVersionsOutput(
-      branchKeyMaterials := materials
-    ));
+                        branchKeyMaterials := materials
+                      ));
   }
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/AwsCryptographyKeyStoreOperations.dfy
@@ -300,4 +300,29 @@ module AwsCryptographyKeyStoreOperations refines AbstractAwsCryptographyKeyStore
       config.ddbClient
     );
   }
+
+  predicate GetBranchKeyVersionsEnsuresPublicly(input: GetBranchKeyVersionsInput, output: Result<GetBranchKeyVersionsOutput, Error>)
+  {true}
+
+  method GetBranchKeyVersions(config: InternalConfig, input: GetBranchKeyVersionsInput)
+    returns (output: Result<GetBranchKeyVersionsOutput, Error>)
+  {
+    :- Need(
+      input.count > 0 && DDB.IsValid_PositiveIntegerObject(input.count),
+      Types.KeyStoreException(message := "GetBranchKeyVersions count must be a positive integer.")
+    );
+    var materials :- GetKeys.GetBranchKeyVersions(
+      input.branchKeyIdentifier,
+      input.count as DDB.PositiveIntegerObject,
+      config.ddbTableName,
+      config.logicalKeyStoreName,
+      config.kmsConfiguration,
+      config.grantTokens,
+      config.kmsClient,
+      config.ddbClient
+    );
+    output := Success(GetBranchKeyVersionsOutput(
+      branchKeyMaterials := materials
+    ));
+  }
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/DDBKeystoreOperations.dfy
@@ -377,4 +377,57 @@ module DDBKeystoreOperations {
     )
   }
 
+  method QueryBranchKeyVersionItems(
+    branchKeyIdentifier: string,
+    limit: DDB.PositiveIntegerObject,
+    tableName: DDB.TableName,
+    ddbClient: DDB.IDynamoDBClient
+  )
+    returns (output: Result<seq<DDB.AttributeMap>, Types.Error>)
+    requires DDB.IsValid_TableName(tableName)
+    requires ddbClient.ValidState()
+    modifies ddbClient.Modifies
+    ensures ddbClient.ValidState()
+  {
+    var queryInput := DDB.QueryInput(
+      TableName := tableName,
+      KeyConditionExpression := Some("#pk = :pkval AND begins_with(#sk, :skprefix)"),
+      ExpressionAttributeNames := Some(
+        map[
+          "#pk" := Structure.BRANCH_KEY_IDENTIFIER_FIELD,
+          "#sk" := Structure.TYPE_FIELD
+        ]
+      ),
+      ExpressionAttributeValues := Some(
+        map[
+          ":pkval" := DDB.AttributeValue.S(branchKeyIdentifier),
+          ":skprefix" := DDB.AttributeValue.S(Structure.BRANCH_KEY_TYPE_PREFIX)
+        ]
+      ),
+      Limit := Some(limit),
+      ScanIndexForward := Some(false),
+      IndexName := None,
+      Select := None,
+      AttributesToGet := None,
+      ConsistentRead := None,
+      KeyConditions := None,
+      QueryFilter := None,
+      ConditionalOperator := None,
+      ExclusiveStartKey := None,
+      ReturnConsumedCapacity := None,
+      ProjectionExpression := None,
+      FilterExpression := None
+    );
+
+    var maybeQuery := ddbClient.Query(queryInput);
+    var queryResponse :- maybeQuery
+    .MapFailure(e => Types.ComAmazonawsDynamodb(ComAmazonawsDynamodb := e));
+
+    if queryResponse.Items.None? || |queryResponse.Items.value| == 0 {
+      return Success([]);
+    }
+
+    return Success(queryResponse.Items.value);
+  }
+
 }

--- a/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
+++ b/AwsCryptographicMaterialProviders/dafny/AwsCryptographyKeyStore/src/GetKeys.dfy
@@ -549,4 +549,68 @@ module GetKeys {
   }
 
 
+  method GetBranchKeyVersions(
+    branchKeyIdentifier: string,
+    count: DDB.PositiveIntegerObject,
+    tableName: DDB.TableName,
+    logicalKeyStoreName: string,
+    kmsConfiguration: Types.KMSConfiguration,
+    grantTokens: KMS.GrantTokenList,
+    kmsClient: KMS.IKMSClient,
+    ddbClient: DDB.IDynamoDBClient
+  )
+    returns (output: Result<seq<Types.BranchKeyMaterials>, Types.Error>)
+    requires DDB.IsValid_TableName(tableName)
+    requires ddbClient.Modifies !! kmsClient.Modifies
+    requires kmsClient.ValidState() && ddbClient.ValidState()
+    modifies ddbClient.Modifies, kmsClient.Modifies
+    ensures kmsClient.ValidState() && ddbClient.ValidState()
+  {
+    var items :- DDBKeystoreOperations.QueryBranchKeyVersionItems(
+      branchKeyIdentifier,
+      count,
+      tableName,
+      ddbClient
+    );
+
+    var results: seq<Types.BranchKeyMaterials> := [];
+    var i: int := 0;
+
+    while i < |items|
+      invariant kmsClient.ValidState() && ddbClient.ValidState()
+    {
+      var item := items[i];
+
+      if Structure.VersionBranchKeyItem?(item) {
+        var encryptionContext := Structure.ToBranchKeyContext(item, logicalKeyStoreName);
+
+        if KMSKeystoreOperations.AttemptKmsOperation?(kmsConfiguration, encryptionContext)
+           && KmsArn.ValidKmsArn?(encryptionContext[Structure.KMS_FIELD])
+        {
+          var maybeBranchKey := KMSKeystoreOperations.DecryptKey(
+            encryptionContext,
+            item,
+            kmsConfiguration,
+            grantTokens,
+            kmsClient
+          );
+
+          if maybeBranchKey.Success? {
+            var maybeMaterials := Structure.ToBranchKeyMaterials(
+              encryptionContext,
+              maybeBranchKey.value.Plaintext.value
+            );
+            if maybeMaterials.Success? {
+              results := results + [maybeMaterials.value];
+            }
+          }
+        }
+      }
+
+      i := i + 1;
+    }
+
+    return Success(results);
+  }
+
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/WrappedAwsCryptographyKeyStoreService/shim.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/WrappedAwsCryptographyKeyStoreService/shim.go
@@ -15,7 +15,7 @@ type Shim struct {
 	client *awscryptographykeystoresmithygenerated.Client
 }
 
-func (_static *CompanionStruct_Default___) WrappedKeyStore(inputConfig AwsCryptographyKeyStoreTypes.KeyStoreConfig) Wrappers.Result {
+func  WrappedKeyStore(inputConfig AwsCryptographyKeyStoreTypes.KeyStoreConfig) Wrappers.Result {
 	var nativeConfig = awscryptographykeystoresmithygenerated.KeyStoreConfig_FromDafny(inputConfig)
 	var nativeClient, nativeError = awscryptographykeystoresmithygenerated.NewClient(nativeConfig)
 	if nativeError != nil {
@@ -85,4 +85,13 @@ func (shim *Shim) GetBeaconKey(input AwsCryptographyKeyStoreTypes.GetBeaconKeyIn
 		return Wrappers.Companion_Result_.Create_Failure_(awscryptographykeystoresmithygenerated.Error_ToDafny(native_error))
 	}
 	return Wrappers.Companion_Result_.Create_Success_(awscryptographykeystoresmithygenerated.GetBeaconKeyOutput_ToDafny(*native_response))
+}
+
+func (shim *Shim) GetBranchKeyVersions(input AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput) Wrappers.Result {
+	var native_request = awscryptographykeystoresmithygenerated.GetBranchKeyVersionsInput_FromDafny(input)
+	var native_response, native_error = shim.client.GetBranchKeyVersions(context.Background(), native_request)
+	if native_error != nil {
+		return Wrappers.Companion_Result_.Create_Failure_(awscryptographykeystoresmithygenerated.Error_ToDafny(native_error))
+	}
+	return Wrappers.Companion_Result_.Create_Success_(awscryptographykeystoresmithygenerated.GetBranchKeyVersionsOutput_ToDafny(*native_response))
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/WrappedAwsCryptographyMaterialProvidersService/shim.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/WrappedAwsCryptographyMaterialProvidersService/shim.go
@@ -16,7 +16,7 @@ type Shim struct {
 	client *awscryptographymaterialproviderssmithygenerated.Client
 }
 
-func (_static *CompanionStruct_Default___) WrappedMaterialProviders(inputConfig AwsCryptographyMaterialProvidersTypes.MaterialProvidersConfig) Wrappers.Result {
+func  WrappedMaterialProviders(inputConfig AwsCryptographyMaterialProvidersTypes.MaterialProvidersConfig) Wrappers.Result {
 	var nativeConfig = awscryptographymaterialproviderssmithygenerated.MaterialProvidersConfig_FromDafny(inputConfig)
 	var nativeClient, nativeError = awscryptographymaterialproviderssmithygenerated.NewClient(nativeConfig)
 	if nativeError != nil {
@@ -284,4 +284,13 @@ func (shim *Shim) ValidateCommitmentPolicyOnDecrypt(input AwsCryptographyMateria
 		return Wrappers.Companion_Result_.Create_Failure_(awscryptographymaterialproviderssmithygenerated.Error_ToDafny(native_error))
 	}
 	return Wrappers.Companion_Result_.Create_Success_(dafny.TupleOf())
+}
+
+func (shim *Shim) GetCacheIdentifier(input AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput) Wrappers.Result {
+	var native_request = awscryptographymaterialproviderssmithygenerated.GetCacheIdentifierInput_FromDafny(input)
+	var native_response, native_error = shim.client.GetCacheIdentifier(context.Background(), native_request)
+	if native_error != nil {
+		return Wrappers.Companion_Result_.Create_Failure_(awscryptographymaterialproviderssmithygenerated.Error_ToDafny(native_error))
+	}
+	return Wrappers.Companion_Result_.Create_Success_(awscryptographymaterialproviderssmithygenerated.GetCacheIdentifierOutput_ToDafny(*native_response))
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/api_client.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/api_client.go
@@ -162,3 +162,24 @@ func (client *Client) GetBeaconKey(ctx context.Context, params awscryptographyke
 	return &native_response, nil
 
 }
+
+func (client *Client) GetBranchKeyVersions(ctx context.Context, params awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput) (*awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput, error) {
+	err := params.Validate()
+	if err != nil {
+		opaqueErr := awscryptographykeystoresmithygeneratedtypes.OpaqueError{
+			ErrObject: err,
+		}
+		return nil, opaqueErr
+	}
+
+	var dafny_request AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput = GetBranchKeyVersionsInput_ToDafny(params)
+	var dafny_response = client.DafnyClient.GetBranchKeyVersions(dafny_request)
+
+	if dafny_response.Is_Failure() {
+		err := dafny_response.Dtor_error().(AwsCryptographyKeyStoreTypes.Error)
+		return nil, Error_FromDafny(err)
+	}
+	var native_response = GetBranchKeyVersionsOutput_FromDafny(dafny_response.Dtor_value().(AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput))
+	return &native_response, nil
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/to_dafny.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/to_dafny.go
@@ -109,6 +109,24 @@ func GetBranchKeyVersionOutput_ToDafny(nativeOutput awscryptographykeystoresmith
 
 }
 
+func GetBranchKeyVersionsInput_ToDafny(nativeInput awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput) AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput {
+
+	return func() AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput {
+
+		return AwsCryptographyKeyStoreTypes.Companion_GetBranchKeyVersionsInput_.Create_GetBranchKeyVersionsInput_(Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_ToDafny(nativeInput.BranchKeyIdentifier), Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_ToDafny(nativeInput.Count))
+	}()
+
+}
+
+func GetBranchKeyVersionsOutput_ToDafny(nativeOutput awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput) AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput {
+
+	return func() AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput {
+
+		return AwsCryptographyKeyStoreTypes.Companion_GetBranchKeyVersionsOutput_.Create_GetBranchKeyVersionsOutput_(Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_ToDafny(nativeOutput.BranchKeyMaterials))
+	}()
+
+}
+
 func GetKeyStoreInfoOutput_ToDafny(nativeOutput awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput) AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput {
 
 	return func() AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput {
@@ -476,6 +494,45 @@ func Aws_cryptography_keyStore_GetBranchKeyVersionInput_branchKeyVersion_ToDafny
 }
 
 func Aws_cryptography_keyStore_GetBranchKeyVersionOutput_branchKeyMaterials_ToDafny(input awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
+	return func() AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
+
+		return AwsCryptographyKeyStoreTypes.Companion_BranchKeyMaterials_.Create_BranchKeyMaterials_(Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_ToDafny(input.BranchKeyIdentifier), Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_ToDafny(input.BranchKeyVersion), Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_ToDafny(input.EncryptionContext), Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_ToDafny(input.BranchKey))
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_ToDafny(input string) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		return func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}()
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_ToDafny(input int32) int32 {
+	return func() int32 {
+
+		return input
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_ToDafny(input []awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		var fieldValue []interface{} = make([]interface{}, 0, len(input))
+		for _, val := range input {
+			element := Aws_cryptography_keyStore_BranchKeyMaterialsList_member_ToDafny(val)
+			fieldValue = append(fieldValue, element)
+		}
+		return dafny.SeqOf(fieldValue...)
+	}()
+}
+
+func Aws_cryptography_keyStore_BranchKeyMaterialsList_member_ToDafny(input awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
 	return func() AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
 
 		return AwsCryptographyKeyStoreTypes.Companion_BranchKeyMaterials_.Create_BranchKeyMaterials_(Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_ToDafny(input.BranchKeyIdentifier), Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_ToDafny(input.BranchKeyVersion), Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_ToDafny(input.EncryptionContext), Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_ToDafny(input.BranchKey))

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/to_native.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygenerated/to_native.go
@@ -80,6 +80,20 @@ func GetBranchKeyVersionOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreType
 
 }
 
+func GetBranchKeyVersionsInput_FromDafny(dafnyInput AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput) awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput {
+
+	return awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput{BranchKeyIdentifier: Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_FromDafny(dafnyInput.Dtor_branchKeyIdentifier()),
+		Count: Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_FromDafny(dafnyInput.Dtor_count()),
+	}
+
+}
+
+func GetBranchKeyVersionsOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput) awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput {
+
+	return awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput{BranchKeyMaterials: Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_FromDafny(dafnyOutput.Dtor_branchKeyMaterials())}
+
+}
+
 func GetKeyStoreInfoOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput) awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput {
 
 	return awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput{KeyStoreId: Aws_cryptography_keyStore_GetKeyStoreInfoOutput_keyStoreId_FromDafny(dafnyOutput.Dtor_keyStoreId()),
@@ -394,6 +408,39 @@ func Aws_cryptography_keyStore_GetBranchKeyVersionInput_branchKeyVersion_FromDaf
 	}()
 }
 func Aws_cryptography_keyStore_GetBranchKeyVersionOutput_branchKeyMaterials_FromDafny(input interface{}) awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
+	return awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials{BranchKeyIdentifier: Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyIdentifier()),
+		BranchKeyVersion:  Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyVersion()),
+		EncryptionContext: Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_encryptionContext()),
+		BranchKey:         Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKey()),
+	}
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_FromDafny(input interface{}) string {
+	return func() string {
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return s
+	}()
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_FromDafny(input interface{}) int32 {
+	return func() int32 {
+		var b = input.(int32)
+		return b
+	}()
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_FromDafny(input interface{}) []awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
+	fieldValue := make([]awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials, 0)
+	for i := dafny.Iterate(input.(dafny.Sequence)); ; {
+		val, ok := i()
+		if !ok {
+			break
+		}
+		fieldValue = append(fieldValue, Aws_cryptography_keyStore_BranchKeyMaterialsList_member_FromDafny(val))
+	}
+	return fieldValue
+}
+func Aws_cryptography_keyStore_BranchKeyMaterialsList_member_FromDafny(input interface{}) awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
 	return awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials{BranchKeyIdentifier: Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyIdentifier()),
 		BranchKeyVersion:  Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyVersion()),
 		EncryptionContext: Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_encryptionContext()),

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygeneratedtypes/types.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographykeystoresmithygeneratedtypes/types.go
@@ -213,6 +213,42 @@ func (input GetBranchKeyVersionOutput) Validate() error {
 	return nil
 }
 
+type GetBranchKeyVersionsInput struct {
+	BranchKeyIdentifier string
+
+	Count int32
+}
+
+func (input GetBranchKeyVersionsInput) Validate() error {
+
+	return nil
+}
+
+type GetBranchKeyVersionsOutput struct {
+	BranchKeyMaterials []BranchKeyMaterials
+}
+
+func (input GetBranchKeyVersionsOutput) Validate() error {
+	if input.BranchKeyMaterials == nil {
+		return fmt.Errorf("input.BranchKeyMaterials is required but has a nil value.")
+	}
+	if input.Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate() != nil {
+		return input.Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate()
+	}
+
+	return nil
+}
+
+func (input GetBranchKeyVersionsOutput) Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate() error {
+	for _, item := range input.BranchKeyMaterials {
+		if item.Validate() != nil {
+			return item.Validate()
+		}
+	}
+
+	return nil
+}
+
 type MRDiscovery struct {
 	Region string
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/api_client.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/api_client.go
@@ -651,3 +651,24 @@ func (client *Client) ValidateCommitmentPolicyOnDecrypt(ctx context.Context, par
 	}
 	return nil
 }
+
+func (client *Client) GetCacheIdentifier(ctx context.Context, params awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput) (*awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput, error) {
+	err := params.Validate()
+	if err != nil {
+		opaqueErr := awscryptographymaterialproviderssmithygeneratedtypes.OpaqueError{
+			ErrObject: err,
+		}
+		return nil, opaqueErr
+	}
+
+	var dafny_request AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput = GetCacheIdentifierInput_ToDafny(params)
+	var dafny_response = client.DafnyClient.GetCacheIdentifier(dafny_request)
+
+	if dafny_response.Is_Failure() {
+		err := dafny_response.Dtor_error().(AwsCryptographyMaterialProvidersTypes.Error)
+		return nil, Error_FromDafny(err)
+	}
+	var native_response = GetCacheIdentifierOutput_FromDafny(dafny_response.Dtor_value().(AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput))
+	return &native_response, nil
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_dafny.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_dafny.go
@@ -269,6 +269,24 @@ func AlgorithmSuiteInfo_ToDafny(nativeOutput awscryptographymaterialproviderssmi
 
 }
 
+func GetCacheIdentifierInput_ToDafny(nativeInput awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput) AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput {
+
+	return func() AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput {
+
+		return AwsCryptographyMaterialProvidersTypes.Companion_GetCacheIdentifierInput_.Create_GetCacheIdentifierInput_(Keyring_ToDafny(nativeInput.Keyring), Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_ToDafny(nativeInput.BranchKeyId), Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_ToDafny(nativeInput.BranchKeyVersion))
+	}()
+
+}
+
+func GetCacheIdentifierOutput_ToDafny(nativeOutput awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput) AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput {
+
+	return func() AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput {
+
+		return AwsCryptographyMaterialProvidersTypes.Companion_GetCacheIdentifierOutput_.Create_GetCacheIdentifierOutput_(Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_ToDafny(nativeOutput.Identifier))
+	}()
+
+}
+
 func InitializeDecryptionMaterialsInput_ToDafny(nativeInput awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput) AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput {
 
 	return func() AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput {
@@ -2469,6 +2487,43 @@ func Aws_cryptography_materialProviders_SymmetricSigningKeyList_member_ToDafny(i
 }
 
 func Aws_cryptography_materialProviders_GetAlgorithmSuiteInfoInput_binaryId_ToDafny(input []byte) dafny.Sequence {
+	return func() dafny.Sequence {
+		if input == nil {
+			return nil
+		}
+		return dafny.SeqOfBytes(input)
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_ToDafny(input string) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		return func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}()
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_ToDafny(input *string) Wrappers.Option {
+	return func() Wrappers.Option {
+		if input == nil {
+			return Wrappers.Companion_Option_.Create_None_()
+		}
+		return Wrappers.Companion_Option_.Create_Some_(func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(*input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}())
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_ToDafny(input []byte) dafny.Sequence {
 	return func() dafny.Sequence {
 		if input == nil {
 			return nil

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_native.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_native.go
@@ -282,6 +282,21 @@ func AlgorithmSuiteInfo_FromDafny(dafnyOutput AwsCryptographyMaterialProvidersTy
 
 }
 
+func GetCacheIdentifierInput_FromDafny(dafnyInput AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput) awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput {
+
+	return awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput{Keyring: Keyring_FromDafny(dafnyInput.Dtor_keyring()),
+		BranchKeyId:      Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_FromDafny(dafnyInput.Dtor_branchKeyId()),
+		BranchKeyVersion: Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_FromDafny(dafnyInput.Dtor_branchKeyVersion().UnwrapOr(nil)),
+	}
+
+}
+
+func GetCacheIdentifierOutput_FromDafny(dafnyOutput AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput) awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput {
+
+	return awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput{Identifier: Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_FromDafny(dafnyOutput.Dtor_identifier())}
+
+}
+
 func InitializeDecryptionMaterialsInput_FromDafny(dafnyInput AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput) awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput {
 
 	return awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput{AlgorithmSuiteId: Aws_cryptography_materialProviders_InitializeDecryptionMaterialsInput_algorithmSuiteId_FromDafny(dafnyInput.Dtor_algorithmSuiteId()),
@@ -2258,6 +2273,35 @@ func Aws_cryptography_materialProviders_SymmetricSigningKeyList_member_FromDafny
 	}()
 }
 func Aws_cryptography_materialProviders_GetAlgorithmSuiteInfoInput_binaryId_FromDafny(input interface{}) []byte {
+	return func() []byte {
+		if input == nil {
+			return nil
+		}
+		return dafny.ToByteArray(input.(dafny.Sequence))
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_FromDafny(input interface{}) string {
+	return func() string {
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return s
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_FromDafny(input interface{}) *string {
+	return func() *string {
+		if input == nil {
+			return nil
+		}
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return &s
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_FromDafny(input interface{}) []byte {
 	return func() []byte {
 		if input == nil {
 			return nil

--- a/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygeneratedtypes/types.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/ImplementationFromDafny-go/awscryptographymaterialproviderssmithygeneratedtypes/types.go
@@ -1477,6 +1477,28 @@ func (input GetAlgorithmSuiteInfoInput) Validate() error {
 	return nil
 }
 
+type GetCacheIdentifierInput struct {
+	BranchKeyId string
+
+	Keyring IKeyring
+
+	BranchKeyVersion *string
+}
+
+func (input GetCacheIdentifierInput) Validate() error {
+
+	return nil
+}
+
+type GetCacheIdentifierOutput struct {
+	Identifier []byte
+}
+
+func (input GetCacheIdentifierOutput) Validate() error {
+
+	return nil
+}
+
 type InitializeDecryptionMaterialsInput struct {
 	AlgorithmSuiteId AlgorithmSuiteId
 

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/WrappedAwsCryptographyKeyStoreService/shim.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/WrappedAwsCryptographyKeyStoreService/shim.go
@@ -15,7 +15,7 @@ type Shim struct {
 	client *awscryptographykeystoresmithygenerated.Client
 }
 
-func (_static *CompanionStruct_Default___) WrappedKeyStore(inputConfig AwsCryptographyKeyStoreTypes.KeyStoreConfig) Wrappers.Result {
+func  WrappedKeyStore(inputConfig AwsCryptographyKeyStoreTypes.KeyStoreConfig) Wrappers.Result {
 	var nativeConfig = awscryptographykeystoresmithygenerated.KeyStoreConfig_FromDafny(inputConfig)
 	var nativeClient, nativeError = awscryptographykeystoresmithygenerated.NewClient(nativeConfig)
 	if nativeError != nil {
@@ -85,4 +85,13 @@ func (shim *Shim) GetBeaconKey(input AwsCryptographyKeyStoreTypes.GetBeaconKeyIn
 		return Wrappers.Companion_Result_.Create_Failure_(awscryptographykeystoresmithygenerated.Error_ToDafny(native_error))
 	}
 	return Wrappers.Companion_Result_.Create_Success_(awscryptographykeystoresmithygenerated.GetBeaconKeyOutput_ToDafny(*native_response))
+}
+
+func (shim *Shim) GetBranchKeyVersions(input AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput) Wrappers.Result {
+	var native_request = awscryptographykeystoresmithygenerated.GetBranchKeyVersionsInput_FromDafny(input)
+	var native_response, native_error = shim.client.GetBranchKeyVersions(context.Background(), native_request)
+	if native_error != nil {
+		return Wrappers.Companion_Result_.Create_Failure_(awscryptographykeystoresmithygenerated.Error_ToDafny(native_error))
+	}
+	return Wrappers.Companion_Result_.Create_Success_(awscryptographykeystoresmithygenerated.GetBranchKeyVersionsOutput_ToDafny(*native_response))
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/WrappedAwsCryptographyMaterialProvidersService/shim.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/WrappedAwsCryptographyMaterialProvidersService/shim.go
@@ -16,7 +16,7 @@ type Shim struct {
 	client *awscryptographymaterialproviderssmithygenerated.Client
 }
 
-func (_static *CompanionStruct_Default___) WrappedMaterialProviders(inputConfig AwsCryptographyMaterialProvidersTypes.MaterialProvidersConfig) Wrappers.Result {
+func  WrappedMaterialProviders(inputConfig AwsCryptographyMaterialProvidersTypes.MaterialProvidersConfig) Wrappers.Result {
 	var nativeConfig = awscryptographymaterialproviderssmithygenerated.MaterialProvidersConfig_FromDafny(inputConfig)
 	var nativeClient, nativeError = awscryptographymaterialproviderssmithygenerated.NewClient(nativeConfig)
 	if nativeError != nil {
@@ -284,4 +284,13 @@ func (shim *Shim) ValidateCommitmentPolicyOnDecrypt(input AwsCryptographyMateria
 		return Wrappers.Companion_Result_.Create_Failure_(awscryptographymaterialproviderssmithygenerated.Error_ToDafny(native_error))
 	}
 	return Wrappers.Companion_Result_.Create_Success_(dafny.TupleOf())
+}
+
+func (shim *Shim) GetCacheIdentifier(input AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput) Wrappers.Result {
+	var native_request = awscryptographymaterialproviderssmithygenerated.GetCacheIdentifierInput_FromDafny(input)
+	var native_response, native_error = shim.client.GetCacheIdentifier(context.Background(), native_request)
+	if native_error != nil {
+		return Wrappers.Companion_Result_.Create_Failure_(awscryptographymaterialproviderssmithygenerated.Error_ToDafny(native_error))
+	}
+	return Wrappers.Companion_Result_.Create_Success_(awscryptographymaterialproviderssmithygenerated.GetCacheIdentifierOutput_ToDafny(*native_response))
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/api_client.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/api_client.go
@@ -162,3 +162,24 @@ func (client *Client) GetBeaconKey(ctx context.Context, params awscryptographyke
 	return &native_response, nil
 
 }
+
+func (client *Client) GetBranchKeyVersions(ctx context.Context, params awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput) (*awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput, error) {
+	err := params.Validate()
+	if err != nil {
+		opaqueErr := awscryptographykeystoresmithygeneratedtypes.OpaqueError{
+			ErrObject: err,
+		}
+		return nil, opaqueErr
+	}
+
+	var dafny_request AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput = GetBranchKeyVersionsInput_ToDafny(params)
+	var dafny_response = client.DafnyClient.GetBranchKeyVersions(dafny_request)
+
+	if dafny_response.Is_Failure() {
+		err := dafny_response.Dtor_error().(AwsCryptographyKeyStoreTypes.Error)
+		return nil, Error_FromDafny(err)
+	}
+	var native_response = GetBranchKeyVersionsOutput_FromDafny(dafny_response.Dtor_value().(AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput))
+	return &native_response, nil
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/to_dafny.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/to_dafny.go
@@ -109,6 +109,24 @@ func GetBranchKeyVersionOutput_ToDafny(nativeOutput awscryptographykeystoresmith
 
 }
 
+func GetBranchKeyVersionsInput_ToDafny(nativeInput awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput) AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput {
+
+	return func() AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput {
+
+		return AwsCryptographyKeyStoreTypes.Companion_GetBranchKeyVersionsInput_.Create_GetBranchKeyVersionsInput_(Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_ToDafny(nativeInput.BranchKeyIdentifier), Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_ToDafny(nativeInput.Count))
+	}()
+
+}
+
+func GetBranchKeyVersionsOutput_ToDafny(nativeOutput awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput) AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput {
+
+	return func() AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput {
+
+		return AwsCryptographyKeyStoreTypes.Companion_GetBranchKeyVersionsOutput_.Create_GetBranchKeyVersionsOutput_(Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_ToDafny(nativeOutput.BranchKeyMaterials))
+	}()
+
+}
+
 func GetKeyStoreInfoOutput_ToDafny(nativeOutput awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput) AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput {
 
 	return func() AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput {
@@ -476,6 +494,45 @@ func Aws_cryptography_keyStore_GetBranchKeyVersionInput_branchKeyVersion_ToDafny
 }
 
 func Aws_cryptography_keyStore_GetBranchKeyVersionOutput_branchKeyMaterials_ToDafny(input awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
+	return func() AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
+
+		return AwsCryptographyKeyStoreTypes.Companion_BranchKeyMaterials_.Create_BranchKeyMaterials_(Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_ToDafny(input.BranchKeyIdentifier), Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_ToDafny(input.BranchKeyVersion), Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_ToDafny(input.EncryptionContext), Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_ToDafny(input.BranchKey))
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_ToDafny(input string) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		return func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}()
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_ToDafny(input int32) int32 {
+	return func() int32 {
+
+		return input
+	}()
+}
+
+func Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_ToDafny(input []awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		var fieldValue []interface{} = make([]interface{}, 0, len(input))
+		for _, val := range input {
+			element := Aws_cryptography_keyStore_BranchKeyMaterialsList_member_ToDafny(val)
+			fieldValue = append(fieldValue, element)
+		}
+		return dafny.SeqOf(fieldValue...)
+	}()
+}
+
+func Aws_cryptography_keyStore_BranchKeyMaterialsList_member_ToDafny(input awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials) AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
 	return func() AwsCryptographyKeyStoreTypes.BranchKeyMaterials {
 
 		return AwsCryptographyKeyStoreTypes.Companion_BranchKeyMaterials_.Create_BranchKeyMaterials_(Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_ToDafny(input.BranchKeyIdentifier), Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_ToDafny(input.BranchKeyVersion), Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_ToDafny(input.EncryptionContext), Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_ToDafny(input.BranchKey))

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/to_native.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygenerated/to_native.go
@@ -80,6 +80,20 @@ func GetBranchKeyVersionOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreType
 
 }
 
+func GetBranchKeyVersionsInput_FromDafny(dafnyInput AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsInput) awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput {
+
+	return awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsInput{BranchKeyIdentifier: Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_FromDafny(dafnyInput.Dtor_branchKeyIdentifier()),
+		Count: Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_FromDafny(dafnyInput.Dtor_count()),
+	}
+
+}
+
+func GetBranchKeyVersionsOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreTypes.GetBranchKeyVersionsOutput) awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput {
+
+	return awscryptographykeystoresmithygeneratedtypes.GetBranchKeyVersionsOutput{BranchKeyMaterials: Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_FromDafny(dafnyOutput.Dtor_branchKeyMaterials())}
+
+}
+
 func GetKeyStoreInfoOutput_FromDafny(dafnyOutput AwsCryptographyKeyStoreTypes.GetKeyStoreInfoOutput) awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput {
 
 	return awscryptographykeystoresmithygeneratedtypes.GetKeyStoreInfoOutput{KeyStoreId: Aws_cryptography_keyStore_GetKeyStoreInfoOutput_keyStoreId_FromDafny(dafnyOutput.Dtor_keyStoreId()),
@@ -394,6 +408,39 @@ func Aws_cryptography_keyStore_GetBranchKeyVersionInput_branchKeyVersion_FromDaf
 	}()
 }
 func Aws_cryptography_keyStore_GetBranchKeyVersionOutput_branchKeyMaterials_FromDafny(input interface{}) awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
+	return awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials{BranchKeyIdentifier: Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyIdentifier()),
+		BranchKeyVersion:  Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyVersion()),
+		EncryptionContext: Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_encryptionContext()),
+		BranchKey:         Aws_cryptography_keyStore_BranchKeyMaterials_branchKey_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKey()),
+	}
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_branchKeyIdentifier_FromDafny(input interface{}) string {
+	return func() string {
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return s
+	}()
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsInput_count_FromDafny(input interface{}) int32 {
+	return func() int32 {
+		var b = input.(int32)
+		return b
+	}()
+}
+func Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_FromDafny(input interface{}) []awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
+	fieldValue := make([]awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials, 0)
+	for i := dafny.Iterate(input.(dafny.Sequence)); ; {
+		val, ok := i()
+		if !ok {
+			break
+		}
+		fieldValue = append(fieldValue, Aws_cryptography_keyStore_BranchKeyMaterialsList_member_FromDafny(val))
+	}
+	return fieldValue
+}
+func Aws_cryptography_keyStore_BranchKeyMaterialsList_member_FromDafny(input interface{}) awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials {
 	return awscryptographykeystoresmithygeneratedtypes.BranchKeyMaterials{BranchKeyIdentifier: Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyIdentifier_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyIdentifier()),
 		BranchKeyVersion:  Aws_cryptography_keyStore_BranchKeyMaterials_branchKeyVersion_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_branchKeyVersion()),
 		EncryptionContext: Aws_cryptography_keyStore_BranchKeyMaterials_encryptionContext_FromDafny(input.(AwsCryptographyKeyStoreTypes.BranchKeyMaterials).Dtor_encryptionContext()),

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygeneratedtypes/types.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographykeystoresmithygeneratedtypes/types.go
@@ -213,6 +213,42 @@ func (input GetBranchKeyVersionOutput) Validate() error {
 	return nil
 }
 
+type GetBranchKeyVersionsInput struct {
+	BranchKeyIdentifier string
+
+	Count int32
+}
+
+func (input GetBranchKeyVersionsInput) Validate() error {
+
+	return nil
+}
+
+type GetBranchKeyVersionsOutput struct {
+	BranchKeyMaterials []BranchKeyMaterials
+}
+
+func (input GetBranchKeyVersionsOutput) Validate() error {
+	if input.BranchKeyMaterials == nil {
+		return fmt.Errorf("input.BranchKeyMaterials is required but has a nil value.")
+	}
+	if input.Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate() != nil {
+		return input.Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate()
+	}
+
+	return nil
+}
+
+func (input GetBranchKeyVersionsOutput) Aws_cryptography_keyStore_GetBranchKeyVersionsOutput_branchKeyMaterials_Validate() error {
+	for _, item := range input.BranchKeyMaterials {
+		if item.Validate() != nil {
+			return item.Validate()
+		}
+	}
+
+	return nil
+}
+
 type MRDiscovery struct {
 	Region string
 }

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/api_client.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/api_client.go
@@ -651,3 +651,24 @@ func (client *Client) ValidateCommitmentPolicyOnDecrypt(ctx context.Context, par
 	}
 	return nil
 }
+
+func (client *Client) GetCacheIdentifier(ctx context.Context, params awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput) (*awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput, error) {
+	err := params.Validate()
+	if err != nil {
+		opaqueErr := awscryptographymaterialproviderssmithygeneratedtypes.OpaqueError{
+			ErrObject: err,
+		}
+		return nil, opaqueErr
+	}
+
+	var dafny_request AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput = GetCacheIdentifierInput_ToDafny(params)
+	var dafny_response = client.DafnyClient.GetCacheIdentifier(dafny_request)
+
+	if dafny_response.Is_Failure() {
+		err := dafny_response.Dtor_error().(AwsCryptographyMaterialProvidersTypes.Error)
+		return nil, Error_FromDafny(err)
+	}
+	var native_response = GetCacheIdentifierOutput_FromDafny(dafny_response.Dtor_value().(AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput))
+	return &native_response, nil
+
+}

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_dafny.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_dafny.go
@@ -269,6 +269,24 @@ func AlgorithmSuiteInfo_ToDafny(nativeOutput awscryptographymaterialproviderssmi
 
 }
 
+func GetCacheIdentifierInput_ToDafny(nativeInput awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput) AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput {
+
+	return func() AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput {
+
+		return AwsCryptographyMaterialProvidersTypes.Companion_GetCacheIdentifierInput_.Create_GetCacheIdentifierInput_(Keyring_ToDafny(nativeInput.Keyring), Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_ToDafny(nativeInput.BranchKeyId), Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_ToDafny(nativeInput.BranchKeyVersion))
+	}()
+
+}
+
+func GetCacheIdentifierOutput_ToDafny(nativeOutput awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput) AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput {
+
+	return func() AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput {
+
+		return AwsCryptographyMaterialProvidersTypes.Companion_GetCacheIdentifierOutput_.Create_GetCacheIdentifierOutput_(Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_ToDafny(nativeOutput.Identifier))
+	}()
+
+}
+
 func InitializeDecryptionMaterialsInput_ToDafny(nativeInput awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput) AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput {
 
 	return func() AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput {
@@ -2469,6 +2487,43 @@ func Aws_cryptography_materialProviders_SymmetricSigningKeyList_member_ToDafny(i
 }
 
 func Aws_cryptography_materialProviders_GetAlgorithmSuiteInfoInput_binaryId_ToDafny(input []byte) dafny.Sequence {
+	return func() dafny.Sequence {
+		if input == nil {
+			return nil
+		}
+		return dafny.SeqOfBytes(input)
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_ToDafny(input string) dafny.Sequence {
+	return func() dafny.Sequence {
+
+		return func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}()
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_ToDafny(input *string) Wrappers.Option {
+	return func() Wrappers.Option {
+		if input == nil {
+			return Wrappers.Companion_Option_.Create_None_()
+		}
+		return Wrappers.Companion_Option_.Create_Some_(func() dafny.Sequence {
+			res, err := UTF8.DecodeFromNativeGoByteArray([]byte(*input))
+			if err != nil {
+				panic("invalid utf8 input provided")
+			}
+			return res
+		}())
+	}()
+}
+
+func Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_ToDafny(input []byte) dafny.Sequence {
 	return func() dafny.Sequence {
 		if input == nil {
 			return nil

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_native.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygenerated/to_native.go
@@ -282,6 +282,21 @@ func AlgorithmSuiteInfo_FromDafny(dafnyOutput AwsCryptographyMaterialProvidersTy
 
 }
 
+func GetCacheIdentifierInput_FromDafny(dafnyInput AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierInput) awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput {
+
+	return awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierInput{Keyring: Keyring_FromDafny(dafnyInput.Dtor_keyring()),
+		BranchKeyId:      Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_FromDafny(dafnyInput.Dtor_branchKeyId()),
+		BranchKeyVersion: Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_FromDafny(dafnyInput.Dtor_branchKeyVersion().UnwrapOr(nil)),
+	}
+
+}
+
+func GetCacheIdentifierOutput_FromDafny(dafnyOutput AwsCryptographyMaterialProvidersTypes.GetCacheIdentifierOutput) awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput {
+
+	return awscryptographymaterialproviderssmithygeneratedtypes.GetCacheIdentifierOutput{Identifier: Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_FromDafny(dafnyOutput.Dtor_identifier())}
+
+}
+
 func InitializeDecryptionMaterialsInput_FromDafny(dafnyInput AwsCryptographyMaterialProvidersTypes.InitializeDecryptionMaterialsInput) awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput {
 
 	return awscryptographymaterialproviderssmithygeneratedtypes.InitializeDecryptionMaterialsInput{AlgorithmSuiteId: Aws_cryptography_materialProviders_InitializeDecryptionMaterialsInput_algorithmSuiteId_FromDafny(dafnyInput.Dtor_algorithmSuiteId()),
@@ -2258,6 +2273,35 @@ func Aws_cryptography_materialProviders_SymmetricSigningKeyList_member_FromDafny
 	}()
 }
 func Aws_cryptography_materialProviders_GetAlgorithmSuiteInfoInput_binaryId_FromDafny(input interface{}) []byte {
+	return func() []byte {
+		if input == nil {
+			return nil
+		}
+		return dafny.ToByteArray(input.(dafny.Sequence))
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyId_FromDafny(input interface{}) string {
+	return func() string {
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return s
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierInput_branchKeyVersion_FromDafny(input interface{}) *string {
+	return func() *string {
+		if input == nil {
+			return nil
+		}
+
+		a := UTF8.Encode(input.(dafny.Sequence)).Dtor_value()
+		s := string(dafny.ToByteArray(a.(dafny.Sequence)))
+
+		return &s
+	}()
+}
+func Aws_cryptography_materialProviders_GetCacheIdentifierOutput_identifier_FromDafny(input interface{}) []byte {
 	return func() []byte {
 		if input == nil {
 			return nil

--- a/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygeneratedtypes/types.go
+++ b/AwsCryptographicMaterialProviders/runtimes/go/TestsFromDafny-go/awscryptographymaterialproviderssmithygeneratedtypes/types.go
@@ -1477,6 +1477,28 @@ func (input GetAlgorithmSuiteInfoInput) Validate() error {
 	return nil
 }
 
+type GetCacheIdentifierInput struct {
+	BranchKeyId string
+
+	Keyring IKeyring
+
+	BranchKeyVersion *string
+}
+
+func (input GetCacheIdentifierInput) Validate() error {
+
+	return nil
+}
+
+type GetCacheIdentifierOutput struct {
+	Identifier []byte
+}
+
+func (input GetCacheIdentifierOutput) Validate() error {
+
+	return nil
+}
+
 type InitializeDecryptionMaterialsInput struct {
 	AlgorithmSuiteId AlgorithmSuiteId
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStore.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/KeyStore.java
@@ -20,6 +20,8 @@ import software.amazon.cryptography.keystore.model.GetBeaconKeyInput;
 import software.amazon.cryptography.keystore.model.GetBeaconKeyOutput;
 import software.amazon.cryptography.keystore.model.GetBranchKeyVersionInput;
 import software.amazon.cryptography.keystore.model.GetBranchKeyVersionOutput;
+import software.amazon.cryptography.keystore.model.GetBranchKeyVersionsInput;
+import software.amazon.cryptography.keystore.model.GetBranchKeyVersionsOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStoreInfoOutput;
 import software.amazon.cryptography.keystore.model.KeyStoreConfig;
 import software.amazon.cryptography.keystore.model.VersionKeyInput;
@@ -141,6 +143,27 @@ public class KeyStore {
       throw ToNative.Error(result.dtor_error());
     }
     return ToNative.GetBranchKeyVersionOutput(result.dtor_value());
+  }
+
+  /**
+   * Queries DynamoDB for branch key versions and decrypts each via KMS.
+   *
+   * @param input Inputs for getting branch key versions.
+   * @return Outputs for getting branch key versions.
+   */
+  public GetBranchKeyVersionsOutput GetBranchKeyVersions(
+    GetBranchKeyVersionsInput input
+  ) {
+    software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput dafnyValue =
+      ToDafny.GetBranchKeyVersionsInput(input);
+    Result<
+      software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput,
+      Error
+    > result = this._impl.GetBranchKeyVersions(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.GetBranchKeyVersionsOutput(result.dtor_value());
   }
 
   /**

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToDafny.java
@@ -10,6 +10,7 @@ import dafny.TypeDescriptor;
 import java.lang.Byte;
 import java.lang.Character;
 import java.lang.IllegalArgumentException;
+import java.lang.Integer;
 import java.lang.RuntimeException;
 import java.lang.String;
 import java.nio.ByteBuffer;
@@ -31,6 +32,8 @@ import software.amazon.cryptography.keystore.internaldafny.types.GetBeaconKeyInp
 import software.amazon.cryptography.keystore.internaldafny.types.GetBeaconKeyOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionInput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionOutput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput;
+import software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput;
 import software.amazon.cryptography.keystore.internaldafny.types.IKeyStoreClient;
 import software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration;
@@ -315,6 +318,28 @@ public class ToDafny {
     return new GetBranchKeyVersionOutput(branchKeyMaterials);
   }
 
+  public static GetBranchKeyVersionsInput GetBranchKeyVersionsInput(
+    software.amazon.cryptography.keystore.model.GetBranchKeyVersionsInput nativeValue
+  ) {
+    DafnySequence<? extends Character> branchKeyIdentifier;
+    branchKeyIdentifier =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.branchKeyIdentifier()
+      );
+    Integer count;
+    count = (nativeValue.count());
+    return new GetBranchKeyVersionsInput(branchKeyIdentifier, count);
+  }
+
+  public static GetBranchKeyVersionsOutput GetBranchKeyVersionsOutput(
+    software.amazon.cryptography.keystore.model.GetBranchKeyVersionsOutput nativeValue
+  ) {
+    DafnySequence<? extends BranchKeyMaterials> branchKeyMaterials;
+    branchKeyMaterials =
+      ToDafny.BranchKeyMaterialsList(nativeValue.branchKeyMaterials());
+    return new GetBranchKeyVersionsOutput(branchKeyMaterials);
+  }
+
   public static GetKeyStoreInfoOutput GetKeyStoreInfoOutput(
     software.amazon.cryptography.keystore.model.GetKeyStoreInfoOutput nativeValue
   ) {
@@ -489,6 +514,20 @@ public class ToDafny {
       "Cannot convert " +
       nativeValue +
       " to software.amazon.cryptography.keystore.internaldafny.types.KMSConfiguration."
+    );
+  }
+
+  public static DafnySequence<
+    ? extends BranchKeyMaterials
+  > BranchKeyMaterialsList(
+    List<
+      software.amazon.cryptography.keystore.model.BranchKeyMaterials
+    > nativeValue
+  ) {
+    return software.amazon.smithy.dafny.conversion.ToDafny.Aggregate.GenericToSequence(
+      nativeValue,
+      software.amazon.cryptography.keystore.ToDafny::BranchKeyMaterials,
+      BranchKeyMaterials._typeDescriptor()
     );
   }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/ToNative.java
@@ -32,6 +32,8 @@ import software.amazon.cryptography.keystore.model.GetBeaconKeyInput;
 import software.amazon.cryptography.keystore.model.GetBeaconKeyOutput;
 import software.amazon.cryptography.keystore.model.GetBranchKeyVersionInput;
 import software.amazon.cryptography.keystore.model.GetBranchKeyVersionOutput;
+import software.amazon.cryptography.keystore.model.GetBranchKeyVersionsInput;
+import software.amazon.cryptography.keystore.model.GetBranchKeyVersionsOutput;
 import software.amazon.cryptography.keystore.model.GetKeyStoreInfoOutput;
 import software.amazon.cryptography.keystore.model.KMSConfiguration;
 import software.amazon.cryptography.keystore.model.KeyStoreConfig;
@@ -301,6 +303,31 @@ public class ToNative {
     return nativeBuilder.build();
   }
 
+  public static GetBranchKeyVersionsInput GetBranchKeyVersionsInput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput dafnyValue
+  ) {
+    GetBranchKeyVersionsInput.Builder nativeBuilder =
+      GetBranchKeyVersionsInput.builder();
+    nativeBuilder.branchKeyIdentifier(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_branchKeyIdentifier()
+      )
+    );
+    nativeBuilder.count((dafnyValue.dtor_count()));
+    return nativeBuilder.build();
+  }
+
+  public static GetBranchKeyVersionsOutput GetBranchKeyVersionsOutput(
+    software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput dafnyValue
+  ) {
+    GetBranchKeyVersionsOutput.Builder nativeBuilder =
+      GetBranchKeyVersionsOutput.builder();
+    nativeBuilder.branchKeyMaterials(
+      ToNative.BranchKeyMaterialsList(dafnyValue.dtor_branchKeyMaterials())
+    );
+    return nativeBuilder.build();
+  }
+
   public static GetKeyStoreInfoOutput GetKeyStoreInfoOutput(
     software.amazon.cryptography.keystore.internaldafny.types.GetKeyStoreInfoOutput dafnyValue
   ) {
@@ -434,6 +461,17 @@ public class ToNative {
       );
     }
     return nativeBuilder.build();
+  }
+
+  public static List<BranchKeyMaterials> BranchKeyMaterialsList(
+    DafnySequence<
+      ? extends software.amazon.cryptography.keystore.internaldafny.types.BranchKeyMaterials
+    > dafnyValue
+  ) {
+    return software.amazon.smithy.dafny.conversion.ToNative.Aggregate.GenericToList(
+      dafnyValue,
+      software.amazon.cryptography.keystore.ToNative::BranchKeyMaterials
+    );
   }
 
   public static List<String> GrantTokenList(

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetBranchKeyVersionsInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetBranchKeyVersionsInput.java
@@ -1,0 +1,119 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.Objects;
+
+/**
+ * Inputs for getting branch key versions.
+ */
+public class GetBranchKeyVersionsInput {
+
+  /**
+   * The identifier of the Branch Key to get versions for.
+   */
+  private final String branchKeyIdentifier;
+
+  /**
+   * The maximum number of versions to retrieve.
+   */
+  private final Integer count;
+
+  protected GetBranchKeyVersionsInput(BuilderImpl builder) {
+    this.branchKeyIdentifier = builder.branchKeyIdentifier();
+    this.count = builder.count();
+  }
+
+  /**
+   * @return The identifier of the Branch Key to get versions for.
+   */
+  public String branchKeyIdentifier() {
+    return this.branchKeyIdentifier;
+  }
+
+  /**
+   * @return The maximum number of versions to retrieve.
+   */
+  public Integer count() {
+    return this.count;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param branchKeyIdentifier The identifier of the Branch Key to get versions for.
+     */
+    Builder branchKeyIdentifier(String branchKeyIdentifier);
+
+    /**
+     * @return The identifier of the Branch Key to get versions for.
+     */
+    String branchKeyIdentifier();
+
+    /**
+     * @param count The maximum number of versions to retrieve.
+     */
+    Builder count(Integer count);
+
+    /**
+     * @return The maximum number of versions to retrieve.
+     */
+    Integer count();
+
+    GetBranchKeyVersionsInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected String branchKeyIdentifier;
+
+    protected Integer count;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetBranchKeyVersionsInput model) {
+      this.branchKeyIdentifier = model.branchKeyIdentifier();
+      this.count = model.count();
+    }
+
+    public Builder branchKeyIdentifier(String branchKeyIdentifier) {
+      this.branchKeyIdentifier = branchKeyIdentifier;
+      return this;
+    }
+
+    public String branchKeyIdentifier() {
+      return this.branchKeyIdentifier;
+    }
+
+    public Builder count(Integer count) {
+      this.count = count;
+      return this;
+    }
+
+    public Integer count() {
+      return this.count;
+    }
+
+    public GetBranchKeyVersionsInput build() {
+      if (Objects.isNull(this.branchKeyIdentifier())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `branchKeyIdentifier`"
+        );
+      }
+      if (Objects.isNull(this.count())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `count`"
+        );
+      }
+      return new GetBranchKeyVersionsInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetBranchKeyVersionsOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/keystore/model/GetBranchKeyVersionsOutput.java
@@ -1,0 +1,82 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.keystore.model;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Outputs for getting branch key versions.
+ */
+public class GetBranchKeyVersionsOutput {
+
+  /**
+   * The list of decrypted branch key materials.
+   */
+  private final List<BranchKeyMaterials> branchKeyMaterials;
+
+  protected GetBranchKeyVersionsOutput(BuilderImpl builder) {
+    this.branchKeyMaterials = builder.branchKeyMaterials();
+  }
+
+  /**
+   * @return The list of decrypted branch key materials.
+   */
+  public List<BranchKeyMaterials> branchKeyMaterials() {
+    return this.branchKeyMaterials;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param branchKeyMaterials The list of decrypted branch key materials.
+     */
+    Builder branchKeyMaterials(List<BranchKeyMaterials> branchKeyMaterials);
+
+    /**
+     * @return The list of decrypted branch key materials.
+     */
+    List<BranchKeyMaterials> branchKeyMaterials();
+
+    GetBranchKeyVersionsOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected List<BranchKeyMaterials> branchKeyMaterials;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetBranchKeyVersionsOutput model) {
+      this.branchKeyMaterials = model.branchKeyMaterials();
+    }
+
+    public Builder branchKeyMaterials(
+      List<BranchKeyMaterials> branchKeyMaterials
+    ) {
+      this.branchKeyMaterials = branchKeyMaterials;
+      return this;
+    }
+
+    public List<BranchKeyMaterials> branchKeyMaterials() {
+      return this.branchKeyMaterials;
+    }
+
+    public GetBranchKeyVersionsOutput build() {
+      if (Objects.isNull(this.branchKeyMaterials())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `branchKeyMaterials`"
+        );
+      }
+      return new GetBranchKeyVersionsOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/MaterialProviders.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/MaterialProviders.java
@@ -36,6 +36,8 @@ import software.amazon.cryptography.materialproviders.model.CreateRawRsaKeyringI
 import software.amazon.cryptography.materialproviders.model.CreateRequiredEncryptionContextCMMInput;
 import software.amazon.cryptography.materialproviders.model.DecryptionMaterials;
 import software.amazon.cryptography.materialproviders.model.EncryptionMaterials;
+import software.amazon.cryptography.materialproviders.model.GetCacheIdentifierInput;
+import software.amazon.cryptography.materialproviders.model.GetCacheIdentifierOutput;
 import software.amazon.cryptography.materialproviders.model.InitializeDecryptionMaterialsInput;
 import software.amazon.cryptography.materialproviders.model.InitializeEncryptionMaterialsInput;
 import software.amazon.cryptography.materialproviders.model.MaterialProvidersConfig;
@@ -476,6 +478,27 @@ public class MaterialProviders {
       throw ToNative.Error(result.dtor_error());
     }
     return ToNative.AlgorithmSuiteInfo(result.dtor_value());
+  }
+
+  /**
+   * Computes the cache entry identifier used internally by the Hierarchical Keyring. Requires the keyring to be a Hierarchical Keyring.
+   *
+   * @param input Inputs for computing a cache identifier.
+   * @return Outputs for computing a cache identifier.
+   */
+  public GetCacheIdentifierOutput GetCacheIdentifier(
+    GetCacheIdentifierInput input
+  ) {
+    software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput dafnyValue =
+      ToDafny.GetCacheIdentifierInput(input);
+    Result<
+      software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput,
+      Error
+    > result = this._impl.GetCacheIdentifier(dafnyValue);
+    if (result.is_Failure()) {
+      throw ToNative.Error(result.dtor_error());
+    }
+    return ToNative.GetCacheIdentifierOutput(result.dtor_value());
   }
 
   public DecryptionMaterials InitializeDecryptionMaterials(

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/ToDafny.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/ToDafny.java
@@ -77,6 +77,8 @@ import software.amazon.cryptography.materialproviders.internaldafny.types.GetBra
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetBranchKeyIdOutput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheEntryInput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheEntryOutput;
+import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput;
+import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetClientInput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetEncryptionMaterialsInput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.GetEncryptionMaterialsOutput;
@@ -1356,6 +1358,42 @@ public class ToDafny {
       messagesUsed,
       bytesUsed
     );
+  }
+
+  public static GetCacheIdentifierInput GetCacheIdentifierInput(
+    software.amazon.cryptography.materialproviders.model.GetCacheIdentifierInput nativeValue
+  ) {
+    software.amazon.cryptography.materialproviders.internaldafny.types.IKeyring keyring;
+    keyring = ToDafny.Keyring(nativeValue.keyring());
+    DafnySequence<? extends Character> branchKeyId;
+    branchKeyId =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+        nativeValue.branchKeyId()
+      );
+    Option<DafnySequence<? extends Character>> branchKeyVersion;
+    branchKeyVersion =
+      Objects.nonNull(nativeValue.branchKeyVersion())
+        ? Option.create_Some(
+          DafnySequence._typeDescriptor(TypeDescriptor.CHAR),
+          software.amazon.smithy.dafny.conversion.ToDafny.Simple.CharacterSequence(
+            nativeValue.branchKeyVersion()
+          )
+        )
+        : Option.create_None(
+          DafnySequence._typeDescriptor(TypeDescriptor.CHAR)
+        );
+    return new GetCacheIdentifierInput(keyring, branchKeyId, branchKeyVersion);
+  }
+
+  public static GetCacheIdentifierOutput GetCacheIdentifierOutput(
+    software.amazon.cryptography.materialproviders.model.GetCacheIdentifierOutput nativeValue
+  ) {
+    DafnySequence<? extends Byte> identifier;
+    identifier =
+      software.amazon.smithy.dafny.conversion.ToDafny.Simple.ByteSequence(
+        nativeValue.identifier()
+      );
+    return new GetCacheIdentifierOutput(identifier);
   }
 
   public static GetClientInput GetClientInput(

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/ToNative.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/ToNative.java
@@ -80,6 +80,8 @@ import software.amazon.cryptography.materialproviders.model.GetBranchKeyIdInput;
 import software.amazon.cryptography.materialproviders.model.GetBranchKeyIdOutput;
 import software.amazon.cryptography.materialproviders.model.GetCacheEntryInput;
 import software.amazon.cryptography.materialproviders.model.GetCacheEntryOutput;
+import software.amazon.cryptography.materialproviders.model.GetCacheIdentifierInput;
+import software.amazon.cryptography.materialproviders.model.GetCacheIdentifierOutput;
 import software.amazon.cryptography.materialproviders.model.GetClientInput;
 import software.amazon.cryptography.materialproviders.model.GetEncryptionMaterialsInput;
 import software.amazon.cryptography.materialproviders.model.GetEncryptionMaterialsOutput;
@@ -1120,6 +1122,40 @@ public class ToNative {
     nativeBuilder.expiryTime((dafnyValue.dtor_expiryTime()));
     nativeBuilder.messagesUsed((dafnyValue.dtor_messagesUsed()));
     nativeBuilder.bytesUsed((dafnyValue.dtor_bytesUsed()));
+    return nativeBuilder.build();
+  }
+
+  public static GetCacheIdentifierInput GetCacheIdentifierInput(
+    software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput dafnyValue
+  ) {
+    GetCacheIdentifierInput.Builder nativeBuilder =
+      GetCacheIdentifierInput.builder();
+    nativeBuilder.keyring(ToNative.Keyring(dafnyValue.dtor_keyring()));
+    nativeBuilder.branchKeyId(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+        dafnyValue.dtor_branchKeyId()
+      )
+    );
+    if (dafnyValue.dtor_branchKeyVersion().is_Some()) {
+      nativeBuilder.branchKeyVersion(
+        software.amazon.smithy.dafny.conversion.ToNative.Simple.String(
+          dafnyValue.dtor_branchKeyVersion().dtor_value()
+        )
+      );
+    }
+    return nativeBuilder.build();
+  }
+
+  public static GetCacheIdentifierOutput GetCacheIdentifierOutput(
+    software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput dafnyValue
+  ) {
+    GetCacheIdentifierOutput.Builder nativeBuilder =
+      GetCacheIdentifierOutput.builder();
+    nativeBuilder.identifier(
+      software.amazon.smithy.dafny.conversion.ToNative.Simple.ByteBuffer(
+        dafnyValue.dtor_identifier()
+      )
+    );
     return nativeBuilder.build();
   }
 

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/GetCacheIdentifierInput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/GetCacheIdentifierInput.java
@@ -1,0 +1,156 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.materialproviders.model;
+
+import java.util.Objects;
+import software.amazon.cryptography.materialproviders.IKeyring;
+import software.amazon.cryptography.materialproviders.Keyring;
+
+/**
+ * Inputs for computing a cache identifier.
+ */
+public class GetCacheIdentifierInput {
+
+  /**
+   * The Hierarchical Keyring whose internal state is used to compute the cache identifier.
+   */
+  private final IKeyring keyring;
+
+  /**
+   * The branch key identifier.
+   */
+  private final String branchKeyId;
+
+  /**
+   * The branch key version. If provided, computes the decrypt-path cache identifier. If omitted, computes the encrypt-path cache identifier.
+   */
+  private final String branchKeyVersion;
+
+  protected GetCacheIdentifierInput(BuilderImpl builder) {
+    this.keyring = builder.keyring();
+    this.branchKeyId = builder.branchKeyId();
+    this.branchKeyVersion = builder.branchKeyVersion();
+  }
+
+  /**
+   * @return The Hierarchical Keyring whose internal state is used to compute the cache identifier.
+   */
+  public IKeyring keyring() {
+    return this.keyring;
+  }
+
+  /**
+   * @return The branch key identifier.
+   */
+  public String branchKeyId() {
+    return this.branchKeyId;
+  }
+
+  /**
+   * @return The branch key version. If provided, computes the decrypt-path cache identifier. If omitted, computes the encrypt-path cache identifier.
+   */
+  public String branchKeyVersion() {
+    return this.branchKeyVersion;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param keyring The Hierarchical Keyring whose internal state is used to compute the cache identifier.
+     */
+    Builder keyring(IKeyring keyring);
+
+    /**
+     * @return The Hierarchical Keyring whose internal state is used to compute the cache identifier.
+     */
+    IKeyring keyring();
+
+    /**
+     * @param branchKeyId The branch key identifier.
+     */
+    Builder branchKeyId(String branchKeyId);
+
+    /**
+     * @return The branch key identifier.
+     */
+    String branchKeyId();
+
+    /**
+     * @param branchKeyVersion The branch key version. If provided, computes the decrypt-path cache identifier. If omitted, computes the encrypt-path cache identifier.
+     */
+    Builder branchKeyVersion(String branchKeyVersion);
+
+    /**
+     * @return The branch key version. If provided, computes the decrypt-path cache identifier. If omitted, computes the encrypt-path cache identifier.
+     */
+    String branchKeyVersion();
+
+    GetCacheIdentifierInput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected IKeyring keyring;
+
+    protected String branchKeyId;
+
+    protected String branchKeyVersion;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetCacheIdentifierInput model) {
+      this.keyring = model.keyring();
+      this.branchKeyId = model.branchKeyId();
+      this.branchKeyVersion = model.branchKeyVersion();
+    }
+
+    public Builder keyring(IKeyring keyring) {
+      this.keyring = Keyring.wrap(keyring);
+      return this;
+    }
+
+    public IKeyring keyring() {
+      return this.keyring;
+    }
+
+    public Builder branchKeyId(String branchKeyId) {
+      this.branchKeyId = branchKeyId;
+      return this;
+    }
+
+    public String branchKeyId() {
+      return this.branchKeyId;
+    }
+
+    public Builder branchKeyVersion(String branchKeyVersion) {
+      this.branchKeyVersion = branchKeyVersion;
+      return this;
+    }
+
+    public String branchKeyVersion() {
+      return this.branchKeyVersion;
+    }
+
+    public GetCacheIdentifierInput build() {
+      if (Objects.isNull(this.keyring())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `keyring`"
+        );
+      }
+      if (Objects.isNull(this.branchKeyId())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `branchKeyId`"
+        );
+      }
+      return new GetCacheIdentifierInput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/GetCacheIdentifierOutput.java
+++ b/AwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/model/GetCacheIdentifierOutput.java
@@ -1,0 +1,80 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+package software.amazon.cryptography.materialproviders.model;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Outputs for computing a cache identifier.
+ */
+public class GetCacheIdentifierOutput {
+
+  /**
+   * The computed cache entry identifier.
+   */
+  private final ByteBuffer identifier;
+
+  protected GetCacheIdentifierOutput(BuilderImpl builder) {
+    this.identifier = builder.identifier();
+  }
+
+  /**
+   * @return The computed cache entry identifier.
+   */
+  public ByteBuffer identifier() {
+    return this.identifier;
+  }
+
+  public Builder toBuilder() {
+    return new BuilderImpl(this);
+  }
+
+  public static Builder builder() {
+    return new BuilderImpl();
+  }
+
+  public interface Builder {
+    /**
+     * @param identifier The computed cache entry identifier.
+     */
+    Builder identifier(ByteBuffer identifier);
+
+    /**
+     * @return The computed cache entry identifier.
+     */
+    ByteBuffer identifier();
+
+    GetCacheIdentifierOutput build();
+  }
+
+  static class BuilderImpl implements Builder {
+
+    protected ByteBuffer identifier;
+
+    protected BuilderImpl() {}
+
+    protected BuilderImpl(GetCacheIdentifierOutput model) {
+      this.identifier = model.identifier();
+    }
+
+    public Builder identifier(ByteBuffer identifier) {
+      this.identifier = identifier;
+      return this;
+    }
+
+    public ByteBuffer identifier() {
+      return this.identifier;
+    }
+
+    public GetCacheIdentifierOutput build() {
+      if (Objects.isNull(this.identifier())) {
+        throw new IllegalArgumentException(
+          "Missing value for required field `identifier`"
+        );
+      }
+      return new GetCacheIdentifierOutput(this);
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/GetCacheIdentifierInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/GetCacheIdentifierInput.cs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.MaterialProviders;
+namespace AWS.Cryptography.MaterialProviders
+{
+  public class GetCacheIdentifierInput
+  {
+    private AWS.Cryptography.MaterialProviders.IKeyring _keyring;
+    private string _branchKeyId;
+    private string _branchKeyVersion;
+    public AWS.Cryptography.MaterialProviders.IKeyring Keyring
+    {
+      get { return this._keyring; }
+      set { this._keyring = value; }
+    }
+    public bool IsSetKeyring()
+    {
+      return this._keyring != null;
+    }
+    public string BranchKeyId
+    {
+      get { return this._branchKeyId; }
+      set { this._branchKeyId = value; }
+    }
+    public bool IsSetBranchKeyId()
+    {
+      return this._branchKeyId != null;
+    }
+    public string BranchKeyVersion
+    {
+      get { return this._branchKeyVersion; }
+      set { this._branchKeyVersion = value; }
+    }
+    public bool IsSetBranchKeyVersion()
+    {
+      return this._branchKeyVersion != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetKeyring()) throw new System.ArgumentException("Missing value for required property 'Keyring'");
+      if (!IsSetBranchKeyId()) throw new System.ArgumentException("Missing value for required property 'BranchKeyId'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/GetCacheIdentifierOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/GetCacheIdentifierOutput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.MaterialProviders;
+namespace AWS.Cryptography.MaterialProviders
+{
+  public class GetCacheIdentifierOutput
+  {
+    private System.IO.MemoryStream _identifier;
+    public System.IO.MemoryStream Identifier
+    {
+      get { return this._identifier; }
+      set { this._identifier = value; }
+    }
+    public bool IsSetIdentifier()
+    {
+      return this._identifier != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetIdentifier()) throw new System.ArgumentException("Missing value for required property 'Identifier'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/MaterialProviders.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/MaterialProviders.cs
@@ -229,5 +229,12 @@ namespace AWS.Cryptography.MaterialProviders
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
 
     }
+    public AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput GetCacheIdentifier(AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput input)
+    {
+      software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput, software.amazon.cryptography.materialproviders.internaldafny.types._IError> result = _impl.GetCacheIdentifier(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(result.dtor_value);
+    }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographicMaterialProviders/TypeConversion.cs
@@ -2238,6 +2238,60 @@ namespace AWS.Cryptography.MaterialProviders
     {
       return ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S15_PositiveInteger(value);
     }
+    public static AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput value)
+    {
+      software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput)value; AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput converted = new AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput(); converted.Keyring = (AWS.Cryptography.MaterialProviders.IKeyring)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(concrete._keyring);
+      converted.BranchKeyId = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(concrete._branchKeyId);
+      if (concrete._branchKeyVersion.is_Some) converted.BranchKeyVersion = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(concrete._branchKeyVersion); return converted;
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput value)
+    {
+      value.Validate();
+      string var_branchKeyVersion = value.IsSetBranchKeyVersion() ? value.BranchKeyVersion : (string)null;
+      return new software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput(ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(value.Keyring), ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(value.BranchKeyId), ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(var_branchKeyVersion));
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
+    {
+      return value.is_None ? (string)null : FromDafny_N6_smithy__N3_api__S6_String(value.Extract());
+    }
+    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(string value)
+    {
+      return value == null ? Wrappers_Compile.Option<Dafny.ISequence<char>>.create_None() : Wrappers_Compile.Option<Dafny.ISequence<char>>.create_Some(ToDafny_N6_smithy__N3_api__S6_String((string)value));
+    }
+    public static AWS.Cryptography.MaterialProviders.IKeyring FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(software.amazon.cryptography.materialproviders.internaldafny.types.IKeyring value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S16_KeyringReference(value);
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types.IKeyring ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(AWS.Cryptography.MaterialProviders.IKeyring value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S16_KeyringReference(value);
+    }
+    public static AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput value)
+    {
+      software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput)value; AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput converted = new AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput(); converted.Identifier = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(concrete._identifier); return converted;
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput(ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(value.Identifier));
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
     public static AWS.Cryptography.MaterialProviders.GetClientInput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S14_GetClientInput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetClientInput value)
     {
       software.amazon.cryptography.materialproviders.internaldafny.types.GetClientInput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetClientInput)value; AWS.Cryptography.MaterialProviders.GetClientInput converted = new AWS.Cryptography.MaterialProviders.GetClientInput(); converted.Region = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S14_GetClientInput__M6_region(concrete._region); return converted;

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetBranchKeyVersionsInput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetBranchKeyVersionsInput.cs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetBranchKeyVersionsInput
+  {
+    private string _branchKeyIdentifier;
+    private int? _count;
+    public string BranchKeyIdentifier
+    {
+      get { return this._branchKeyIdentifier; }
+      set { this._branchKeyIdentifier = value; }
+    }
+    public bool IsSetBranchKeyIdentifier()
+    {
+      return this._branchKeyIdentifier != null;
+    }
+    public int Count
+    {
+      get { return this._count.GetValueOrDefault(); }
+      set { this._count = value; }
+    }
+    public bool IsSetCount()
+    {
+      return this._count.HasValue;
+    }
+    public void Validate()
+    {
+      if (!IsSetBranchKeyIdentifier()) throw new System.ArgumentException("Missing value for required property 'BranchKeyIdentifier'");
+      if (!IsSetCount()) throw new System.ArgumentException("Missing value for required property 'Count'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetBranchKeyVersionsOutput.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/GetBranchKeyVersionsOutput.cs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+// Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+using System;
+using AWS.Cryptography.KeyStore;
+namespace AWS.Cryptography.KeyStore
+{
+  public class GetBranchKeyVersionsOutput
+  {
+    private System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> _branchKeyMaterials;
+    public System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> BranchKeyMaterials
+    {
+      get { return this._branchKeyMaterials; }
+      set { this._branchKeyMaterials = value; }
+    }
+    public bool IsSetBranchKeyMaterials()
+    {
+      return this._branchKeyMaterials != null;
+    }
+    public void Validate()
+    {
+      if (!IsSetBranchKeyMaterials()) throw new System.ArgumentException("Missing value for required property 'BranchKeyMaterials'");
+
+    }
+  }
+}

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStore.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/KeyStore.cs
@@ -75,5 +75,12 @@ namespace AWS.Cryptography.KeyStore
       if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
       return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S18_GetBeaconKeyOutput(result.dtor_value);
     }
+    public AWS.Cryptography.KeyStore.GetBranchKeyVersionsOutput GetBranchKeyVersions(AWS.Cryptography.KeyStore.GetBranchKeyVersionsInput input)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsInput internalInput = TypeConversion.ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput(input);
+      Wrappers_Compile._IResult<software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsOutput, software.amazon.cryptography.keystore.internaldafny.types._IError> result = _impl.GetBranchKeyVersions(internalInput);
+      if (result.is_Failure) throw TypeConversion.FromDafny_CommonError(result.dtor_error);
+      return TypeConversion.FromDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput(result.dtor_value);
+    }
   }
 }

--- a/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
+++ b/AwsCryptographicMaterialProviders/runtimes/net/Generated/AwsCryptographyKeyStore/TypeConversion.cs
@@ -102,6 +102,22 @@ namespace AWS.Cryptography.KeyStore
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S17_EncryptionContext(value);
     }
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials> value)
+    {
+      return new System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials>(value.Elements.Select(FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList__M6_member));
+    }
+    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList(System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> value)
+    {
+      return Dafny.Sequence<software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials>.FromArray(value.Select(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList__M6_member).ToArray());
+    }
+    public static AWS.Cryptography.KeyStore.BranchKeyMaterials FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList__M6_member(software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S18_BranchKeyMaterials(value);
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList__M6_member(AWS.Cryptography.KeyStore.BranchKeyMaterials value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S18_BranchKeyMaterials(value);
+    }
     public static AWS.Cryptography.KeyStore.CreateKeyInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput(software.amazon.cryptography.keystore.internaldafny.types._ICreateKeyInput value)
     {
       software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.CreateKeyInput)value; AWS.Cryptography.KeyStore.CreateKeyInput converted = new AWS.Cryptography.KeyStore.CreateKeyInput(); if (concrete._branchKeyIdentifier.is_Some) converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S14_CreateKeyInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
@@ -338,6 +354,51 @@ namespace AWS.Cryptography.KeyStore
     public static software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionOutput__M18_branchKeyMaterials(AWS.Cryptography.KeyStore.BranchKeyMaterials value)
     {
       return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S18_BranchKeyMaterials(value);
+    }
+    public static AWS.Cryptography.KeyStore.GetBranchKeyVersionsInput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput(software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsInput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput)value; AWS.Cryptography.KeyStore.GetBranchKeyVersionsInput converted = new AWS.Cryptography.KeyStore.GetBranchKeyVersionsInput(); converted.BranchKeyIdentifier = (string)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M19_branchKeyIdentifier(concrete._branchKeyIdentifier);
+      converted.Count = (int)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M5_count(concrete._count); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsInput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput(AWS.Cryptography.KeyStore.GetBranchKeyVersionsInput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsInput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M19_branchKeyIdentifier(value.BranchKeyIdentifier), ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M5_count(value.Count));
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M19_branchKeyIdentifier(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M19_branchKeyIdentifier(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static int FromDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M5_count(int value)
+    {
+      return FromDafny_N6_smithy__N3_api__S7_Integer(value);
+    }
+    public static int ToDafny_N3_aws__N12_cryptography__N8_keyStore__S25_GetBranchKeyVersionsInput__M5_count(int value)
+    {
+      return ToDafny_N6_smithy__N3_api__S7_Integer(value);
+    }
+    public static AWS.Cryptography.KeyStore.GetBranchKeyVersionsOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsOutput value)
+    {
+      software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput concrete = (software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput)value; AWS.Cryptography.KeyStore.GetBranchKeyVersionsOutput converted = new AWS.Cryptography.KeyStore.GetBranchKeyVersionsOutput(); converted.BranchKeyMaterials = (System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials>)FromDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput__M18_branchKeyMaterials(concrete._branchKeyMaterials); return converted;
+    }
+    public static software.amazon.cryptography.keystore.internaldafny.types._IGetBranchKeyVersionsOutput ToDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput(AWS.Cryptography.KeyStore.GetBranchKeyVersionsOutput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.keystore.internaldafny.types.GetBranchKeyVersionsOutput(ToDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput__M18_branchKeyMaterials(value.BranchKeyMaterials));
+    }
+    public static System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> FromDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput__M18_branchKeyMaterials(Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials> value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList(value);
+    }
+    public static Dafny.ISequence<software.amazon.cryptography.keystore.internaldafny.types._IBranchKeyMaterials> ToDafny_N3_aws__N12_cryptography__N8_keyStore__S26_GetBranchKeyVersionsOutput__M18_branchKeyMaterials(System.Collections.Generic.List<AWS.Cryptography.KeyStore.BranchKeyMaterials> value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N8_keyStore__S22_BranchKeyMaterialsList(value);
     }
     public static AWS.Cryptography.KeyStore.GetKeyStoreInfoOutput FromDafny_N3_aws__N12_cryptography__N8_keyStore__S21_GetKeyStoreInfoOutput(software.amazon.cryptography.keystore.internaldafny.types._IGetKeyStoreInfoOutput value)
     {
@@ -718,6 +779,14 @@ namespace AWS.Cryptography.KeyStore
     public static Dafny.ISequence<char> ToDafny_N3_com__N9_amazonaws__N3_kms__S10_RegionType(string value)
     {
       return Dafny.Sequence<char>.FromString(value);
+    }
+    public static int FromDafny_N6_smithy__N3_api__S7_Integer(int value)
+    {
+      return value;
+    }
+    public static int ToDafny_N6_smithy__N3_api__S7_Integer(int value)
+    {
+      return value;
     }
     public static string FromDafny_N6_smithy__N3_api__S6_String(Dafny.ISequence<char> value)
     {

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/__init__.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/__init__.py
@@ -1,3 +1,4 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/client.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/client.py
@@ -21,6 +21,7 @@ from .deserialize import (
     _deserialize_get_active_branch_key,
     _deserialize_get_beacon_key,
     _deserialize_get_branch_key_version,
+    _deserialize_get_branch_key_versions,
     _deserialize_get_key_store_info,
     _deserialize_version_key,
 )
@@ -36,6 +37,8 @@ from .models import (
     GetBeaconKeyOutput,
     GetBranchKeyVersionInput,
     GetBranchKeyVersionOutput,
+    GetBranchKeyVersionsInput,
+    GetBranchKeyVersionsOutput,
     GetKeyStoreInfoOutput,
     Unit,
     VersionKeyInput,
@@ -47,6 +50,7 @@ from .serialize import (
     _serialize_get_active_branch_key,
     _serialize_get_beacon_key,
     _serialize_get_branch_key_version,
+    _serialize_get_branch_key_versions,
     _serialize_get_key_store_info,
     _serialize_version_key,
 )
@@ -55,17 +59,15 @@ from .serialize import (
 Input = TypeVar("Input")
 Output = TypeVar("Output")
 
-
 class KeyStore:
-    """Client for KeyStore.
+    """Client for KeyStore
 
     :param config: Configuration for the client.
     """
-
     def __init__(
         self,
         config: KeyStoreConfig | None = None,
-        dafny_client: IKeyStoreClient | None = None,
+        dafny_client: IKeyStoreClient | None = None
     ):
         if config is None:
             self._config = Config()
@@ -97,9 +99,7 @@ class KeyStore:
         )
 
     def create_key_store(self, input: CreateKeyStoreInput) -> CreateKeyStoreOutput:
-        """Create the DynamoDB table that backs this Key Store based on the Key
-        Store configuration. If a table already exists, validate it is
-        configured as expected.
+        """Create the DynamoDB table that backs this Key Store based on the Key Store configuration. If a table already exists, validate it is configured as expected.
 
         :param input: The operation's input.
         """
@@ -113,8 +113,7 @@ class KeyStore:
         )
 
     def create_key(self, input: CreateKeyInput) -> CreateKeyOutput:
-        """Create a new Branch Key in the Key Store. Additionally create a
-        Beacon Key that is tied to this Branch Key.
+        """Create a new Branch Key in the Key Store. Additionally create a Beacon Key that is tied to this Branch Key.
 
         :param input: The operation's input.
         """
@@ -128,8 +127,7 @@ class KeyStore:
         )
 
     def version_key(self, input: VersionKeyInput) -> VersionKeyOutput:
-        """Create a new ACTIVE version of an existing Branch Key in the Key
-        Store, and set the previously ACTIVE version to DECRYPT_ONLY.
+        """Create a new ACTIVE version of an existing Branch Key in the Key Store, and set the previously ACTIVE version to DECRYPT_ONLY.
 
         :param input: Inputs for versioning a Branch Key.
         """
@@ -142,11 +140,8 @@ class KeyStore:
             operation_name="VersionKey",
         )
 
-    def get_active_branch_key(
-        self, input: GetActiveBranchKeyInput
-    ) -> GetActiveBranchKeyOutput:
-        """Get the ACTIVE version for a particular Branch Key from the Key
-        Store.
+    def get_active_branch_key(self, input: GetActiveBranchKeyInput) -> GetActiveBranchKeyOutput:
+        """Get the ACTIVE version for a particular Branch Key from the Key Store.
 
         :param input: Inputs for getting a Branch Key's ACTIVE version.
         """
@@ -159,9 +154,7 @@ class KeyStore:
             operation_name="GetActiveBranchKey",
         )
 
-    def get_branch_key_version(
-        self, input: GetBranchKeyVersionInput
-    ) -> GetBranchKeyVersionOutput:
+    def get_branch_key_version(self, input: GetBranchKeyVersionInput) -> GetBranchKeyVersionOutput:
         """Get a particular version of a Branch Key from the Key Store.
 
         :param input: Inputs for getting a version of a Branch Key.
@@ -187,6 +180,20 @@ class KeyStore:
             deserialize=_deserialize_get_beacon_key,
             config=self._config,
             operation_name="GetBeaconKey",
+        )
+
+    def get_branch_key_versions(self, input: GetBranchKeyVersionsInput) -> GetBranchKeyVersionsOutput:
+        """Queries DynamoDB for branch key versions and decrypts each via KMS.
+
+        :param input: Inputs for getting branch key versions.
+        """
+        return self._execute_operation(
+            input=input,
+            plugins=[],
+            serialize=_serialize_get_branch_key_versions,
+            deserialize=_deserialize_get_branch_key_versions,
+            config=self._config,
+            operation_name="GetBranchKeyVersions",
         )
 
     def _execute_operation(
@@ -225,13 +232,12 @@ class KeyStore:
             transport_response=None,
         )
         try:
-            _client_interceptors = config.interceptors
+          _client_interceptors = config.interceptors
         except AttributeError:
-            config.interceptors = []
-            _client_interceptors = config.interceptors
+          config.interceptors = []
+          _client_interceptors = config.interceptors
         client_interceptors = cast(
-            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-            _client_interceptors,
+            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]], _client_interceptors
         )
         interceptors = client_interceptors
 
@@ -314,7 +320,7 @@ class KeyStore:
                             error_info=RetryErrorInfo(
                                 # TODO: Determine the error type.
                                 error_type=RetryErrorType.CLIENT_ERROR,
-                            ),
+                            )
                         )
                     except SmithyRetryException:
                         raise context_with_response.response
@@ -329,10 +335,7 @@ class KeyStore:
         # The response will be set either with the modeled output or an exception. The
         # transport_request and transport_response may be set or None.
         execution_context = cast(
-            InterceptorContext[
-                Input, Output, DafnyRequest | None, DafnyResponse | None
-            ],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None], context
         )
         return self._finalize_execution(interceptors, execution_context)
 
@@ -357,10 +360,8 @@ class KeyStore:
                 InterceptorContext[Input, None, DafnyRequest, DafnyResponse], context
             )
 
-            context_with_response._transport_response = (
-                config.dafnyImplInterface.handle_request(
-                    input=context_with_response.transport_request
-                )
+            context_with_response._transport_response = config.dafnyImplInterface.handle_request(
+                input=context_with_response.transport_request
             )
 
             # Step 7n: Invoke read_after_transmit
@@ -397,8 +398,7 @@ class KeyStore:
         # None. This will also be true after _finalize_attempt because there is no opportunity
         # there to set the transport_response.
         attempt_context = cast(
-            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None], context
         )
         return self._finalize_attempt(interceptors, attempt_context)
 
@@ -428,9 +428,7 @@ class KeyStore:
     def _finalize_execution(
         self,
         interceptors: list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-        context: InterceptorContext[
-            Input, Output, DafnyRequest | None, DafnyResponse | None
-        ],
+        context: InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None],
     ) -> Output:
         try:
             # Step 9: Invoke modify_before_completion

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/config.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/config.py
@@ -20,8 +20,6 @@ from .models import KMSConfiguration, _kms_configuration_from_dict
 
 
 _ServiceInterceptor = Any
-
-
 @dataclass(init=False)
 class Config:
     """Configuration for KeyStore."""
@@ -39,20 +37,20 @@ class Config:
     ):
         """Constructor.
 
-        :param interceptors: The list of interceptors, which are hooks
-            that are called during the execution of a request.
-        :param retry_strategy: The retry strategy for issuing retry
-            tokens and computing retry delays.
+        :param interceptors: The list of interceptors, which are hooks that are called
+        during the execution of a request.
+
+        :param retry_strategy: The retry strategy for issuing retry tokens and computing
+        retry delays.
+
         :param dafnyImplInterface:
         """
         self.interceptors = interceptors or []
         self.retry_strategy = retry_strategy or SimpleRetryStrategy()
         self.dafnyImplInterface = dafnyImplInterface
 
-
 # A callable that allows customizing the config object on each request.
 Plugin: TypeAlias = Callable[[Config], None]
-
 
 class KeyStoreConfig(Config):
     ddb_table_name: str
@@ -62,7 +60,6 @@ class KeyStoreConfig(Config):
     grant_tokens: Optional[list[str]]
     ddb_client: Optional[BaseClient]
     kms_client: Optional[BaseClient]
-
     def __init__(
         self,
         *,
@@ -74,7 +71,7 @@ class KeyStoreConfig(Config):
         ddb_client: Optional[BaseClient] = None,
         kms_client: Optional[BaseClient] = None,
     ):
-        """Constructor for KeyStoreConfig.
+        """Constructor for KeyStoreConfig
 
         :param ddb_table_name: The DynamoDB table name that backs this Key Store.
         :param kms_configuration: Configures Key Store's KMS Key ARN restrictions.
@@ -93,14 +90,10 @@ class KeyStoreConfig(Config):
         """
         super().__init__()
         if (ddb_table_name is not None) and (len(ddb_table_name) < 3):
-            raise ValueError(
-                "The size of ddb_table_name must be greater than or equal to 3"
-            )
+            raise ValueError("The size of ddb_table_name must be greater than or equal to 3")
 
         if (ddb_table_name is not None) and (len(ddb_table_name) > 255):
-            raise ValueError(
-                "The size of ddb_table_name must be less than or equal to 255"
-            )
+            raise ValueError("The size of ddb_table_name must be less than or equal to 255")
 
         self.ddb_table_name = ddb_table_name
         self.kms_configuration = kms_configuration
@@ -111,7 +104,9 @@ class KeyStoreConfig(Config):
         self.kms_client = kms_client
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KeyStoreConfig to a dictionary."""
+        """Converts the KeyStoreConfig to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "ddb_table_name": self.ddb_table_name,
             "kms_configuration": self.kms_configuration.as_dict(),
@@ -134,7 +129,9 @@ class KeyStoreConfig(Config):
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyStoreConfig":
-        """Creates a KeyStoreConfig from a dictionary."""
+        """Creates a KeyStoreConfig from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "ddb_table_name": d["ddb_table_name"],
             "kms_configuration": _kms_configuration_from_dict(d["kms_configuration"]),
@@ -183,29 +180,22 @@ class KeyStoreConfig(Config):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KeyStoreConfig):
             return False
-        attributes: list[str] = [
-            "ddb_table_name",
-            "kms_configuration",
-            "logical_key_store_name",
-            "id",
-            "grant_tokens",
-            "ddb_client",
-            "kms_client",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['ddb_table_name','kms_configuration','logical_key_store_name','id','grant_tokens','ddb_client','kms_client',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def dafny_config_to_smithy_config(dafny_config) -> KeyStoreConfig:
-    """Converts the provided Dafny shape for this localService's config into
-    the corresponding Smithy-modelled shape."""
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KeyStoreConfig(
-        dafny_config
-    )
-
+    """
+    Converts the provided Dafny shape for this localService's config
+    into the corresponding Smithy-modelled shape.
+    """
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KeyStoreConfig(dafny_config)
 
 def smithy_config_to_dafny_config(smithy_config) -> DafnyKeyStoreConfig:
-    """Converts the provided Smithy-modelled shape for this localService's
-    config into the corresponding Dafny shape."""
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KeyStoreConfig(
-        smithy_config
-    )
+    """
+    Converts the provided Smithy-modelled shape for this localService's config
+    into the corresponding Dafny shape.
+    """
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KeyStoreConfig(smithy_config)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafnyImplInterface.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafnyImplInterface.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 
-from aws_cryptographic_material_providers.internaldafny.generated.KeyStore import (
-    KeyStoreClient,
-)
+from aws_cryptographic_material_providers.internaldafny.generated.KeyStore import KeyStoreClient
 from .dafny_protocol import DafnyRequest
-
 
 class DafnyImplInterface:
     impl: KeyStoreClient | None = None
@@ -28,11 +25,12 @@ class DafnyImplInterface:
                 "GetActiveBranchKey": self.impl.GetActiveBranchKey,
                 "GetBranchKeyVersion": self.impl.GetBranchKeyVersion,
                 "GetBeaconKey": self.impl.GetBeaconKey,
+                "GetBranchKeyVersions": self.impl.GetBranchKeyVersions,
             }
 
-        # This logic is where a typical Smithy client would expect the "server" to be.
-        # This code can be thought of as logic our Dafny "server" uses
-        #   to route incoming client requests to the correct request handler code.
+         # This logic is where a typical Smithy client would expect the "server" to be.
+         # This code can be thought of as logic our Dafny "server" uses
+         #   to route incoming client requests to the correct request handler code.
         if input.dafny_operation_input is None:
             return self.operation_map[input.operation_name]()
         else:

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafny_protocol.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafny_protocol.py
@@ -8,6 +8,7 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     GetActiveBranchKeyInput_GetActiveBranchKeyInput as DafnyGetActiveBranchKeyInput,
     GetBeaconKeyInput_GetBeaconKeyInput as DafnyGetBeaconKeyInput,
     GetBranchKeyVersionInput_GetBranchKeyVersionInput as DafnyGetBranchKeyVersionInput,
+    GetBranchKeyVersionsInput_GetBranchKeyVersionsInput as DafnyGetBranchKeyVersionsInput,
     VersionKeyInput_VersionKeyInput as DafnyVersionKeyInput,
 )
 import aws_cryptographic_material_providers.internaldafny.generated.module_
@@ -15,7 +16,6 @@ import aws_cryptographic_material_providers.internaldafny.generated.module_
 
 import smithy_dafny_standard_library.internaldafny.generated.Wrappers as Wrappers
 from typing import Union
-
 
 class DafnyRequest:
     operation_name: str
@@ -28,6 +28,7 @@ class DafnyRequest:
         DafnyGetBranchKeyVersionInput,
         DafnyGetBeaconKeyInput,
         None,
+        DafnyGetBranchKeyVersionsInput,
         DafnyCreateKeyInput,
         DafnyCreateKeyStoreInput,
     ]
@@ -35,7 +36,6 @@ class DafnyRequest:
     def __init__(self, operation_name, dafny_operation_input):
         self.operation_name = operation_name
         self.dafny_operation_input = dafny_operation_input
-
 
 class DafnyResponse(Wrappers.Result):
     def __init__(self):

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafny_to_smithy.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/dafny_to_smithy.py
@@ -13,296 +13,144 @@ import aws_cryptographic_material_providers.smithygenerated.aws_cryptography_key
 
 
 def smithy_api_Unit():
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.Unit()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.Unit(
     )
-
 
 def aws_cryptography_keystore_CreateKeyStoreInput(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.CreateKeyStoreInput()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.CreateKeyStoreInput(
     )
-
 
 def aws_cryptography_keystore_CreateKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.CreateKeyInput(
-        branch_key_identifier=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big")
-                    for c in dafny_input.branchKeyIdentifier.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.branchKeyIdentifier.is_Some)
-            else None
-        ),
-        encryption_context=(
-            (
-                {
-                    bytes(key.Elements)
-                    .decode("utf-8"): bytes(value.Elements)
-                    .decode("utf-8")
-                    for (key, value) in dafny_input.encryptionContext.value.items
-                }
-            )
-            if (dafny_input.encryptionContext.is_Some)
-            else None
-        ),
+        branch_key_identifier=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier.value).decode('utf-16-be')) if (dafny_input.branchKeyIdentifier.is_Some) else None,
+        encryption_context=({bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.value.items }) if (dafny_input.encryptionContext.is_Some) else None,
     )
-
 
 def aws_cryptography_keystore_VersionKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.VersionKeyInput(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_GetActiveBranchKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetActiveBranchKeyInput(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_GetBranchKeyVersionInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBranchKeyVersionInput(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
-        branch_key_version=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyVersion
-        ).decode("utf-16-be"),
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
+        branch_key_version=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyVersion).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_GetBeaconKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBeaconKeyInput(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
     )
 
+def aws_cryptography_keystore_GetBranchKeyVersionsInput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBranchKeyVersionsInput(
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
+        count=dafny_input.count,
+    )
 
 def aws_cryptography_keystore_KMSConfiguration(dafny_input):
     # Convert KMSConfiguration
     if isinstance(dafny_input, KMSConfiguration_kmsKeyArn):
-        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsKeyArn(
-            b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.kmsKeyArn).decode(
-                "utf-16-be"
-            )
-        )
+        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsKeyArn(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.kmsKeyArn).decode('utf-16-be'))
     elif isinstance(dafny_input, KMSConfiguration_kmsMRKeyArn):
-        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsMRKeyArn(
-            b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.kmsMRKeyArn).decode(
-                "utf-16-be"
-            )
-        )
+        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsMRKeyArn(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.kmsMRKeyArn).decode('utf-16-be'))
     elif isinstance(dafny_input, KMSConfiguration_discovery):
-        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_Discovery(
-                dafny_input.discovery
-            )
-        )
+        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_Discovery(dafny_input.discovery))
     elif isinstance(dafny_input, KMSConfiguration_mrDiscovery):
-        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationMrDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_MRDiscovery(
-                dafny_input.mrDiscovery
-            )
-        )
+        KMSConfiguration_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationMrDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_MRDiscovery(dafny_input.mrDiscovery))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return KMSConfiguration_union_value
 
-
 def aws_cryptography_keystore_Discovery(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.Discovery()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.Discovery(
     )
-
 
 def aws_cryptography_keystore_MRDiscovery(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.MRDiscovery(
-        region=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.region).decode(
-            "utf-16-be"
-        ),
+        region=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.region).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_GetKeyStoreInfoOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetKeyStoreInfoOutput(
-        key_store_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyStoreId
-        ).decode("utf-16-be"),
-        key_store_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyStoreName
-        ).decode("utf-16-be"),
-        logical_key_store_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.logicalKeyStoreName
-        ).decode("utf-16-be"),
-        grant_tokens=[
-            b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                "utf-16-be"
-            )
-            for list_element in dafny_input.grantTokens
-        ],
-        kms_configuration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KMSConfiguration(
-            dafny_input.kmsConfiguration
-        ),
+        key_store_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyStoreId).decode('utf-16-be'),
+        key_store_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyStoreName).decode('utf-16-be'),
+        logical_key_store_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.logicalKeyStoreName).decode('utf-16-be'),
+        grant_tokens=[b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens],
+        kms_configuration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KMSConfiguration(dafny_input.kmsConfiguration),
     )
-
 
 def aws_cryptography_keystore_CreateKeyStoreOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.CreateKeyStoreOutput(
-        table_arn=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.tableArn
-        ).decode("utf-16-be"),
+        table_arn=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.tableArn).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_CreateKeyOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.CreateKeyOutput(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_keystore_VersionKeyOutput(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.VersionKeyOutput()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.VersionKeyOutput(
     )
-
 
 def aws_cryptography_keystore_BranchKeyMaterials(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.BranchKeyMaterials(
-        branch_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyIdentifier
-        ).decode("utf-16-be"),
-        branch_key_version=bytes(dafny_input.branchKeyVersion.Elements).decode("utf-8"),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
+        branch_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyIdentifier).decode('utf-16-be'),
+        branch_key_version=bytes(dafny_input.branchKeyVersion.Elements).decode('utf-8'),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
         branch_key=bytes(dafny_input.branchKey),
     )
 
-
 def aws_cryptography_keystore_GetActiveBranchKeyOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetActiveBranchKeyOutput(
-        branch_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(
-            dafny_input.branchKeyMaterials
-        ),
+        branch_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(dafny_input.branchKeyMaterials),
     )
-
 
 def aws_cryptography_keystore_GetBranchKeyVersionOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBranchKeyVersionOutput(
-        branch_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(
-            dafny_input.branchKeyMaterials
-        ),
+        branch_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(dafny_input.branchKeyMaterials),
     )
-
 
 def aws_cryptography_keystore_BeaconKeyMaterials(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.BeaconKeyMaterials(
-        beacon_key_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.beaconKeyIdentifier
-        ).decode("utf-16-be"),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        beacon_key=(
-            (bytes(dafny_input.beaconKey.value))
-            if (dafny_input.beaconKey.is_Some)
-            else None
-        ),
-        hmac_keys=(
-            (
-                {
-                    b"".join(ord(c).to_bytes(2, "big") for c in key).decode(
-                        "utf-16-be"
-                    ): bytes(value)
-                    for (key, value) in dafny_input.hmacKeys.value.items
-                }
-            )
-            if (dafny_input.hmacKeys.is_Some)
-            else None
-        ),
+        beacon_key_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.beaconKeyIdentifier).decode('utf-16-be'),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        beacon_key=(bytes(dafny_input.beaconKey.value)) if (dafny_input.beaconKey.is_Some) else None,
+        hmac_keys=({b''.join(ord(c).to_bytes(2, 'big') for c in key).decode('utf-16-be'): bytes(value) for (key, value) in dafny_input.hmacKeys.value.items }) if (dafny_input.hmacKeys.is_Some) else None,
     )
-
 
 def aws_cryptography_keystore_GetBeaconKeyOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBeaconKeyOutput(
-        beacon_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BeaconKeyMaterials(
-            dafny_input.beaconKeyMaterials
-        ),
+        beacon_key_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BeaconKeyMaterials(dafny_input.beaconKeyMaterials),
     )
 
+def aws_cryptography_keystore_GetBranchKeyVersionsOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.GetBranchKeyVersionsOutput(
+        branch_key_materials=[aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(list_element) for list_element in dafny_input.branchKeyMaterials],
+    )
 
 def aws_cryptography_keystore_DdbClientReference(dafny_input):
     return dafny_input._impl
 
-
 def aws_cryptography_keystore_KmsClientReference(dafny_input):
     return dafny_input._impl
-
 
 def aws_cryptography_keystore_KeyStoreConfig(dafny_input):
     # Deferred import of .config to avoid circular dependency
     import aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.config
-
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.config.KeyStoreConfig(
-        ddb_table_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.ddbTableName
-        ).decode("utf-16-be"),
-        kms_configuration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KMSConfiguration(
-            dafny_input.kmsConfiguration
-        ),
-        logical_key_store_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.logicalKeyStoreName
-        ).decode("utf-16-be"),
-        id=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big") for c in dafny_input.id.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.id.is_Some)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
-        ddb_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_DdbClientReference(
-                    dafny_input.ddbClient.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.ddbClient.UnwrapOr(None) is not None)
-            else None
-        ),
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KmsClientReference(
-                    dafny_input.kmsClient.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.kmsClient.UnwrapOr(None) is not None)
-            else None
-        ),
+        ddb_table_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.ddbTableName).decode('utf-16-be'),
+        kms_configuration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KMSConfiguration(dafny_input.kmsConfiguration),
+        logical_key_store_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.logicalKeyStoreName).decode('utf-16-be'),
+        id=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.id.value).decode('utf-16-be')) if (dafny_input.id.is_Some) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
+        ddb_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_DdbClientReference(dafny_input.ddbClient.UnwrapOr(None))) if (dafny_input.ddbClient.UnwrapOr(None) is not None) else None,
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_KmsClientReference(dafny_input.kmsClient.UnwrapOr(None))) if (dafny_input.kmsClient.UnwrapOr(None) is not None) else None,
     )

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/deserialize.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/deserialize.py
@@ -11,6 +11,7 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     GetActiveBranchKeyOutput_GetActiveBranchKeyOutput as DafnyGetActiveBranchKeyOutput,
     GetBeaconKeyOutput_GetBeaconKeyOutput as DafnyGetBeaconKeyOutput,
     GetBranchKeyVersionOutput_GetBranchKeyVersionOutput as DafnyGetBranchKeyVersionOutput,
+    GetBranchKeyVersionsOutput_GetBranchKeyVersionsOutput as DafnyGetBranchKeyVersionsOutput,
     GetKeyStoreInfoOutput_GetKeyStoreInfoOutput as DafnyGetKeyStoreInfoOutput,
     VersionKeyOutput_VersionKeyOutput as DafnyVersionKeyOutput,
 )
@@ -40,106 +41,77 @@ from .config import Config
 
 def _deserialize_get_key_store_info(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetKeyStoreInfoOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetKeyStoreInfoOutput(input.value)
 
 def _deserialize_create_key_store(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_CreateKeyStoreOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_CreateKeyStoreOutput(input.value)
 
 def _deserialize_create_key(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_CreateKeyOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_CreateKeyOutput(input.value)
 
 def _deserialize_version_key(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_VersionKeyOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_VersionKeyOutput(input.value)
 
 def _deserialize_get_active_branch_key(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetActiveBranchKeyOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetActiveBranchKeyOutput(input.value)
 
 def _deserialize_get_branch_key_version(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetBranchKeyVersionOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetBranchKeyVersionOutput(input.value)
 
 def _deserialize_get_beacon_key(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetBeaconKeyOutput(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetBeaconKeyOutput(input.value)
 
+def _deserialize_get_branch_key_versions(input: DafnyResponse, config: Config):
+
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_GetBranchKeyVersionsOutput(input.value)
 
 def _deserialize_error(error: Error) -> ServiceError:
     if error.is_Opaque:
         return OpaqueError(obj=error.obj)
     elif error.is_OpaqueWithText:
-        return OpaqueWithTextError(
-            obj=error.obj, obj_message=_dafny.string_of(error.objMessage)
-        )
+        return OpaqueWithTextError(obj=error.obj, obj_message=_dafny.string_of(error.objMessage))
     elif error.is_CollectionOfErrors:
         return CollectionOfErrors(
             message=_dafny.string_of(error.message),
             list=[_deserialize_error(dafny_e) for dafny_e in error.list],
         )
     elif error.is_KeyStoreException:
-        return KeyStoreException(message=_dafny.string_of(error.message))
+      return KeyStoreException(message=_dafny.string_of(error.message))
     elif error.is_ComAmazonawsKms:
         if hasattr(error.ComAmazonawsKms, "objMessage"):
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.objMessage)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.objMessage))
         elif hasattr(error.ComAmazonawsKms, "Message"):
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.Message)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.Message))
         else:
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.message)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.message))
     elif error.is_ComAmazonawsDynamodb:
         if hasattr(error.ComAmazonawsDynamodb, "objMessage"):
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.objMessage)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.objMessage))
         elif hasattr(error.ComAmazonawsDynamodb, "Message"):
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.Message)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.Message))
         else:
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.message)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.message))
     else:
         return OpaqueError(obj=error)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/errors.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/errors.py
@@ -16,34 +16,27 @@ from typing import Any, Dict, Generic, List, Literal, TypeVar
 
 
 class ServiceError(Exception):
-    """Base error for all errors in the service."""
-
+    """Base error for all errors in the service.
+    """
     pass
 
-
-T = TypeVar("T")
-
-
+T = TypeVar('T')
 class ApiError(ServiceError, Generic[T]):
-    """Base error for all api errors in the service."""
-
+    """Base error for all api errors in the service.
+    """
     code: T
-
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
 
-
-class UnknownApiError(ApiError[Literal["Unknown"]]):
-    """Error representing any unknown api errors."""
-
-    code: Literal["Unknown"] = "Unknown"
-
+class UnknownApiError(ApiError[Literal['Unknown']]):
+    """Error representing any unknown api errors
+    """
+    code: Literal['Unknown'] = 'Unknown'
 
 class KeyStoreException(ApiError[Literal["KeyStoreException"]]):
     code: Literal["KeyStoreException"] = "KeyStoreException"
     message: str
-
     def __init__(
         self,
         *,
@@ -52,17 +45,21 @@ class KeyStoreException(ApiError[Literal["KeyStoreException"]]):
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KeyStoreException to a dictionary."""
+        """Converts the KeyStoreException to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyStoreException":
-        """Creates a KeyStoreException from a dictionary."""
+        """Creates a KeyStoreException from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return KeyStoreException(**kwargs)
@@ -77,65 +74,68 @@ class KeyStoreException(ApiError[Literal["KeyStoreException"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KeyStoreException):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KeyStoreException(ApiError[Literal["KeyStoreException"]]):
     code: Literal["KeyStoreException"] = "KeyStoreException"
     message: str
 
-
 class ComAmazonawsDynamodb(ApiError[Literal["ComAmazonawsDynamodb"]]):
     ComAmazonawsDynamodb: Any
 
-
 class ComAmazonawsKms(ApiError[Literal["ComAmazonawsKms"]]):
     ComAmazonawsKms: Any
-
 
 class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
     code: Literal["CollectionOfErrors"] = "CollectionOfErrors"
     message: str
     list: List[ServiceError]
 
-    def __init__(self, *, message: str, list):
+    def __init__(
+        self,
+        *,
+        message: str,
+        list
+    ):
         super().__init__(message)
         self.list = list
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the CollectionOfErrors to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "list": self.list,
+            'message': self.message,
+            'code': self.code,
+            'list': self.list,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CollectionOfErrors":
         """Creates a CollectionOfErrors from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "list": d["list"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'list': d['list']
+        }
 
         return CollectionOfErrors(**kwargs)
 
     def __repr__(self) -> str:
         result = "CollectionOfErrors("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"list={self.list}"
+        result += f'list={self.list}'
         result += ")"
         return result
 
@@ -144,48 +144,56 @@ class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
             return False
         if not (self.list == other.list):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueError(ApiError[Literal["OpaqueError"]]):
     code: Literal["OpaqueError"] = "OpaqueError"
     obj: Any  # As an OpaqueError, type of obj is unknown
 
-    def __init__(self, *, obj):
+    def __init__(
+        self,
+        *,
+        obj
+    ):
         super().__init__("")
         self.obj = obj
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueError":
         """Creates a OpaqueError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "obj": d["obj"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'obj': d['obj']
+        }
 
         return OpaqueError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
+        result += f'obj={self.obj}'
         result += ")"
         return result
 
@@ -194,16 +202,23 @@ class OpaqueError(ApiError[Literal["OpaqueError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     code: Literal["OpaqueWithTextError"] = "OpaqueWithTextError"
     obj: Any  # As an OpaqueWithTextError, type of obj is unknown
-    obj_message: str  # obj_message is a message representing the details of obj
+    obj_message: str # obj_message is a message representing the details of obj
 
-    def __init__(self, *, obj, obj_message):
+    def __init__(
+        self,
+        *,
+        obj,
+        obj_message
+    ):
         super().__init__("")
         self.obj = obj
         self.obj_message = obj_message
@@ -211,39 +226,38 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueWithTextError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
-            "obj_message": self.obj_message,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
+            'obj_message': self.obj_message,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueWithTextError":
         """Creates a OpaqueWithTextError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
-            "obj": d["obj"],
-            "obj_message": d["obj_message"],
+            'message': d['message'],
+            'obj': d['obj'],
+            'obj_message': d['obj_message']
         }
 
         return OpaqueWithTextError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueWithTextError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
-        result += f"obj_message={self.obj_message}"
+        result += f'obj={self.obj}'
+        result += f'obj_message={self.obj_message}'
         result += ")"
         return result
 
@@ -252,50 +266,36 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def _smithy_error_to_dafny_error(e: ServiceError):
-    """Converts the provided native Smithy-modeled error into the corresponding
-    Dafny error."""
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.errors.KeyStoreException,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_KeyStoreException(
-            message=_dafny.Seq(e.message)
-        )
+    """
+    Converts the provided native Smithy-modeled error
+    into the corresponding Dafny error.
+    """
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.errors.KeyStoreException):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_KeyStoreException(message=_dafny.Seq(e.message))
 
     if isinstance(e, ComAmazonawsDynamodb):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_ComAmazonawsDynamodb(
-            com_amazonaws_dynamodb_sdk_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_ComAmazonawsDynamodb(com_amazonaws_dynamodb_sdk_error_to_dafny_error(e.message))
 
     if isinstance(e, ComAmazonawsKms):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_ComAmazonawsKms(
-            com_amazonaws_kms_sdk_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_ComAmazonawsKms(com_amazonaws_kms_sdk_error_to_dafny_error(e.message))
 
     if isinstance(e, CollectionOfErrors):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_CollectionOfErrors(
-            message=_dafny.Seq(e.message),
-            list=_dafny.Seq(
-                _smithy_error_to_dafny_error(native_err) for native_err in e.list
-            ),
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_CollectionOfErrors(message=_dafny.Seq(e.message), list=_dafny.Seq(
+            _smithy_error_to_dafny_error(native_err) for native_err in e.list
+        ))
 
     if isinstance(e, OpaqueError):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_Opaque(
-            obj=e.obj
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_Opaque(obj=e.obj)
 
     if isinstance(e, OpaqueWithTextError):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_OpaqueWithText(
-            obj=e.obj, objMessage=e.obj_message
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_OpaqueWithText(obj=e.obj, objMessage=e.obj_message)
 
     else:
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_Opaque(
-            obj=e
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyKeyStoreTypes.Error_Opaque(obj=e)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/models.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/models.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class BeaconKeyMaterials:
@@ -10,7 +10,6 @@ class BeaconKeyMaterials:
     encryption_context: dict[str, str]
     beacon_key: Optional[bytes | bytearray]
     hmac_keys: Optional[dict[str, bytes | bytearray]]
-
     def __init__(
         self,
         *,
@@ -25,7 +24,9 @@ class BeaconKeyMaterials:
         self.hmac_keys = hmac_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the BeaconKeyMaterials to a dictionary."""
+        """Converts the BeaconKeyMaterials to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "beacon_key_identifier": self.beacon_key_identifier,
             "encryption_context": self.encryption_context,
@@ -41,7 +42,9 @@ class BeaconKeyMaterials:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "BeaconKeyMaterials":
-        """Creates a BeaconKeyMaterials from a dictionary."""
+        """Creates a BeaconKeyMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "beacon_key_identifier": d["beacon_key_identifier"],
             "encryption_context": d["encryption_context"],
@@ -74,21 +77,17 @@ class BeaconKeyMaterials:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BeaconKeyMaterials):
             return False
-        attributes: list[str] = [
-            "beacon_key_identifier",
-            "encryption_context",
-            "beacon_key",
-            "hmac_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['beacon_key_identifier','encryption_context','beacon_key','hmac_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class BranchKeyMaterials:
     branch_key_identifier: str
     branch_key_version: str
     encryption_context: dict[str, str]
     branch_key: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -103,7 +102,9 @@ class BranchKeyMaterials:
         self.branch_key = branch_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the BranchKeyMaterials to a dictionary."""
+        """Converts the BranchKeyMaterials to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
             "branch_key_version": self.branch_key_version,
@@ -113,7 +114,9 @@ class BranchKeyMaterials:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "BranchKeyMaterials":
-        """Creates a BranchKeyMaterials from a dictionary."""
+        """Creates a BranchKeyMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
             "branch_key_version": d["branch_key_version"],
@@ -142,19 +145,15 @@ class BranchKeyMaterials:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, BranchKeyMaterials):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-            "branch_key_version",
-            "encryption_context",
-            "branch_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier','branch_key_version','encryption_context','branch_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateKeyInput:
     branch_key_identifier: Optional[str]
     encryption_context: Optional[dict[str, str]]
-
     def __init__(
         self,
         *,
@@ -170,7 +169,9 @@ class CreateKeyInput:
         self.encryption_context = encryption_context
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateKeyInput to a dictionary."""
+        """Converts the CreateKeyInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.branch_key_identifier is not None:
@@ -183,7 +184,9 @@ class CreateKeyInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateKeyInput":
-        """Creates a CreateKeyInput from a dictionary."""
+        """Creates a CreateKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {}
 
         if "branch_key_identifier" in d:
@@ -207,16 +210,14 @@ class CreateKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateKeyInput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-            "encryption_context",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier','encryption_context',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateKeyOutput:
     branch_key_identifier: str
-
     def __init__(
         self,
         *,
@@ -224,20 +225,23 @@ class CreateKeyOutput:
     ):
         """Outputs for Branch Key creation.
 
-        :param branch_key_identifier: A identifier for the created
-            Branch Key.
+        :param branch_key_identifier: A identifier for the created Branch Key.
         """
         self.branch_key_identifier = branch_key_identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateKeyOutput to a dictionary."""
+        """Converts the CreateKeyOutput to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateKeyOutput":
-        """Creates a CreateKeyOutput from a dictionary."""
+        """Creates a CreateKeyOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
         }
@@ -254,20 +258,24 @@ class CreateKeyOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateKeyOutput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateKeyStoreInput:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateKeyStoreInput to a dictionary."""
+        """Converts the CreateKeyStoreInput to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateKeyStoreInput":
-        """Creates a CreateKeyStoreInput from a dictionary."""
+        """Creates a CreateKeyStoreInput from a dictionary.
+
+        """
         return CreateKeyStoreInput()
 
     def __repr__(self) -> str:
@@ -278,10 +286,8 @@ class CreateKeyStoreInput:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, CreateKeyStoreInput)
 
-
 class CreateKeyStoreOutput:
     table_arn: str
-
     def __init__(
         self,
         *,
@@ -289,8 +295,7 @@ class CreateKeyStoreOutput:
     ):
         """Outputs for Key Store DynamoDB table creation.
 
-        :param table_arn: The ARN of the DynamoDB table that backs this
-            Key Store.
+        :param table_arn: The ARN of the DynamoDB table that backs this Key Store.
         """
         if (table_arn is not None) and (len(table_arn) < 1):
             raise ValueError("The size of table_arn must be greater than or equal to 1")
@@ -301,14 +306,18 @@ class CreateKeyStoreOutput:
         self.table_arn = table_arn
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateKeyStoreOutput to a dictionary."""
+        """Converts the CreateKeyStoreOutput to a dictionary.
+
+        """
         return {
             "table_arn": self.table_arn,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateKeyStoreOutput":
-        """Creates a CreateKeyStoreOutput from a dictionary."""
+        """Creates a CreateKeyStoreOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "table_arn": d["table_arn"],
         }
@@ -325,20 +334,24 @@ class CreateKeyStoreOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateKeyStoreOutput):
             return False
-        attributes: list[str] = [
-            "table_arn",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['table_arn',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class Discovery:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the Discovery to a dictionary."""
+        """Converts the Discovery to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "Discovery":
-        """Creates a Discovery from a dictionary."""
+        """Creates a Discovery from a dictionary.
+
+        """
         return Discovery()
 
     def __repr__(self) -> str:
@@ -349,10 +362,8 @@ class Discovery:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, Discovery)
 
-
 class GetActiveBranchKeyInput:
     branch_key_identifier: str
-
     def __init__(
         self,
         *,
@@ -360,20 +371,24 @@ class GetActiveBranchKeyInput:
     ):
         """Inputs for getting a Branch Key's ACTIVE version.
 
-        :param branch_key_identifier: The identifier for the Branch Key
-            to get the ACTIVE version for.
+        :param branch_key_identifier: The identifier for the Branch Key to get the
+        ACTIVE version for.
         """
         self.branch_key_identifier = branch_key_identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetActiveBranchKeyInput to a dictionary."""
+        """Converts the GetActiveBranchKeyInput to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetActiveBranchKeyInput":
-        """Creates a GetActiveBranchKeyInput from a dictionary."""
+        """Creates a GetActiveBranchKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
         }
@@ -390,15 +405,14 @@ class GetActiveBranchKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetActiveBranchKeyInput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetActiveBranchKeyOutput:
     branch_key_materials: BranchKeyMaterials
-
     def __init__(
         self,
         *,
@@ -411,18 +425,20 @@ class GetActiveBranchKeyOutput:
         self.branch_key_materials = branch_key_materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetActiveBranchKeyOutput to a dictionary."""
+        """Converts the GetActiveBranchKeyOutput to a dictionary.
+
+        """
         return {
             "branch_key_materials": self.branch_key_materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetActiveBranchKeyOutput":
-        """Creates a GetActiveBranchKeyOutput from a dictionary."""
+        """Creates a GetActiveBranchKeyOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "branch_key_materials": BranchKeyMaterials.from_dict(
-                d["branch_key_materials"]
-            ),
+            "branch_key_materials": BranchKeyMaterials.from_dict(d["branch_key_materials"]),
         }
 
         return GetActiveBranchKeyOutput(**kwargs)
@@ -437,36 +453,39 @@ class GetActiveBranchKeyOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetActiveBranchKeyOutput):
             return False
-        attributes: list[str] = [
-            "branch_key_materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBeaconKeyInput:
     branch_key_identifier: str
-
     def __init__(
         self,
         *,
         branch_key_identifier: str,
     ):
-        """Inputs for getting a Beacon Key.
+        """Inputs for getting a Beacon Key
 
-        :param branch_key_identifier: The identifier of the Branch Key
-            the Beacon Key is associated with.
+        :param branch_key_identifier: The identifier of the Branch Key the Beacon Key is
+        associated with.
         """
         self.branch_key_identifier = branch_key_identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBeaconKeyInput to a dictionary."""
+        """Converts the GetBeaconKeyInput to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBeaconKeyInput":
-        """Creates a GetBeaconKeyInput from a dictionary."""
+        """Creates a GetBeaconKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
         }
@@ -483,39 +502,40 @@ class GetBeaconKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBeaconKeyInput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBeaconKeyOutput:
     beacon_key_materials: BeaconKeyMaterials
-
     def __init__(
         self,
         *,
         beacon_key_materials: BeaconKeyMaterials,
     ):
-        """Outputs for getting a Beacon Key.
+        """Outputs for getting a Beacon Key
 
         :param beacon_key_materials: The materials for the Beacon Key.
         """
         self.beacon_key_materials = beacon_key_materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBeaconKeyOutput to a dictionary."""
+        """Converts the GetBeaconKeyOutput to a dictionary.
+
+        """
         return {
             "beacon_key_materials": self.beacon_key_materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBeaconKeyOutput":
-        """Creates a GetBeaconKeyOutput from a dictionary."""
+        """Creates a GetBeaconKeyOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "beacon_key_materials": BeaconKeyMaterials.from_dict(
-                d["beacon_key_materials"]
-            ),
+            "beacon_key_materials": BeaconKeyMaterials.from_dict(d["beacon_key_materials"]),
         }
 
         return GetBeaconKeyOutput(**kwargs)
@@ -530,16 +550,15 @@ class GetBeaconKeyOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBeaconKeyOutput):
             return False
-        attributes: list[str] = [
-            "beacon_key_materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['beacon_key_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBranchKeyVersionInput:
     branch_key_identifier: str
     branch_key_version: str
-
     def __init__(
         self,
         *,
@@ -548,15 +567,17 @@ class GetBranchKeyVersionInput:
     ):
         """Inputs for getting a version of a Branch Key.
 
-        :param branch_key_identifier: The identifier for the Branch Key
-            to get a particular version for.
+        :param branch_key_identifier: The identifier for the Branch Key to get a
+        particular version for.
         :param branch_key_version: The version to get.
         """
         self.branch_key_identifier = branch_key_identifier
         self.branch_key_version = branch_key_version
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBranchKeyVersionInput to a dictionary."""
+        """Converts the GetBranchKeyVersionInput to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
             "branch_key_version": self.branch_key_version,
@@ -564,7 +585,9 @@ class GetBranchKeyVersionInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBranchKeyVersionInput":
-        """Creates a GetBranchKeyVersionInput from a dictionary."""
+        """Creates a GetBranchKeyVersionInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
             "branch_key_version": d["branch_key_version"],
@@ -585,16 +608,14 @@ class GetBranchKeyVersionInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBranchKeyVersionInput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-            "branch_key_version",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier','branch_key_version',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBranchKeyVersionOutput:
     branch_key_materials: BranchKeyMaterials
-
     def __init__(
         self,
         *,
@@ -607,18 +628,20 @@ class GetBranchKeyVersionOutput:
         self.branch_key_materials = branch_key_materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBranchKeyVersionOutput to a dictionary."""
+        """Converts the GetBranchKeyVersionOutput to a dictionary.
+
+        """
         return {
             "branch_key_materials": self.branch_key_materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBranchKeyVersionOutput":
-        """Creates a GetBranchKeyVersionOutput from a dictionary."""
+        """Creates a GetBranchKeyVersionOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "branch_key_materials": BranchKeyMaterials.from_dict(
-                d["branch_key_materials"]
-            ),
+            "branch_key_materials": BranchKeyMaterials.from_dict(d["branch_key_materials"]),
         }
 
         return GetBranchKeyVersionOutput(**kwargs)
@@ -633,15 +656,120 @@ class GetBranchKeyVersionOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBranchKeyVersionOutput):
             return False
-        attributes: list[str] = [
-            "branch_key_materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['branch_key_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
+class GetBranchKeyVersionsInput:
+    branch_key_identifier: str
+    count: int
+    def __init__(
+        self,
+        *,
+        branch_key_identifier: str,
+        count: int,
+    ):
+        """Inputs for getting branch key versions.
+
+        :param branch_key_identifier: The identifier of the Branch Key to get versions
+        for.
+        :param count: The maximum number of versions to retrieve.
+        """
+        self.branch_key_identifier = branch_key_identifier
+        self.count = count
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Converts the GetBranchKeyVersionsInput to a dictionary.
+
+        """
+        return {
+            "branch_key_identifier": self.branch_key_identifier,
+            "count": self.count,
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "GetBranchKeyVersionsInput":
+        """Creates a GetBranchKeyVersionsInput from a dictionary.
+
+        """
+        kwargs: Dict[str, Any] = {
+            "branch_key_identifier": d["branch_key_identifier"],
+            "count": d["count"],
+        }
+
+        return GetBranchKeyVersionsInput(**kwargs)
+
+    def __repr__(self) -> str:
+        result = "GetBranchKeyVersionsInput("
+        if self.branch_key_identifier is not None:
+            result += f"branch_key_identifier={repr(self.branch_key_identifier)}, "
+
+        if self.count is not None:
+            result += f"count={repr(self.count)}"
+
+        return result + ")"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, GetBranchKeyVersionsInput):
+            return False
+        attributes: list[str] = ['branch_key_identifier','count',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
+
+class GetBranchKeyVersionsOutput:
+    branch_key_materials: list[BranchKeyMaterials]
+    def __init__(
+        self,
+        *,
+        branch_key_materials: list[BranchKeyMaterials],
+    ):
+        """Outputs for getting branch key versions.
+
+        :param branch_key_materials: The list of decrypted branch key materials.
+        """
+        self.branch_key_materials = branch_key_materials
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Converts the GetBranchKeyVersionsOutput to a dictionary.
+
+        """
+        return {
+            "branch_key_materials": _branch_key_materials_list_as_dict(self.branch_key_materials),
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "GetBranchKeyVersionsOutput":
+        """Creates a GetBranchKeyVersionsOutput from a dictionary.
+
+        """
+        kwargs: Dict[str, Any] = {
+            "branch_key_materials": _branch_key_materials_list_from_dict(d["branch_key_materials"]),
+        }
+
+        return GetBranchKeyVersionsOutput(**kwargs)
+
+    def __repr__(self) -> str:
+        result = "GetBranchKeyVersionsOutput("
+        if self.branch_key_materials is not None:
+            result += f"branch_key_materials={repr(self.branch_key_materials)}"
+
+        return result + ")"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, GetBranchKeyVersionsOutput):
+            return False
+        attributes: list[str] = ['branch_key_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class MRDiscovery:
     region: str
-
     def __init__(
         self,
         *,
@@ -659,14 +787,18 @@ class MRDiscovery:
         self.region = region
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the MRDiscovery to a dictionary."""
+        """Converts the MRDiscovery to a dictionary.
+
+        """
         return {
             "region": self.region,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MRDiscovery":
-        """Creates a MRDiscovery from a dictionary."""
+        """Creates a MRDiscovery from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "region": d["region"],
         }
@@ -683,22 +815,19 @@ class MRDiscovery:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MRDiscovery):
             return False
-        attributes: list[str] = [
-            "region",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['region',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class KMSConfigurationKmsKeyArn:
-    """Key Store is restricted to only this KMS Key ARN.
-
-    If a different KMS Key ARN is encountered when creating, versioning,
-    or getting a Branch Key or Beacon Key, KMS is never called and an
-    exception is thrown. While a Multi-Region Key (MKR) may be provided,
-    the whole ARN, including the Region, is persisted in Branch Keys and
-    MUST strictly equal this value to be considered valid.
+class KMSConfigurationKmsKeyArn():
+    """Key Store is restricted to only this KMS Key ARN. If a different KMS Key ARN is
+    encountered when creating, versioning, or getting a Branch Key or Beacon Key,
+    KMS is never called and an exception is thrown. While a Multi-Region Key (MKR)
+    may be provided, the whole ARN, including the Region, is persisted in Branch
+    Keys and MUST strictly equal this value to be considered valid.
     """
-
     def __init__(self, value: str):
         if (value is not None) and (len(value) < 1):
             raise ValueError("The size of value must be greater than or equal to 1")
@@ -713,7 +842,7 @@ class KMSConfigurationKmsKeyArn:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSConfigurationKmsKeyArn":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KMSConfigurationKmsKeyArn(d["kmsKeyArn"])
@@ -726,16 +855,11 @@ class KMSConfigurationKmsKeyArn:
             return False
         return self.value == other.value
 
-
-class KMSConfigurationKmsMRKeyArn:
-    """If an MRK ARN is provided, and the Key Store table holds an MRK ARN,
-    then those two ARNs may differ in region, although they must be otherwise
-    equal.
-
-    If either ARN is not an MRK ARN, then mrkKmsKeyArn behaves exactly
-    as kmsKeyArn.
+class KMSConfigurationKmsMRKeyArn():
+    """If an MRK ARN is provided, and the Key Store table holds an MRK ARN, then those
+    two ARNs may differ in region, although they must be otherwise equal. If either
+    ARN is not an MRK ARN, then mrkKmsKeyArn behaves exactly as kmsKeyArn.
     """
-
     def __init__(self, value: str):
         if (value is not None) and (len(value) < 1):
             raise ValueError("The size of value must be greater than or equal to 1")
@@ -750,7 +874,7 @@ class KMSConfigurationKmsMRKeyArn:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSConfigurationKmsMRKeyArn":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KMSConfigurationKmsMRKeyArn(d["kmsMRKeyArn"])
@@ -763,18 +887,13 @@ class KMSConfigurationKmsMRKeyArn:
             return False
         return self.value == other.value
 
-
-class KMSConfigurationDiscovery:
-    """The Key Store can use the KMS Key ARNs already persisted in the Backing
-    Table.
-
-    The VersionKey and CreateKey Operations are NOT supported and will
-    fail with a runtime exception. There is no Multi-Region logic with
-    this configuration; if a Multi-Region Key is encountered, and the
-    region in the ARN is not the region of the KMS Client, requests will
-    Fail with KMS Exceptions.
+class KMSConfigurationDiscovery():
+    """The Key Store can use the KMS Key ARNs already persisted in the Backing Table.
+    The VersionKey and CreateKey Operations are NOT supported and will fail with a
+    runtime exception. There is no Multi-Region logic with this configuration; if a
+    Multi-Region Key is encountered, and the region in the ARN is not the region of
+    the KMS Client, requests will Fail with KMS Exceptions.
     """
-
     def __init__(self, value: Discovery):
         self.value = value
 
@@ -783,7 +902,7 @@ class KMSConfigurationDiscovery:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSConfigurationDiscovery":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KMSConfigurationDiscovery(Discovery.from_dict(d["discovery"]))
@@ -796,16 +915,12 @@ class KMSConfigurationDiscovery:
             return False
         return self.value == other.value
 
-
-class KMSConfigurationMrDiscovery:
-    """The Key Store can use the KMS Key ARNs already persisted in the Backing
-    Table.
-
-    The VersionKey and CreateKey Operations are NOT supported and will
-    fail with a runtime exception. If a Multi-Region Key is encountered,
-    the region in the ARN is changed to the configured region.
+class KMSConfigurationMrDiscovery():
+    """The Key Store can use the KMS Key ARNs already persisted in the Backing Table.
+    The VersionKey and CreateKey Operations are NOT supported and will fail with a
+    runtime exception. If a Multi-Region Key is encountered, the region in the ARN
+    is changed to the configured region.
     """
-
     def __init__(self, value: MRDiscovery):
         self.value = value
 
@@ -814,7 +929,7 @@ class KMSConfigurationMrDiscovery:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSConfigurationMrDiscovery":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KMSConfigurationMrDiscovery(MRDiscovery.from_dict(d["mrDiscovery"]))
@@ -827,12 +942,11 @@ class KMSConfigurationMrDiscovery:
             return False
         return self.value == other.value
 
-
-class KMSConfigurationUnknown:
+class KMSConfigurationUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -845,24 +959,15 @@ class KMSConfigurationUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSConfigurationUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return KMSConfigurationUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"KMSConfigurationUnknown(tag={self.tag})"
 
-
 # Configures Key Store's KMS Key ARN restrictions.
-KMSConfiguration = Union[
-    KMSConfigurationKmsKeyArn,
-    KMSConfigurationKmsMRKeyArn,
-    KMSConfigurationDiscovery,
-    KMSConfigurationMrDiscovery,
-    KMSConfigurationUnknown,
-]
-
-
+KMSConfiguration = Union[KMSConfigurationKmsKeyArn, KMSConfigurationKmsMRKeyArn, KMSConfigurationDiscovery, KMSConfigurationMrDiscovery, KMSConfigurationUnknown]
 def _kms_configuration_from_dict(d: Dict[str, Any]) -> KMSConfiguration:
     if "kmsKeyArn" in d:
         return KMSConfigurationKmsKeyArn.from_dict(d)
@@ -876,8 +981,7 @@ def _kms_configuration_from_dict(d: Dict[str, Any]) -> KMSConfiguration:
     if "mrDiscovery" in d:
         return KMSConfigurationMrDiscovery.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class GetKeyStoreInfoOutput:
     key_store_id: str
@@ -885,7 +989,6 @@ class GetKeyStoreInfoOutput:
     logical_key_store_name: str
     grant_tokens: list[str]
     kms_configuration: KMSConfiguration
-
     def __init__(
         self,
         *,
@@ -898,26 +1001,19 @@ class GetKeyStoreInfoOutput:
         """The configuration information for a Key Store.
 
         :param key_store_id: An identifier for this Key Store.
-        :param key_store_name: The DynamoDB table name that backs this
-            Key Store.
-        :param logical_key_store_name: The logical name for this Key
-            Store, which is cryptographically bound to the keys it
-            holds.
-        :param grant_tokens: The AWS KMS grant tokens that are used when
-            this Key Store calls to AWS KMS.
-        :param kms_configuration: Configures Key Store's KMS Key ARN
-            restrictions.
+        :param key_store_name: The DynamoDB table name that backs this Key Store.
+        :param logical_key_store_name: The logical name for this Key Store, which is
+        cryptographically bound to the keys it holds.
+        :param grant_tokens: The AWS KMS grant tokens that are used when this Key Store
+        calls to AWS KMS.
+        :param kms_configuration: Configures Key Store's KMS Key ARN restrictions.
         """
         self.key_store_id = key_store_id
         if (key_store_name is not None) and (len(key_store_name) < 3):
-            raise ValueError(
-                "The size of key_store_name must be greater than or equal to 3"
-            )
+            raise ValueError("The size of key_store_name must be greater than or equal to 3")
 
         if (key_store_name is not None) and (len(key_store_name) > 255):
-            raise ValueError(
-                "The size of key_store_name must be less than or equal to 255"
-            )
+            raise ValueError("The size of key_store_name must be less than or equal to 255")
 
         self.key_store_name = key_store_name
         self.logical_key_store_name = logical_key_store_name
@@ -925,7 +1021,9 @@ class GetKeyStoreInfoOutput:
         self.kms_configuration = kms_configuration
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetKeyStoreInfoOutput to a dictionary."""
+        """Converts the GetKeyStoreInfoOutput to a dictionary.
+
+        """
         return {
             "key_store_id": self.key_store_id,
             "key_store_name": self.key_store_name,
@@ -936,7 +1034,9 @@ class GetKeyStoreInfoOutput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetKeyStoreInfoOutput":
-        """Creates a GetKeyStoreInfoOutput from a dictionary."""
+        """Creates a GetKeyStoreInfoOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_store_id": d["key_store_id"],
             "key_store_name": d["key_store_name"],
@@ -969,19 +1069,14 @@ class GetKeyStoreInfoOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetKeyStoreInfoOutput):
             return False
-        attributes: list[str] = [
-            "key_store_id",
-            "key_store_name",
-            "logical_key_store_name",
-            "grant_tokens",
-            "kms_configuration",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_store_id','key_store_name','logical_key_store_name','grant_tokens','kms_configuration',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class VersionKeyInput:
     branch_key_identifier: str
-
     def __init__(
         self,
         *,
@@ -989,20 +1084,23 @@ class VersionKeyInput:
     ):
         """Inputs for versioning a Branch Key.
 
-        :param branch_key_identifier: The identifier for the Branch Key
-            to be versioned.
+        :param branch_key_identifier: The identifier for the Branch Key to be versioned.
         """
         self.branch_key_identifier = branch_key_identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the VersionKeyInput to a dictionary."""
+        """Converts the VersionKeyInput to a dictionary.
+
+        """
         return {
             "branch_key_identifier": self.branch_key_identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "VersionKeyInput":
-        """Creates a VersionKeyInput from a dictionary."""
+        """Creates a VersionKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_identifier": d["branch_key_identifier"],
         }
@@ -1019,22 +1117,26 @@ class VersionKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, VersionKeyInput):
             return False
-        attributes: list[str] = [
-            "branch_key_identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class VersionKeyOutput:
-    """Outputs for versioning a Branch Key."""
-
+    """Outputs for versioning a Branch Key.
+    """
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the VersionKeyOutput to a dictionary."""
+        """Converts the VersionKeyOutput to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "VersionKeyOutput":
-        """Creates a VersionKeyOutput from a dictionary."""
+        """Creates a VersionKeyOutput from a dictionary.
+
+        """
         return VersionKeyOutput()
 
     def __repr__(self) -> str:
@@ -1045,6 +1147,11 @@ class VersionKeyOutput:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, VersionKeyOutput)
 
+def _branch_key_materials_list_as_dict(given: list[BranchKeyMaterials]) -> List[Any]:
+    return [v.as_dict() for v in given]
+
+def _branch_key_materials_list_from_dict(given: List[Any]) -> list[BranchKeyMaterials]:
+    return [BranchKeyMaterials.from_dict(v) for v in given]
 
 class Unit:
     pass

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/plugin.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/plugin.py
@@ -7,37 +7,29 @@ from smithy_python.interfaces.retries import RetryStrategy
 from smithy_python.exceptions import SmithyRetryException
 from .dafnyImplInterface import DafnyImplInterface
 
-
 def set_config_impl(config: Config):
-    """Set the Dafny-compiled implementation in the Smithy-Python client Config
-    and load our custom NoRetriesStrategy."""
+    """
+    Set the Dafny-compiled implementation in the Smithy-Python client Config
+    and load our custom NoRetriesStrategy.
+    """
     config.dafnyImplInterface = DafnyImplInterface()
     if isinstance(config, KeyStoreConfig):
-        from aws_cryptographic_material_providers.internaldafny.generated.KeyStore import (
-            default__,
-        )
-
-        config.dafnyImplInterface.impl = default__.KeyStore(
-            smithy_config_to_dafny_config(config)
-        ).value
+        from aws_cryptographic_material_providers.internaldafny.generated.KeyStore import default__
+        config.dafnyImplInterface.impl = default__.KeyStore(smithy_config_to_dafny_config(config)).value
     config.retry_strategy = NoRetriesStrategy()
 
-
 class ZeroRetryDelayToken:
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not wait to retry.
     """
-
     retry_delay = 0
 
-
 class NoRetriesStrategy(RetryStrategy):
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not retry calling Dafny code.
     """
-
     def acquire_initial_retry_token(self):
         return ZeroRetryDelayToken()
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/serialize.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/serialize.py
@@ -12,56 +12,23 @@ from .config import Config
 def _serialize_get_key_store_info(input, config: Config) -> DafnyRequest:
     return DafnyRequest(operation_name="GetKeyStoreInfo", dafny_operation_input=None)
 
-
 def _serialize_create_key_store(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateKeyStore",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_CreateKeyStoreInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateKeyStore", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_CreateKeyStoreInput(input))
 
 def _serialize_create_key(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_CreateKeyInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_CreateKeyInput(input))
 
 def _serialize_version_key(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="VersionKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_VersionKeyInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="VersionKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_VersionKeyInput(input))
 
 def _serialize_get_active_branch_key(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="GetActiveBranchKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetActiveBranchKeyInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="GetActiveBranchKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetActiveBranchKeyInput(input))
 
 def _serialize_get_branch_key_version(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="GetBranchKeyVersion",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetBranchKeyVersionInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="GetBranchKeyVersion", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetBranchKeyVersionInput(input))
 
 def _serialize_get_beacon_key(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="GetBeaconKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetBeaconKeyInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="GetBeaconKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetBeaconKeyInput(input))
+
+def _serialize_get_branch_key_versions(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="GetBranchKeyVersions", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_GetBranchKeyVersionsInput(input))

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/smithy_to_dafny.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_keystore/smithy_to_dafny.py
@@ -17,6 +17,8 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     GetBeaconKeyOutput_GetBeaconKeyOutput as DafnyGetBeaconKeyOutput,
     GetBranchKeyVersionInput_GetBranchKeyVersionInput as DafnyGetBranchKeyVersionInput,
     GetBranchKeyVersionOutput_GetBranchKeyVersionOutput as DafnyGetBranchKeyVersionOutput,
+    GetBranchKeyVersionsInput_GetBranchKeyVersionsInput as DafnyGetBranchKeyVersionsInput,
+    GetBranchKeyVersionsOutput_GetBranchKeyVersionsOutput as DafnyGetBranchKeyVersionsOutput,
     GetKeyStoreInfoOutput_GetKeyStoreInfoOutput as DafnyGetKeyStoreInfoOutput,
     KMSConfiguration_discovery,
     KMSConfiguration_kmsKeyArn,
@@ -47,518 +49,144 @@ from smithy_dafny_standard_library.internaldafny.generated.Wrappers import (
 def smithy_api_Unit(native_input):
     return None
 
-
 def aws_cryptography_keystore_CreateKeyStoreInput(native_input):
-    return DafnyCreateKeyStoreInput()
-
+    return DafnyCreateKeyStoreInput(
+    )
 
 def aws_cryptography_keystore_CreateKeyInput(native_input):
     return DafnyCreateKeyInput(
-        branchKeyIdentifier=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[
-                                        iter(
-                                            native_input.branch_key_identifier.encode(
-                                                "utf-16-be"
-                                            )
-                                        )
-                                    ]
-                                    * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.branch_key_identifier is not None)
-            else (Option_None())
-        ),
-        encryptionContext=(
-            (
-                Option_Some(
-                    Map(
-                        {
-                            Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                            for (key, value) in native_input.encryption_context.items()
-                        }
-                    )
-                )
-            )
-            if (native_input.encryption_context is not None)
-            else (Option_None())
-        ),
+        branchKeyIdentifier=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])))) if (native_input.branch_key_identifier is not None) else (Option_None())),
+        encryptionContext=((Option_Some(Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }))) if (native_input.encryption_context is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_keystore_VersionKeyInput(native_input):
     return DafnyVersionKeyInput(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_keystore_GetActiveBranchKeyInput(native_input):
     return DafnyGetActiveBranchKeyInput(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_keystore_GetBranchKeyVersionInput(native_input):
     return DafnyGetBranchKeyVersionInput(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        branchKeyVersion=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_version.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
+        branchKeyVersion=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_version.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_keystore_GetBeaconKeyInput(native_input):
     return DafnyGetBeaconKeyInput(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
     )
 
+def aws_cryptography_keystore_GetBranchKeyVersionsInput(native_input):
+    return DafnyGetBranchKeyVersionsInput(
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
+        count=native_input.count,
+    )
 
 def aws_cryptography_keystore_GetKeyStoreInfoOutput(native_input):
     return DafnyGetKeyStoreInfoOutput(
-        keyStoreId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_store_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        keyStoreName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_store_name.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        logicalKeyStoreName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.logical_key_store_name.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        grantTokens=Seq(
-            [
-                Seq(
-                    "".join(
-                        [
-                            chr(int.from_bytes(pair, "big"))
-                            for pair in zip(
-                                *[iter(list_element.encode("utf-16-be"))] * 2
-                            )
-                        ]
-                    )
-                )
-                for list_element in native_input.grant_tokens
-            ]
-        ),
-        kmsConfiguration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KMSConfiguration(
-            native_input.kms_configuration
-        ),
+        keyStoreId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_store_id.encode('utf-16-be'))]*2)])),
+        keyStoreName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_store_name.encode('utf-16-be'))]*2)])),
+        logicalKeyStoreName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.logical_key_store_name.encode('utf-16-be'))]*2)])),
+        grantTokens=Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]),
+        kmsConfiguration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KMSConfiguration(native_input.kms_configuration),
     )
 
-
 def aws_cryptography_keystore_KMSConfiguration(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsKeyArn,
-    ):
-        KMSConfiguration_union_value = KMSConfiguration_kmsKeyArn(
-            Seq(
-                "".join(
-                    [
-                        chr(int.from_bytes(pair, "big"))
-                        for pair in zip(
-                            *[iter(native_input.value.encode("utf-16-be"))] * 2
-                        )
-                    ]
-                )
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsMRKeyArn,
-    ):
-        KMSConfiguration_union_value = KMSConfiguration_kmsMRKeyArn(
-            Seq(
-                "".join(
-                    [
-                        chr(int.from_bytes(pair, "big"))
-                        for pair in zip(
-                            *[iter(native_input.value.encode("utf-16-be"))] * 2
-                        )
-                    ]
-                )
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationDiscovery,
-    ):
-        KMSConfiguration_union_value = KMSConfiguration_discovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_Discovery(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationMrDiscovery,
-    ):
-        KMSConfiguration_union_value = KMSConfiguration_mrDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_MRDiscovery(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsKeyArn):
+        KMSConfiguration_union_value = KMSConfiguration_kmsKeyArn(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.value.encode('utf-16-be'))]*2)])))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationKmsMRKeyArn):
+        KMSConfiguration_union_value = KMSConfiguration_kmsMRKeyArn(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.value.encode('utf-16-be'))]*2)])))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationDiscovery):
+        KMSConfiguration_union_value = KMSConfiguration_discovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_Discovery(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.models.KMSConfigurationMrDiscovery):
+        KMSConfiguration_union_value = KMSConfiguration_mrDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_MRDiscovery(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return KMSConfiguration_union_value
 
-
 def aws_cryptography_keystore_Discovery(native_input):
-    return DafnyDiscovery()
-
+    return DafnyDiscovery(
+    )
 
 def aws_cryptography_keystore_MRDiscovery(native_input):
     return DafnyMRDiscovery(
-        region=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.region.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        region=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.region.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_keystore_CreateKeyStoreOutput(native_input):
     return DafnyCreateKeyStoreOutput(
-        tableArn=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.table_arn.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        tableArn=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.table_arn.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_keystore_CreateKeyOutput(native_input):
     return DafnyCreateKeyOutput(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
     )
 
-
 def aws_cryptography_keystore_VersionKeyOutput(native_input):
-    return DafnyVersionKeyOutput()
-
+    return DafnyVersionKeyOutput(
+    )
 
 def aws_cryptography_keystore_GetActiveBranchKeyOutput(native_input):
     return DafnyGetActiveBranchKeyOutput(
-        branchKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(
-            native_input.branch_key_materials
-        ),
+        branchKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(native_input.branch_key_materials),
     )
-
 
 def aws_cryptography_keystore_BranchKeyMaterials(native_input):
     return DafnyBranchKeyMaterials(
-        branchKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        branchKeyVersion=Seq(native_input.branch_key_version.encode("utf-8")),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
+        branchKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_identifier.encode('utf-16-be'))]*2)])),
+        branchKeyVersion=Seq(native_input.branch_key_version.encode('utf-8')),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
         branchKey=Seq(native_input.branch_key),
     )
 
-
 def aws_cryptography_keystore_GetBranchKeyVersionOutput(native_input):
     return DafnyGetBranchKeyVersionOutput(
-        branchKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(
-            native_input.branch_key_materials
-        ),
+        branchKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(native_input.branch_key_materials),
     )
-
 
 def aws_cryptography_keystore_GetBeaconKeyOutput(native_input):
     return DafnyGetBeaconKeyOutput(
-        beaconKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BeaconKeyMaterials(
-            native_input.beacon_key_materials
-        ),
+        beaconKeyMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BeaconKeyMaterials(native_input.beacon_key_materials),
     )
-
 
 def aws_cryptography_keystore_BeaconKeyMaterials(native_input):
     return DafnyBeaconKeyMaterials(
-        beaconKeyIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.beacon_key_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        beaconKey=(
-            (Option_Some(Seq(native_input.beacon_key)))
-            if (native_input.beacon_key is not None)
-            else (Option_None())
-        ),
-        hmacKeys=(
-            (
-                Option_Some(
-                    Map(
-                        {
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(key.encode("utf-16-be"))] * 2
-                                        )
-                                    ]
-                                )
-                            ): Seq(value)
-                            for (key, value) in native_input.hmac_keys.items()
-                        }
-                    )
-                )
-            )
-            if (native_input.hmac_keys is not None)
-            else (Option_None())
-        ),
+        beaconKeyIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.beacon_key_identifier.encode('utf-16-be'))]*2)])),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        beaconKey=((Option_Some(Seq(native_input.beacon_key))) if (native_input.beacon_key is not None) else (Option_None())),
+        hmacKeys=((Option_Some(Map({Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(key.encode('utf-16-be'))]*2)])): Seq(value) for (key, value) in native_input.hmac_keys.items() }))) if (native_input.hmac_keys is not None) else (Option_None())),
     )
 
+def aws_cryptography_keystore_GetBranchKeyVersionsOutput(native_input):
+    return DafnyGetBranchKeyVersionsOutput(
+        branchKeyMaterials=Seq([aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(list_element) for list_element in native_input.branch_key_materials]),
+    )
 
 def aws_cryptography_keystore_DdbClientReference(native_input):
     import aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb
-
-    client = aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb.default__.DynamoDBClient(
-        boto_client=native_input
-    )
+    client = aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb.default__.DynamoDBClient(boto_client = native_input)
     client.value.impl = native_input
     return client.value
-
 
 def aws_cryptography_keystore_KmsClientReference(native_input):
     import aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms
-
-    client = aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.KMSClient(
-        boto_client=native_input
-    )
+    client = aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.KMSClient(boto_client = native_input)
     client.value.impl = native_input
     return client.value
 
-
 def aws_cryptography_keystore_KeyStoreConfig(native_input):
     return DafnyKeyStoreConfig(
-        ddbTableName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.ddb_table_name.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        kmsConfiguration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KMSConfiguration(
-            native_input.kms_configuration
-        ),
-        logicalKeyStoreName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.logical_key_store_name.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        id=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[iter(native_input.id.encode("utf-16-be"))] * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.id is not None)
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
-        ddbClient=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_DdbClientReference(
-                        native_input.ddb_client
-                    )
-                )
-            )
-            if (
-                (native_input.ddb_client is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_DdbClientReference(
-                        native_input.ddb_client
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        kmsClient=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KmsClientReference(
-                        native_input.kms_client
-                    )
-                )
-            )
-            if (
-                (native_input.kms_client is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KmsClientReference(
-                        native_input.kms_client
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
+        ddbTableName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.ddb_table_name.encode('utf-16-be'))]*2)])),
+        kmsConfiguration=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KMSConfiguration(native_input.kms_configuration),
+        logicalKeyStoreName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.logical_key_store_name.encode('utf-16-be'))]*2)])),
+        id=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.id.encode('utf-16-be'))]*2)])))) if (native_input.id is not None) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
+        ddbClient=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_DdbClientReference(native_input.ddb_client))) if ((native_input.ddb_client is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_DdbClientReference(native_input.ddb_client) is not None)) else (Option_None())),
+        kmsClient=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KmsClientReference(native_input.kms_client))) if ((native_input.kms_client is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_KmsClientReference(native_input.kms_client) is not None)) else (Option_None())),
     )

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/__init__.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/__init__.py
@@ -1,3 +1,4 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/client.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/client.py
@@ -39,6 +39,7 @@ from .deserialize import (
     _deserialize_decryption_materials_with_plaintext_data_key,
     _deserialize_encryption_materials_has_plaintext_data_key,
     _deserialize_get_algorithm_suite_info,
+    _deserialize_get_cache_identifier,
     _deserialize_initialize_decryption_materials,
     _deserialize_initialize_encryption_materials,
     _deserialize_valid_algorithm_suite_info,
@@ -71,6 +72,8 @@ from .models import (
     CreateRequiredEncryptionContextCMMInput,
     DecryptionMaterials,
     EncryptionMaterials,
+    GetCacheIdentifierInput,
+    GetCacheIdentifierOutput,
     InitializeDecryptionMaterialsInput,
     InitializeEncryptionMaterialsInput,
     Unit,
@@ -102,6 +105,7 @@ from .serialize import (
     _serialize_decryption_materials_with_plaintext_data_key,
     _serialize_encryption_materials_has_plaintext_data_key,
     _serialize_get_algorithm_suite_info,
+    _serialize_get_cache_identifier,
     _serialize_initialize_decryption_materials,
     _serialize_initialize_encryption_materials,
     _serialize_valid_algorithm_suite_info,
@@ -115,17 +119,15 @@ from .serialize import (
 Input = TypeVar("Input")
 Output = TypeVar("Output")
 
-
 class AwsCryptographicMaterialProviders:
-    """Client for AwsCryptographicMaterialProviders.
+    """Client for AwsCryptographicMaterialProviders
 
     :param config: Configuration for the client.
     """
-
     def __init__(
         self,
         config: MaterialProvidersConfig | None = None,
-        dafny_client: IAwsCryptographicMaterialProvidersClient | None = None,
+        dafny_client: IAwsCryptographicMaterialProvidersClient | None = None
     ):
         if config is None:
             self._config = Config()
@@ -142,11 +144,8 @@ class AwsCryptographicMaterialProviders:
         if dafny_client is not None:
             self._config.dafnyImplInterface.impl = dafny_client
 
-    def create_aws_kms_keyring(
-        self, input: CreateAwsKmsKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS Keyring, which wraps and unwraps data keys using
-        single symmetric AWS KMS Key.
+    def create_aws_kms_keyring(self, input: CreateAwsKmsKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS Keyring, which wraps and unwraps data keys using single symmetric AWS KMS Key.
 
         :param input: Inputs for for creating a AWS KMS Keyring.
         """
@@ -159,14 +158,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsKeyring",
         )
 
-    def create_aws_kms_discovery_keyring(
-        self, input: CreateAwsKmsDiscoveryKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS Discovery Keyring, which supports unwrapping data
-        keys wrapped by a symmetric AWS KMS Key for a single region.
+    def create_aws_kms_discovery_keyring(self, input: CreateAwsKmsDiscoveryKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS Discovery Keyring, which supports unwrapping data keys wrapped by a symmetric AWS KMS Key for a single region.
 
-        :param input: Inputs for for creating a AWS KMS Discovery
-            Keyring.
+        :param input: Inputs for for creating a AWS KMS Discovery Keyring.
         """
         return self._execute_operation(
             input=input,
@@ -177,11 +172,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsDiscoveryKeyring",
         )
 
-    def create_aws_kms_multi_keyring(
-        self, input: CreateAwsKmsMultiKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS Multi-Keyring, which wraps and unwraps data keys
-        using one or more symmetric AWS KMS Keys.
+    def create_aws_kms_multi_keyring(self, input: CreateAwsKmsMultiKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS Multi-Keyring, which wraps and unwraps data keys using one or more symmetric AWS KMS Keys.
 
         :param input: Inputs for for creating a AWS KMS Multi-Keyring.
         """
@@ -194,15 +186,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsMultiKeyring",
         )
 
-    def create_aws_kms_discovery_multi_keyring(
-        self, input: CreateAwsKmsDiscoveryMultiKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS Discovery Multi-Keyring, which supports
-        unwrapping data keys wrapped by a symmetric AWS KMS Key, for multiple
-        regions.
+    def create_aws_kms_discovery_multi_keyring(self, input: CreateAwsKmsDiscoveryMultiKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS Discovery Multi-Keyring, which supports unwrapping data keys wrapped by a symmetric AWS KMS Key, for multiple regions.
 
-        :param input: Inputs for for creating an AWS KMS Discovery
-            Multi-Keyring.
+        :param input: Inputs for for creating an AWS KMS Discovery Multi-Keyring.
         """
         return self._execute_operation(
             input=input,
@@ -213,11 +200,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsDiscoveryMultiKeyring",
         )
 
-    def create_aws_kms_mrk_keyring(
-        self, input: CreateAwsKmsMrkKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS MRK Keyring, which wraps and unwraps data keys
-        using single symmetric AWS KMS Key or AWS KMS Multi-Region Key.
+    def create_aws_kms_mrk_keyring(self, input: CreateAwsKmsMrkKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS MRK Keyring, which wraps and unwraps data keys using single symmetric AWS KMS Key or AWS KMS Multi-Region Key.
 
         :param input: Inputs for for creating an AWS KMS MRK Keyring.
         """
@@ -230,15 +214,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsMrkKeyring",
         )
 
-    def create_aws_kms_mrk_multi_keyring(
-        self, input: CreateAwsKmsMrkMultiKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS MRK Multi-Keyring, which wraps and unwraps data
-        keys using one or more symmetric AWS KMS Keys or AWS KMS Multi-Region
-        Keys.
+    def create_aws_kms_mrk_multi_keyring(self, input: CreateAwsKmsMrkMultiKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS MRK Multi-Keyring, which wraps and unwraps data keys using one or more symmetric AWS KMS Keys or AWS KMS Multi-Region Keys.
 
-        :param input: Inputs for for creating a AWS KMS MRK Multi-
-            Keyring.
+        :param input: Inputs for for creating a AWS KMS MRK Multi-Keyring.
         """
         return self._execute_operation(
             input=input,
@@ -249,15 +228,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsMrkMultiKeyring",
         )
 
-    def create_aws_kms_mrk_discovery_keyring(
-        self, input: CreateAwsKmsMrkDiscoveryKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS MRK Discovery Keyring, which supports unwrapping
-        data keys wrapped by a symmetric AWS KMS Key or AWS KMS Multi-Region
-        Key in a particular region.
+    def create_aws_kms_mrk_discovery_keyring(self, input: CreateAwsKmsMrkDiscoveryKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS MRK Discovery Keyring, which supports unwrapping data keys wrapped by a symmetric AWS KMS Key or AWS KMS Multi-Region Key in a particular region.
 
-        :param input: Inputs for for creating a AWS KMS MRK Discovery
-            Keyring.
+        :param input: Inputs for for creating a AWS KMS MRK Discovery Keyring.
         """
         return self._execute_operation(
             input=input,
@@ -268,15 +242,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsMrkDiscoveryKeyring",
         )
 
-    def create_aws_kms_mrk_discovery_multi_keyring(
-        self, input: CreateAwsKmsMrkDiscoveryMultiKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS MRK Discovery Multi-Keyring that supports
-        unwrapping data keys wrapped by a symmetric AWS KMS Key or AWS KMS
-        Multi-Region Key, for a single region.
+    def create_aws_kms_mrk_discovery_multi_keyring(self, input: CreateAwsKmsMrkDiscoveryMultiKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS MRK Discovery Multi-Keyring that supports unwrapping data keys wrapped by a symmetric AWS KMS Key or AWS KMS Multi-Region Key, for a single region.
 
-        :param input: Inputs for for creating a AWS KMS MRK Discovery
-            Multi-Keyring.
+        :param input: Inputs for for creating a AWS KMS MRK Discovery Multi-Keyring.
         """
         return self._execute_operation(
             input=input,
@@ -287,12 +256,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsMrkDiscoveryMultiKeyring",
         )
 
-    def create_aws_kms_hierarchical_keyring(
-        self, input: CreateAwsKmsHierarchicalKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates a Hierarchical Keyring, which supports wrapping and
-        unwrapping data keys using Branch Keys persisted in DynamoDB and
-        protected by a symmetric AWS KMS Key or AWS KMS Multi-Region Key.
+    def create_aws_kms_hierarchical_keyring(self, input: CreateAwsKmsHierarchicalKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates a Hierarchical Keyring, which supports wrapping and unwrapping data keys using Branch Keys persisted in DynamoDB and protected by a symmetric AWS KMS Key or AWS KMS Multi-Region Key.
 
         :param input: Inputs for creating a Hierarchical Keyring.
         """
@@ -305,11 +270,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsHierarchicalKeyring",
         )
 
-    def create_aws_kms_rsa_keyring(
-        self, input: CreateAwsKmsRsaKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS RSA Keyring, which wraps and unwraps data keys
-        using a single asymmetric AWS KMS Key for RSA.
+    def create_aws_kms_rsa_keyring(self, input: CreateAwsKmsRsaKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS RSA Keyring, which wraps and unwraps data keys using a single asymmetric AWS KMS Key for RSA.
 
         :param input: Inputs for creating a AWS KMS RSA Keyring.
         """
@@ -322,12 +284,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsRsaKeyring",
         )
 
-    def create_aws_kms_ecdh_keyring(
-        self, input: CreateAwsKmsEcdhKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates an AWS KMS ECDH Keyring, which wraps and unwraps data keys
-        by deriving a shared data key from the established shared secret
-        between parties through the ECDH protocol.
+    def create_aws_kms_ecdh_keyring(self, input: CreateAwsKmsEcdhKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates an AWS KMS ECDH Keyring, which wraps and unwraps data keys by deriving a shared data key from the established shared secret between parties through the ECDH protocol.
 
         :param input: Inputs for creating an AWS KMS ECDH Keyring.
         """
@@ -340,9 +298,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateAwsKmsEcdhKeyring",
         )
 
-    def create_multi_keyring(
-        self, input: CreateMultiKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
+    def create_multi_keyring(self, input: CreateMultiKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
         """Creates a Multi-Keyring comprised of one or more other Keyrings.
 
         :param input: Inputs for creating a Multi-Keyring.
@@ -356,11 +312,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateMultiKeyring",
         )
 
-    def create_raw_aes_keyring(
-        self, input: CreateRawAesKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates a Raw AES Keyring, which wraps and unwraps data keys locally
-        using AES_GCM.
+    def create_raw_aes_keyring(self, input: CreateRawAesKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates a Raw AES Keyring, which wraps and unwraps data keys locally using AES_GCM.
 
         :param input: Inputs for creating a Raw AES Keyring.
         """
@@ -373,11 +326,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateRawAesKeyring",
         )
 
-    def create_raw_rsa_keyring(
-        self, input: CreateRawRsaKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates a Raw RSA Keyring, which wraps and unwraps data keys locally
-        using RSA.
+    def create_raw_rsa_keyring(self, input: CreateRawRsaKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates a Raw RSA Keyring, which wraps and unwraps data keys locally using RSA.
 
         :param input: Inputs for creating a Raw RAW Keyring.
         """
@@ -390,12 +340,8 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateRawRsaKeyring",
         )
 
-    def create_raw_ecdh_keyring(
-        self, input: CreateRawEcdhKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
-        """Creates a Raw ECDH Keyring, which wraps and unwraps data keys by
-        deriving a shared data key from the established shared secret between
-        parties through the ECDH protocol.
+    def create_raw_ecdh_keyring(self, input: CreateRawEcdhKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
+        """Creates a Raw ECDH Keyring, which wraps and unwraps data keys by deriving a shared data key from the established shared secret between parties through the ECDH protocol.
 
         :param input: Inputs for creating a raw ECDH Keyring.
         """
@@ -408,13 +354,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateRawEcdhKeyring",
         )
 
-    def create_default_cryptographic_materials_manager(
-        self, input: CreateDefaultCryptographicMaterialsManagerInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager":
+    def create_default_cryptographic_materials_manager(self, input: CreateDefaultCryptographicMaterialsManagerInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager':
         """Creates a Default Cryptographic Materials Manager.
 
-        :param input: Inputs for creating a Default Cryptographic
-            Materials Manager.
+        :param input: Inputs for creating a Default Cryptographic Materials Manager.
         """
         return self._execute_operation(
             input=input,
@@ -425,14 +368,10 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateDefaultCryptographicMaterialsManager",
         )
 
-    def create_required_encryption_context_cmm(
-        self, input: CreateRequiredEncryptionContextCMMInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager":
-        """Creates an Required Encryption Context Cryptographic Materials
-        Manager.
+    def create_required_encryption_context_cmm(self, input: CreateRequiredEncryptionContextCMMInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager':
+        """Creates an Required Encryption Context Cryptographic Materials Manager.
 
-        :param input: Inputs for creating an Required Encryption Context
-            Cryptographic Materials Manager.
+        :param input: Inputs for creating an Required Encryption Context Cryptographic Materials Manager.
         """
         return self._execute_operation(
             input=input,
@@ -443,9 +382,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateRequiredEncryptionContextCMM",
         )
 
-    def create_cryptographic_materials_cache(
-        self, input: CreateCryptographicMaterialsCacheInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsCache":
+    def create_cryptographic_materials_cache(self, input: CreateCryptographicMaterialsCacheInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsCache':
         """Invokes the CreateCryptographicMaterialsCache operation.
 
         :param input: The operation's input.
@@ -459,9 +396,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateCryptographicMaterialsCache",
         )
 
-    def create_default_client_supplier(
-        self, input: CreateDefaultClientSupplierInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier":
+    def create_default_client_supplier(self, input: CreateDefaultClientSupplierInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier':
         """Invokes the CreateDefaultClientSupplier operation.
 
         :param input: The operation's input.
@@ -475,9 +410,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="CreateDefaultClientSupplier",
         )
 
-    def initialize_encryption_materials(
-        self, input: InitializeEncryptionMaterialsInput
-    ) -> EncryptionMaterials:
+    def initialize_encryption_materials(self, input: InitializeEncryptionMaterialsInput) -> EncryptionMaterials:
         """Invokes the InitializeEncryptionMaterials operation.
 
         :param input: The operation's input.
@@ -491,9 +424,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="InitializeEncryptionMaterials",
         )
 
-    def initialize_decryption_materials(
-        self, input: InitializeDecryptionMaterialsInput
-    ) -> DecryptionMaterials:
+    def initialize_decryption_materials(self, input: InitializeDecryptionMaterialsInput) -> DecryptionMaterials:
         """Invokes the InitializeDecryptionMaterials operation.
 
         :param input: The operation's input.
@@ -507,9 +438,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="InitializeDecryptionMaterials",
         )
 
-    def valid_encryption_materials_transition(
-        self, input: ValidEncryptionMaterialsTransitionInput
-    ) -> Unit:
+    def valid_encryption_materials_transition(self, input: ValidEncryptionMaterialsTransitionInput) -> Unit:
         """Invokes the ValidEncryptionMaterialsTransition operation.
 
         :param input: The operation's input.
@@ -523,9 +452,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="ValidEncryptionMaterialsTransition",
         )
 
-    def valid_decryption_materials_transition(
-        self, input: ValidDecryptionMaterialsTransitionInput
-    ) -> Unit:
+    def valid_decryption_materials_transition(self, input: ValidDecryptionMaterialsTransitionInput) -> Unit:
         """Invokes the ValidDecryptionMaterialsTransition operation.
 
         :param input: The operation's input.
@@ -539,9 +466,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="ValidDecryptionMaterialsTransition",
         )
 
-    def encryption_materials_has_plaintext_data_key(
-        self, input: EncryptionMaterials
-    ) -> Unit:
+    def encryption_materials_has_plaintext_data_key(self, input: EncryptionMaterials) -> Unit:
         """Invokes the EncryptionMaterialsHasPlaintextDataKey operation.
 
         :param input: The operation's input.
@@ -555,9 +480,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="EncryptionMaterialsHasPlaintextDataKey",
         )
 
-    def decryption_materials_with_plaintext_data_key(
-        self, input: DecryptionMaterials
-    ) -> Unit:
+    def decryption_materials_with_plaintext_data_key(self, input: DecryptionMaterials) -> Unit:
         """Invokes the DecryptionMaterialsWithPlaintextDataKey operation.
 
         :param input: The operation's input.
@@ -599,9 +522,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="ValidAlgorithmSuiteInfo",
         )
 
-    def validate_commitment_policy_on_encrypt(
-        self, input: ValidateCommitmentPolicyOnEncryptInput
-    ) -> Unit:
+    def validate_commitment_policy_on_encrypt(self, input: ValidateCommitmentPolicyOnEncryptInput) -> Unit:
         """Invokes the ValidateCommitmentPolicyOnEncrypt operation.
 
         :param input: The operation's input.
@@ -615,9 +536,7 @@ class AwsCryptographicMaterialProviders:
             operation_name="ValidateCommitmentPolicyOnEncrypt",
         )
 
-    def validate_commitment_policy_on_decrypt(
-        self, input: ValidateCommitmentPolicyOnDecryptInput
-    ) -> Unit:
+    def validate_commitment_policy_on_decrypt(self, input: ValidateCommitmentPolicyOnDecryptInput) -> Unit:
         """Invokes the ValidateCommitmentPolicyOnDecrypt operation.
 
         :param input: The operation's input.
@@ -629,6 +548,20 @@ class AwsCryptographicMaterialProviders:
             deserialize=_deserialize_validate_commitment_policy_on_decrypt,
             config=self._config,
             operation_name="ValidateCommitmentPolicyOnDecrypt",
+        )
+
+    def get_cache_identifier(self, input: GetCacheIdentifierInput) -> GetCacheIdentifierOutput:
+        """Computes the cache entry identifier used internally by the Hierarchical Keyring. Requires the keyring to be a Hierarchical Keyring.
+
+        :param input: Inputs for computing a cache identifier.
+        """
+        return self._execute_operation(
+            input=input,
+            plugins=[],
+            serialize=_serialize_get_cache_identifier,
+            deserialize=_deserialize_get_cache_identifier,
+            config=self._config,
+            operation_name="GetCacheIdentifier",
         )
 
     def _execute_operation(
@@ -667,13 +600,12 @@ class AwsCryptographicMaterialProviders:
             transport_response=None,
         )
         try:
-            _client_interceptors = config.interceptors
+          _client_interceptors = config.interceptors
         except AttributeError:
-            config.interceptors = []
-            _client_interceptors = config.interceptors
+          config.interceptors = []
+          _client_interceptors = config.interceptors
         client_interceptors = cast(
-            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-            _client_interceptors,
+            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]], _client_interceptors
         )
         interceptors = client_interceptors
 
@@ -756,7 +688,7 @@ class AwsCryptographicMaterialProviders:
                             error_info=RetryErrorInfo(
                                 # TODO: Determine the error type.
                                 error_type=RetryErrorType.CLIENT_ERROR,
-                            ),
+                            )
                         )
                     except SmithyRetryException:
                         raise context_with_response.response
@@ -771,10 +703,7 @@ class AwsCryptographicMaterialProviders:
         # The response will be set either with the modeled output or an exception. The
         # transport_request and transport_response may be set or None.
         execution_context = cast(
-            InterceptorContext[
-                Input, Output, DafnyRequest | None, DafnyResponse | None
-            ],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None], context
         )
         return self._finalize_execution(interceptors, execution_context)
 
@@ -799,10 +728,8 @@ class AwsCryptographicMaterialProviders:
                 InterceptorContext[Input, None, DafnyRequest, DafnyResponse], context
             )
 
-            context_with_response._transport_response = (
-                config.dafnyImplInterface.handle_request(
-                    input=context_with_response.transport_request
-                )
+            context_with_response._transport_response = config.dafnyImplInterface.handle_request(
+                input=context_with_response.transport_request
             )
 
             # Step 7n: Invoke read_after_transmit
@@ -839,8 +766,7 @@ class AwsCryptographicMaterialProviders:
         # None. This will also be true after _finalize_attempt because there is no opportunity
         # there to set the transport_response.
         attempt_context = cast(
-            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None], context
         )
         return self._finalize_attempt(interceptors, attempt_context)
 
@@ -870,9 +796,7 @@ class AwsCryptographicMaterialProviders:
     def _finalize_execution(
         self,
         interceptors: list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-        context: InterceptorContext[
-            Input, Output, DafnyRequest | None, DafnyResponse | None
-        ],
+        context: InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None],
     ) -> Output:
         try:
             # Step 9: Invoke modify_before_completion

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/config.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/config.py
@@ -17,8 +17,6 @@ from smithy_python.interfaces.retries import RetryStrategy
 
 
 _ServiceInterceptor = Any
-
-
 @dataclass(init=False)
 class Config:
     """Configuration for AwsCryptographicMaterialProviders."""
@@ -36,35 +34,40 @@ class Config:
     ):
         """Constructor.
 
-        :param interceptors: The list of interceptors, which are hooks
-            that are called during the execution of a request.
-        :param retry_strategy: The retry strategy for issuing retry
-            tokens and computing retry delays.
+        :param interceptors: The list of interceptors, which are hooks that are called
+        during the execution of a request.
+
+        :param retry_strategy: The retry strategy for issuing retry tokens and computing
+        retry delays.
+
         :param dafnyImplInterface:
         """
         self.interceptors = interceptors or []
         self.retry_strategy = retry_strategy or SimpleRetryStrategy()
         self.dafnyImplInterface = dafnyImplInterface
 
-
 # A callable that allows customizing the config object on each request.
 Plugin: TypeAlias = Callable[[Config], None]
-
 
 class MaterialProvidersConfig(Config):
     def __init__(
         self,
     ):
-        """Constructor for MaterialProvidersConfig."""
+        """Constructor for MaterialProvidersConfig
+        """
         super().__init__()
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the MaterialProvidersConfig to a dictionary."""
+        """Converts the MaterialProvidersConfig to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialProvidersConfig":
-        """Creates a MaterialProvidersConfig from a dictionary."""
+        """Creates a MaterialProvidersConfig from a dictionary.
+
+        """
         return MaterialProvidersConfig()
 
     def __repr__(self) -> str:
@@ -75,18 +78,16 @@ class MaterialProvidersConfig(Config):
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, MaterialProvidersConfig)
 
-
 def dafny_config_to_smithy_config(dafny_config) -> MaterialProvidersConfig:
-    """Converts the provided Dafny shape for this localService's config into
-    the corresponding Smithy-modelled shape."""
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_MaterialProvidersConfig(
-        dafny_config
-    )
-
+    """
+    Converts the provided Dafny shape for this localService's config
+    into the corresponding Smithy-modelled shape.
+    """
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_MaterialProvidersConfig(dafny_config)
 
 def smithy_config_to_dafny_config(smithy_config) -> DafnyMaterialProvidersConfig:
-    """Converts the provided Smithy-modelled shape for this localService's
-    config into the corresponding Dafny shape."""
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_MaterialProvidersConfig(
-        smithy_config
-    )
+    """
+    Converts the provided Smithy-modelled shape for this localService's config
+    into the corresponding Dafny shape.
+    """
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_MaterialProvidersConfig(smithy_config)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafnyImplInterface.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafnyImplInterface.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 
-from aws_cryptographic_material_providers.internaldafny.generated.MaterialProviders import (
-    MaterialProvidersClient,
-)
+from aws_cryptographic_material_providers.internaldafny.generated.MaterialProviders import MaterialProvidersClient
 from .dafny_protocol import DafnyRequest
-
 
 class DafnyImplInterface:
     impl: MaterialProvidersClient | None = None
@@ -50,11 +47,12 @@ class DafnyImplInterface:
                 "ValidAlgorithmSuiteInfo": self.impl.ValidAlgorithmSuiteInfo,
                 "ValidateCommitmentPolicyOnEncrypt": self.impl.ValidateCommitmentPolicyOnEncrypt,
                 "ValidateCommitmentPolicyOnDecrypt": self.impl.ValidateCommitmentPolicyOnDecrypt,
+                "GetCacheIdentifier": self.impl.GetCacheIdentifier,
             }
 
-        # This logic is where a typical Smithy client would expect the "server" to be.
-        # This code can be thought of as logic our Dafny "server" uses
-        #   to route incoming client requests to the correct request handler code.
+         # This logic is where a typical Smithy client would expect the "server" to be.
+         # This code can be thought of as logic our Dafny "server" uses
+         #   to route incoming client requests to the correct request handler code.
         if input.dafny_operation_input is None:
             return self.operation_map[input.operation_name]()
         else:

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafny_protocol.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafny_protocol.py
@@ -25,6 +25,7 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     CreateRequiredEncryptionContextCMMInput_CreateRequiredEncryptionContextCMMInput as DafnyCreateRequiredEncryptionContextCMMInput,
     DecryptionMaterials_DecryptionMaterials as DafnyDecryptionMaterials,
     EncryptionMaterials_EncryptionMaterials as DafnyEncryptionMaterials,
+    GetCacheIdentifierInput_GetCacheIdentifierInput as DafnyGetCacheIdentifierInput,
     InitializeDecryptionMaterialsInput_InitializeDecryptionMaterialsInput as DafnyInitializeDecryptionMaterialsInput,
     InitializeEncryptionMaterialsInput_InitializeEncryptionMaterialsInput as DafnyInitializeEncryptionMaterialsInput,
     ValidDecryptionMaterialsTransitionInput_ValidDecryptionMaterialsTransitionInput as DafnyValidDecryptionMaterialsTransitionInput,
@@ -37,7 +38,6 @@ import aws_cryptographic_material_providers.internaldafny.generated.module_
 
 import smithy_dafny_standard_library.internaldafny.generated.Wrappers as Wrappers
 from typing import Union
-
 
 class DafnyRequest:
     operation_name: str
@@ -58,6 +58,7 @@ class DafnyRequest:
         DafnyInitializeDecryptionMaterialsInput,
         DafnyValidateCommitmentPolicyOnDecryptInput,
         DafnyCreateAwsKmsDiscoveryMultiKeyringInput,
+        DafnyGetCacheIdentifierInput,
         DafnyCreateAwsKmsMrkDiscoveryMultiKeyringInput,
         DafnyCreateAwsKmsRsaKeyringInput,
         DafnyValidDecryptionMaterialsTransitionInput,
@@ -78,7 +79,6 @@ class DafnyRequest:
     def __init__(self, operation_name, dafny_operation_input):
         self.operation_name = operation_name
         self.dafny_operation_input = dafny_operation_input
-
 
 class DafnyResponse(Wrappers.Result):
     def __init__(self):

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafny_to_smithy.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/dafny_to_smithy.py
@@ -73,477 +73,254 @@ import aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.d
 
 def aws_cryptography_materialproviders_GetBranchKeyIdInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdInput(
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
     )
-
 
 def aws_cryptography_materialproviders_GetBranchKeyIdOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdOutput(
-        branch_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyId
-        ).decode("utf-16-be"),
+        branch_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviders_GetClientInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetClientInput(
-        region=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.region).decode(
-            "utf-16-be"
-        ),
+        region=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.region).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviders_KmsClientReference(dafny_input):
     return dafny_input._impl
 
-
 def aws_cryptography_materialproviders_GetClientOutput(dafny_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-        dafny_input
-    )
-
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input)
 
 def aws_cryptography_materialproviders_Materials(dafny_input):
     # Convert Materials
     if isinstance(dafny_input, Materials_Encryption):
-        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsEncryption(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-                dafny_input.Encryption
-            )
-        )
+        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsEncryption(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.Encryption))
     elif isinstance(dafny_input, Materials_Decryption):
-        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsDecryption(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-                dafny_input.Decryption
-            )
-        )
+        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsDecryption(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.Decryption))
     elif isinstance(dafny_input, Materials_BranchKey):
-        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBranchKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(
-                dafny_input.BranchKey
-            )
-        )
+        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBranchKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BranchKeyMaterials(dafny_input.BranchKey))
     elif isinstance(dafny_input, Materials_BeaconKey):
-        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBeaconKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BeaconKeyMaterials(
-                dafny_input.BeaconKey
-            )
-        )
+        Materials_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBeaconKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.dafny_to_smithy.aws_cryptography_keystore_BeaconKeyMaterials(dafny_input.BeaconKey))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return Materials_union_value
 
-
 def aws_cryptography_materialproviders_EncryptionMaterials(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptionMaterials(
-        algorithm_suite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-            dafny_input.algorithmSuite
-        ),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        encrypted_data_keys=[
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(
-                list_element
-            )
-            for list_element in dafny_input.encryptedDataKeys
-        ],
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
-        plaintext_data_key=(
-            (bytes(dafny_input.plaintextDataKey.value))
-            if (dafny_input.plaintextDataKey.is_Some)
-            else None
-        ),
-        signing_key=(
-            (bytes(dafny_input.signingKey.value))
-            if (dafny_input.signingKey.is_Some)
-            else None
-        ),
-        symmetric_signing_keys=(
-            (
-                [
-                    bytes(list_element)
-                    for list_element in dafny_input.symmetricSigningKeys.value
-                ]
-            )
-            if (dafny_input.symmetricSigningKeys.is_Some)
-            else None
-        ),
+        algorithm_suite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(dafny_input.algorithmSuite),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        encrypted_data_keys=[aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in dafny_input.encryptedDataKeys],
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
+        plaintext_data_key=(bytes(dafny_input.plaintextDataKey.value)) if (dafny_input.plaintextDataKey.is_Some) else None,
+        signing_key=(bytes(dafny_input.signingKey.value)) if (dafny_input.signingKey.is_Some) else None,
+        symmetric_signing_keys=([bytes(list_element) for list_element in dafny_input.symmetricSigningKeys.value]) if (dafny_input.symmetricSigningKeys.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_DecryptionMaterials(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptionMaterials(
-        algorithm_suite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-            dafny_input.algorithmSuite
-        ),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
-        plaintext_data_key=(
-            (bytes(dafny_input.plaintextDataKey.value))
-            if (dafny_input.plaintextDataKey.is_Some)
-            else None
-        ),
-        verification_key=(
-            (bytes(dafny_input.verificationKey.value))
-            if (dafny_input.verificationKey.is_Some)
-            else None
-        ),
-        symmetric_signing_key=(
-            (bytes(dafny_input.symmetricSigningKey.value))
-            if (dafny_input.symmetricSigningKey.is_Some)
-            else None
-        ),
+        algorithm_suite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(dafny_input.algorithmSuite),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
+        plaintext_data_key=(bytes(dafny_input.plaintextDataKey.value)) if (dafny_input.plaintextDataKey.is_Some) else None,
+        verification_key=(bytes(dafny_input.verificationKey.value)) if (dafny_input.verificationKey.is_Some) else None,
+        symmetric_signing_key=(bytes(dafny_input.symmetricSigningKey.value)) if (dafny_input.symmetricSigningKey.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_AlgorithmSuiteInfo(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteInfo(
-        id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.id
-        ),
+        id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.id),
         binary_id=bytes(dafny_input.binaryId),
         message_version=dafny_input.messageVersion,
-        encrypt=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Encrypt(
-            dafny_input.encrypt
-        ),
-        kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(
-            dafny_input.kdf
-        ),
-        commitment=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(
-            dafny_input.commitment
-        ),
-        signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SignatureAlgorithm(
-            dafny_input.signature
-        ),
-        symmetric_signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(
-            dafny_input.symmetricSignature
-        ),
-        edk_wrapping=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EdkWrappingAlgorithm(
-            dafny_input.edkWrapping
-        ),
+        encrypt=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Encrypt(dafny_input.encrypt),
+        kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(dafny_input.kdf),
+        commitment=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(dafny_input.commitment),
+        signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SignatureAlgorithm(dafny_input.signature),
+        symmetric_signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(dafny_input.symmetricSignature),
+        edk_wrapping=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EdkWrappingAlgorithm(dafny_input.edkWrapping),
     )
-
 
 def aws_cryptography_materialproviders_EncryptedDataKey(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptedDataKey(
-        key_provider_id=bytes(dafny_input.keyProviderId.Elements).decode("utf-8"),
+        key_provider_id=bytes(dafny_input.keyProviderId.Elements).decode('utf-8'),
         key_provider_info=bytes(dafny_input.keyProviderInfo),
         ciphertext=bytes(dafny_input.ciphertext),
     )
 
-
 def aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input):
     # Convert AlgorithmSuiteId
     if isinstance(dafny_input, AlgorithmSuiteId_ESDK):
-        AlgorithmSuiteId_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdESDK(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(
-                dafny_input.ESDK
-            )
-        )
+        AlgorithmSuiteId_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdESDK(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(dafny_input.ESDK))
     elif isinstance(dafny_input, AlgorithmSuiteId_DBE):
-        AlgorithmSuiteId_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdDBE(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DBEAlgorithmSuiteId(
-                dafny_input.DBE
-            )
-        )
+        AlgorithmSuiteId_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdDBE(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DBEAlgorithmSuiteId(dafny_input.DBE))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return AlgorithmSuiteId_union_value
 
-
 def aws_cryptography_materialproviders_Encrypt(dafny_input):
     # Convert Encrypt
     if isinstance(dafny_input, Encrypt_AES__GCM):
-        Encrypt_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptAES_GCM(
-            aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_AES_GCM(
-                dafny_input.AES__GCM
-            )
-        )
+        Encrypt_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptAES_GCM(aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_AES_GCM(dafny_input.AES__GCM))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return Encrypt_union_value
 
-
 def aws_cryptography_materialproviders_DerivationAlgorithm(dafny_input):
     # Convert DerivationAlgorithm
     if isinstance(dafny_input, DerivationAlgorithm_HKDF):
-        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmHKDF(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_HKDF(
-                dafny_input.HKDF
-            )
-        )
+        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmHKDF(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_HKDF(dafny_input.HKDF))
     elif isinstance(dafny_input, DerivationAlgorithm_IDENTITY):
-        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmIDENTITY(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_IDENTITY(
-                dafny_input.IDENTITY
-            )
-        )
+        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmIDENTITY(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_IDENTITY(dafny_input.IDENTITY))
     elif isinstance(dafny_input, DerivationAlgorithm_None):
-        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmNone(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(
-                dafny_input.None_
-            )
-        )
+        DerivationAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmNone(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(dafny_input.None_))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return DerivationAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_SignatureAlgorithm(dafny_input):
     # Convert SignatureAlgorithm
     if isinstance(dafny_input, SignatureAlgorithm_ECDSA):
-        SignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmECDSA(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ECDSA(
-                dafny_input.ECDSA
-            )
-        )
+        SignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmECDSA(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ECDSA(dafny_input.ECDSA))
     elif isinstance(dafny_input, SignatureAlgorithm_None):
-        SignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmNone(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(
-                dafny_input.None_
-            )
-        )
+        SignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmNone(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(dafny_input.None_))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return SignatureAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(dafny_input):
     # Convert SymmetricSignatureAlgorithm
     if isinstance(dafny_input, SymmetricSignatureAlgorithm_HMAC):
-        SymmetricSignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmHMAC(
-            aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_DigestAlgorithm(
-                dafny_input.HMAC
-            )
-        )
+        SymmetricSignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmHMAC(aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_DigestAlgorithm(dafny_input.HMAC))
     elif isinstance(dafny_input, SymmetricSignatureAlgorithm_None):
-        SymmetricSignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmNone(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(
-                dafny_input.None_
-            )
-        )
+        SymmetricSignatureAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmNone(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_None(dafny_input.None_))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return SymmetricSignatureAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_EdkWrappingAlgorithm(dafny_input):
     # Convert EdkWrappingAlgorithm
     if isinstance(dafny_input, EdkWrappingAlgorithm_DIRECT__KEY__WRAPPING):
-        EdkWrappingAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmDIRECT_KEY_WRAPPING(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(
-                dafny_input.DIRECT__KEY__WRAPPING
-            )
-        )
+        EdkWrappingAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmDIRECT_KEY_WRAPPING(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(dafny_input.DIRECT__KEY__WRAPPING))
     elif isinstance(dafny_input, EdkWrappingAlgorithm_IntermediateKeyWrapping):
-        EdkWrappingAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmIntermediateKeyWrapping(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_IntermediateKeyWrapping(
-                dafny_input.IntermediateKeyWrapping
-            )
-        )
+        EdkWrappingAlgorithm_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmIntermediateKeyWrapping(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_IntermediateKeyWrapping(dafny_input.IntermediateKeyWrapping))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return EdkWrappingAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(dafny_input):
-    if isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__NO__KDF
-    ):
-        return "0x0014"
+    if isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__NO__KDF):
+        return '0x0014'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__NO__KDF
-    ):
-        return "0x0046"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__NO__KDF):
+        return '0x0046'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__NO__KDF
-    ):
-        return "0x0078"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__NO__KDF):
+        return '0x0078'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256
-    ):
-        return "0x0114"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256):
+        return '0x0114'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA256
-    ):
-        return "0x0146"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA256):
+        return '0x0146'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA256
-    ):
-        return "0x0178"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA256):
+        return '0x0178'
 
-    elif isinstance(
-        dafny_input,
-        ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256__ECDSA__P256,
-    ):
-        return "0x0214"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256__ECDSA__P256):
+        return '0x0214'
 
-    elif isinstance(
-        dafny_input,
-        ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384,
-    ):
-        return "0x0346"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384):
+        return '0x0346'
 
-    elif isinstance(
-        dafny_input,
-        ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384,
-    ):
-        return "0x0378"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384):
+        return '0x0378'
 
-    elif isinstance(
-        dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY
-    ):
-        return "0x0478"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY):
+        return '0x0478'
 
-    elif isinstance(
-        dafny_input,
-        ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384,
-    ):
-        return "0x0578"
+    elif isinstance(dafny_input, ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384):
+        return '0x0578'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_DBEAlgorithmSuiteId(dafny_input):
-    if isinstance(
-        dafny_input,
-        DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__SYMSIG__HMAC__SHA384,
-    ):
-        return "0x6700"
+    if isinstance(dafny_input, DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__SYMSIG__HMAC__SHA384):
+        return '0x6700'
 
-    elif isinstance(
-        dafny_input,
-        DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384__SYMSIG__HMAC__SHA384,
-    ):
-        return "0x6701"
+    elif isinstance(dafny_input, DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384__SYMSIG__HMAC__SHA384):
+        return '0x6701'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_HKDF(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.HKDF(
-        hmac=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_DigestAlgorithm(
-            dafny_input.hmac
-        ),
+        hmac=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_DigestAlgorithm(dafny_input.hmac),
         salt_length=dafny_input.saltLength,
         input_key_length=dafny_input.inputKeyLength,
         output_key_length=dafny_input.outputKeyLength,
     )
 
-
 def aws_cryptography_materialproviders_IDENTITY(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.IDENTITY()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.IDENTITY(
     )
-
 
 def aws_cryptography_materialproviders_None(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.None_()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.None_(
     )
-
 
 def aws_cryptography_materialproviders_ECDSA(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ECDSA(
-        curve=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDSASignatureAlgorithm(
-            dafny_input.curve
-        ),
+        curve=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDSASignatureAlgorithm(dafny_input.curve),
     )
-
 
 def aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DIRECT_KEY_WRAPPING()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DIRECT_KEY_WRAPPING(
     )
-
 
 def aws_cryptography_materialproviders_IntermediateKeyWrapping(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.IntermediateKeyWrapping(
-        key_encryption_key_kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(
-            dafny_input.keyEncryptionKeyKdf
-        ),
-        mac_key_kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(
-            dafny_input.macKeyKdf
-        ),
-        pdk_encrypt_algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Encrypt(
-            dafny_input.pdkEncryptAlgorithm
-        ),
+        key_encryption_key_kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(dafny_input.keyEncryptionKeyKdf),
+        mac_key_kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DerivationAlgorithm(dafny_input.macKeyKdf),
+        pdk_encrypt_algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Encrypt(dafny_input.pdkEncryptAlgorithm),
     )
-
 
 def aws_cryptography_materialproviders_PutCacheEntryInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PutCacheEntryInput(
         identifier=bytes(dafny_input.identifier),
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Materials(
-            dafny_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Materials(dafny_input.materials),
         creation_time=dafny_input.creationTime,
         expiry_time=dafny_input.expiryTime,
-        messages_used=(
-            (dafny_input.messagesUsed.value)
-            if (dafny_input.messagesUsed.is_Some)
-            else None
-        ),
-        bytes_used=(
-            (dafny_input.bytesUsed.value) if (dafny_input.bytesUsed.is_Some) else None
-        ),
+        messages_used=(dafny_input.messagesUsed.value) if (dafny_input.messagesUsed.is_Some) else None,
+        bytes_used=(dafny_input.bytesUsed.value) if (dafny_input.bytesUsed.is_Some) else None,
     )
-
 
 def smithy_api_Unit():
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit(
     )
-
 
 def aws_cryptography_materialproviders_GetCacheEntryInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryInput(
         identifier=bytes(dafny_input.identifier),
-        bytes_used=(
-            (dafny_input.bytesUsed.value) if (dafny_input.bytesUsed.is_Some) else None
-        ),
+        bytes_used=(dafny_input.bytesUsed.value) if (dafny_input.bytesUsed.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_GetCacheEntryOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Materials(
-            dafny_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_Materials(dafny_input.materials),
         creation_time=dafny_input.creationTime,
         expiry_time=dafny_input.expiryTime,
         messages_used=dafny_input.messagesUsed,
         bytes_used=dafny_input.bytesUsed,
     )
-
 
 def aws_cryptography_materialproviders_UpdateUsageMetadataInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.UpdateUsageMetadataInput(
@@ -551,976 +328,378 @@ def aws_cryptography_materialproviders_UpdateUsageMetadataInput(dafny_input):
         bytes_used=dafny_input.bytesUsed,
     )
 
-
 def aws_cryptography_materialproviders_DeleteCacheEntryInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DeleteCacheEntryInput(
         identifier=bytes(dafny_input.identifier),
     )
 
-
 def aws_cryptography_materialproviders_CommitmentPolicy(dafny_input):
     # Convert CommitmentPolicy
     if isinstance(dafny_input, CommitmentPolicy_ESDK):
-        CommitmentPolicy_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyESDK(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ESDKCommitmentPolicy(
-                dafny_input.ESDK
-            )
-        )
+        CommitmentPolicy_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyESDK(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ESDKCommitmentPolicy(dafny_input.ESDK))
     elif isinstance(dafny_input, CommitmentPolicy_DBE):
-        CommitmentPolicy_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyDBE(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DBECommitmentPolicy(
-                dafny_input.DBE
-            )
-        )
+        CommitmentPolicy_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyDBE(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DBECommitmentPolicy(dafny_input.DBE))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return CommitmentPolicy_union_value
 
-
 def aws_cryptography_materialproviders_ESDKCommitmentPolicy(dafny_input):
     if isinstance(dafny_input, ESDKCommitmentPolicy_FORBID__ENCRYPT__ALLOW__DECRYPT):
-        return "FORBID_ENCRYPT_ALLOW_DECRYPT"
+        return 'FORBID_ENCRYPT_ALLOW_DECRYPT'
 
     elif isinstance(dafny_input, ESDKCommitmentPolicy_REQUIRE__ENCRYPT__ALLOW__DECRYPT):
-        return "REQUIRE_ENCRYPT_ALLOW_DECRYPT"
+        return 'REQUIRE_ENCRYPT_ALLOW_DECRYPT'
 
-    elif isinstance(
-        dafny_input, ESDKCommitmentPolicy_REQUIRE__ENCRYPT__REQUIRE__DECRYPT
-    ):
-        return "REQUIRE_ENCRYPT_REQUIRE_DECRYPT"
+    elif isinstance(dafny_input, ESDKCommitmentPolicy_REQUIRE__ENCRYPT__REQUIRE__DECRYPT):
+        return 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_DBECommitmentPolicy(dafny_input):
     if isinstance(dafny_input, DBECommitmentPolicy_REQUIRE__ENCRYPT__REQUIRE__DECRYPT):
-        return "REQUIRE_ENCRYPT_REQUIRE_DECRYPT"
+        return 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_GetEncryptionMaterialsInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsInput(
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(
-            dafny_input.commitmentPolicy
-        ),
-        algorithm_suite_id=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-                    dafny_input.algorithmSuiteId.value
-                )
-            )
-            if (dafny_input.algorithmSuiteId.is_Some)
-            else None
-        ),
-        max_plaintext_length=(
-            (dafny_input.maxPlaintextLength.value)
-            if (dafny_input.maxPlaintextLength.is_Some)
-            else None
-        ),
-        required_encryption_context_keys=(
-            (
-                [
-                    bytes(list_element.Elements).decode("utf-8")
-                    for list_element in dafny_input.requiredEncryptionContextKeys.value
-                ]
-            )
-            if (dafny_input.requiredEncryptionContextKeys.is_Some)
-            else None
-        ),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(dafny_input.commitmentPolicy),
+        algorithm_suite_id=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithmSuiteId.value)) if (dafny_input.algorithmSuiteId.is_Some) else None,
+        max_plaintext_length=(dafny_input.maxPlaintextLength.value) if (dafny_input.maxPlaintextLength.is_Some) else None,
+        required_encryption_context_keys=([bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys.value]) if (dafny_input.requiredEncryptionContextKeys.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_GetEncryptionMaterialsOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsOutput(
-        encryption_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-            dafny_input.encryptionMaterials
-        ),
+        encryption_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.encryptionMaterials),
     )
-
 
 def aws_cryptography_materialproviders_DecryptMaterialsInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsInput(
-        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.algorithmSuiteId
-        ),
-        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(
-            dafny_input.commitmentPolicy
-        ),
-        encrypted_data_keys=[
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(
-                list_element
-            )
-            for list_element in dafny_input.encryptedDataKeys
-        ],
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        reproduced_encryption_context=(
-            (
-                {
-                    bytes(key.Elements)
-                    .decode("utf-8"): bytes(value.Elements)
-                    .decode("utf-8")
-                    for (
-                        key,
-                        value,
-                    ) in dafny_input.reproducedEncryptionContext.value.items
-                }
-            )
-            if (dafny_input.reproducedEncryptionContext.is_Some)
-            else None
-        ),
+        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithmSuiteId),
+        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(dafny_input.commitmentPolicy),
+        encrypted_data_keys=[aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in dafny_input.encryptedDataKeys],
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        reproduced_encryption_context=({bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.reproducedEncryptionContext.value.items }) if (dafny_input.reproducedEncryptionContext.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_DecryptMaterialsOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsOutput(
-        decryption_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-            dafny_input.decryptionMaterials
-        ),
+        decryption_materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.decryptionMaterials),
     )
-
 
 def aws_cryptography_materialproviders_OnEncryptInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptInput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-            dafny_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_OnEncryptOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-            dafny_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_OnDecryptInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptInput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-            dafny_input.materials
-        ),
-        encrypted_data_keys=[
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(
-                list_element
-            )
-            for list_element in dafny_input.encryptedDataKeys
-        ],
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.materials),
+        encrypted_data_keys=[aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in dafny_input.encryptedDataKeys],
     )
-
 
 def aws_cryptography_materialproviders_OnDecryptOutput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-            dafny_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsKeyringInput(
-        kms_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.kmsKeyId
-        ).decode("utf-16-be"),
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient
-                )
-            )
-            if (dafny_input.kmsClient is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        kms_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.kmsKeyId).decode('utf-16-be'),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient)) if (dafny_input.kmsClient is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_DiscoveryFilter(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DiscoveryFilter(
-        account_ids=[
-            b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                "utf-16-be"
-            )
-            for list_element in dafny_input.accountIds
-        ],
-        partition=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.partition
-        ).decode("utf-16-be"),
+        account_ids=[b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.accountIds],
+        partition=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.partition).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryKeyringInput(
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient
-                )
-            )
-            if (dafny_input.kmsClient is not None)
-            else None
-        ),
-        discovery_filter=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(
-                    dafny_input.discoveryFilter.value
-                )
-            )
-            if (dafny_input.discoveryFilter.is_Some)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient)) if (dafny_input.kmsClient is not None) else None,
+        discovery_filter=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(dafny_input.discoveryFilter.value)) if (dafny_input.discoveryFilter.is_Some) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
 
-
 def aws_cryptography_materialproviders_ClientSupplierReference(dafny_input):
-    if hasattr(dafny_input, "_native_impl"):
+    if hasattr(dafny_input, '_native_impl'):
         return dafny_input._native_impl
 
     else:
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            ClientSupplier,
-        )
-
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import ClientSupplier
         return ClientSupplier(_impl=dafny_input)
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMultiKeyringInput(
-        generator=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big") for c in dafny_input.generator.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.generator.is_Some)
-            else None
-        ),
-        kms_key_ids=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.kmsKeyIds.value
-                ]
-            )
-            if (dafny_input.kmsKeyIds.is_Some)
-            else None
-        ),
-        client_supplier=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(
-                    dafny_input.clientSupplier.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.clientSupplier.UnwrapOr(None) is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        generator=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.generator.value).decode('utf-16-be')) if (dafny_input.generator.is_Some) else None,
+        kms_key_ids=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.kmsKeyIds.value]) if (dafny_input.kmsKeyIds.is_Some) else None,
+        client_supplier=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(dafny_input.clientSupplier.UnwrapOr(None))) if (dafny_input.clientSupplier.UnwrapOr(None) is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryMultiKeyringInput(
-        regions=[
-            b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                "utf-16-be"
-            )
-            for list_element in dafny_input.regions
-        ],
-        discovery_filter=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(
-                    dafny_input.discoveryFilter.value
-                )
-            )
-            if (dafny_input.discoveryFilter.is_Some)
-            else None
-        ),
-        client_supplier=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(
-                    dafny_input.clientSupplier.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.clientSupplier.UnwrapOr(None) is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        regions=[b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.regions],
+        discovery_filter=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(dafny_input.discoveryFilter.value)) if (dafny_input.discoveryFilter.is_Some) else None,
+        client_supplier=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(dafny_input.clientSupplier.UnwrapOr(None))) if (dafny_input.clientSupplier.UnwrapOr(None) is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkKeyringInput(
-        kms_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.kmsKeyId
-        ).decode("utf-16-be"),
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient
-                )
-            )
-            if (dafny_input.kmsClient is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        kms_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.kmsKeyId).decode('utf-16-be'),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient)) if (dafny_input.kmsClient is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkMultiKeyringInput(
-        generator=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big") for c in dafny_input.generator.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.generator.is_Some)
-            else None
-        ),
-        kms_key_ids=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.kmsKeyIds.value
-                ]
-            )
-            if (dafny_input.kmsKeyIds.is_Some)
-            else None
-        ),
-        client_supplier=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(
-                    dafny_input.clientSupplier.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.clientSupplier.UnwrapOr(None) is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        generator=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.generator.value).decode('utf-16-be')) if (dafny_input.generator.is_Some) else None,
+        kms_key_ids=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.kmsKeyIds.value]) if (dafny_input.kmsKeyIds.is_Some) else None,
+        client_supplier=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(dafny_input.clientSupplier.UnwrapOr(None))) if (dafny_input.clientSupplier.UnwrapOr(None) is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryKeyringInput(
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient
-                )
-            )
-            if (dafny_input.kmsClient is not None)
-            else None
-        ),
-        discovery_filter=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(
-                    dafny_input.discoveryFilter.value
-                )
-            )
-            if (dafny_input.discoveryFilter.is_Some)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
-        region=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.region).decode(
-            "utf-16-be"
-        ),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient)) if (dafny_input.kmsClient is not None) else None,
+        discovery_filter=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(dafny_input.discoveryFilter.value)) if (dafny_input.discoveryFilter.is_Some) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
+        region=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.region).decode('utf-16-be'),
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-        regions=[
-            b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                "utf-16-be"
-            )
-            for list_element in dafny_input.regions
-        ],
-        discovery_filter=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(
-                    dafny_input.discoveryFilter.value
-                )
-            )
-            if (dafny_input.discoveryFilter.is_Some)
-            else None
-        ),
-        client_supplier=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(
-                    dafny_input.clientSupplier.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.clientSupplier.UnwrapOr(None) is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        regions=[b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.regions],
+        discovery_filter=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(dafny_input.discoveryFilter.value)) if (dafny_input.discoveryFilter.is_Some) else None,
+        client_supplier=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(dafny_input.clientSupplier.UnwrapOr(None))) if (dafny_input.clientSupplier.UnwrapOr(None) is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_BranchKeyIdSupplierReference(dafny_input):
-    if hasattr(dafny_input, "_native_impl"):
+    if hasattr(dafny_input, '_native_impl'):
         return dafny_input._native_impl
 
     else:
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            BranchKeyIdSupplier,
-        )
-
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import BranchKeyIdSupplier
         return BranchKeyIdSupplier(_impl=dafny_input)
 
-
 def aws_cryptography_materialproviders_KeyStoreReference(dafny_input):
-    from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client import (
-        KeyStore,
-    )
-
+    from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client import KeyStore
     return KeyStore(config=None, dafny_client=dafny_input)
-
 
 def aws_cryptography_materialproviders_CacheType(dafny_input):
     # Convert CacheType
     if isinstance(dafny_input, CacheType_Default):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeDefault(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DefaultCache(
-                dafny_input.Default
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeDefault(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DefaultCache(dafny_input.Default))
     elif isinstance(dafny_input, CacheType_No):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeNo(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_NoCache(
-                dafny_input.No
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeNo(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_NoCache(dafny_input.No))
     elif isinstance(dafny_input, CacheType_SingleThreaded):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeSingleThreaded(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SingleThreadedCache(
-                dafny_input.SingleThreaded
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeSingleThreaded(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_SingleThreadedCache(dafny_input.SingleThreaded))
     elif isinstance(dafny_input, CacheType_MultiThreaded):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeMultiThreaded(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_MultiThreadedCache(
-                dafny_input.MultiThreaded
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeMultiThreaded(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_MultiThreadedCache(dafny_input.MultiThreaded))
     elif isinstance(dafny_input, CacheType_StormTracking):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeStormTracking(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_StormTrackingCache(
-                dafny_input.StormTracking
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeStormTracking(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_StormTrackingCache(dafny_input.StormTracking))
     elif isinstance(dafny_input, CacheType_Shared):
-        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeShared(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-                dafny_input.Shared
-            )
-        )
+        CacheType_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeShared(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(dafny_input.Shared))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return CacheType_union_value
-
 
 def aws_cryptography_materialproviders_DefaultCache(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DefaultCache(
         entry_capacity=dafny_input.entryCapacity,
     )
 
-
 def aws_cryptography_materialproviders_NoCache(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.NoCache()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.NoCache(
     )
-
 
 def aws_cryptography_materialproviders_SingleThreadedCache(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SingleThreadedCache(
         entry_capacity=dafny_input.entryCapacity,
-        entry_pruning_tail_size=(
-            (dafny_input.entryPruningTailSize.value)
-            if (dafny_input.entryPruningTailSize.is_Some)
-            else None
-        ),
+        entry_pruning_tail_size=(dafny_input.entryPruningTailSize.value) if (dafny_input.entryPruningTailSize.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_MultiThreadedCache(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MultiThreadedCache(
         entry_capacity=dafny_input.entryCapacity,
-        entry_pruning_tail_size=(
-            (dafny_input.entryPruningTailSize.value)
-            if (dafny_input.entryPruningTailSize.is_Some)
-            else None
-        ),
+        entry_pruning_tail_size=(dafny_input.entryPruningTailSize.value) if (dafny_input.entryPruningTailSize.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_StormTrackingCache(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StormTrackingCache(
         entry_capacity=dafny_input.entryCapacity,
-        entry_pruning_tail_size=(
-            (dafny_input.entryPruningTailSize.value)
-            if (dafny_input.entryPruningTailSize.is_Some)
-            else None
-        ),
+        entry_pruning_tail_size=(dafny_input.entryPruningTailSize.value) if (dafny_input.entryPruningTailSize.is_Some) else None,
         grace_period=dafny_input.gracePeriod,
         grace_interval=dafny_input.graceInterval,
         fan_out=dafny_input.fanOut,
         in_flight_ttl=dafny_input.inFlightTTL,
         sleep_milli=dafny_input.sleepMilli,
-        time_units=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_TimeUnits(
-                    dafny_input.timeUnits.value
-                )
-            )
-            if (dafny_input.timeUnits.is_Some)
-            else None
-        ),
+        time_units=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_TimeUnits(dafny_input.timeUnits.value)) if (dafny_input.timeUnits.is_Some) else None,
     )
 
-
-def aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-    dafny_input,
-):
-    if hasattr(dafny_input, "_native_impl"):
+def aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(dafny_input):
+    if hasattr(dafny_input, '_native_impl'):
         return dafny_input._native_impl
 
     else:
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            CryptographicMaterialsCache,
-        )
-
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import CryptographicMaterialsCache
         return CryptographicMaterialsCache(_impl=dafny_input)
-
 
 def aws_cryptography_materialproviders_TimeUnits(dafny_input):
     if isinstance(dafny_input, TimeUnits_Seconds):
-        return "Seconds"
+        return 'Seconds'
 
     elif isinstance(dafny_input, TimeUnits_Milliseconds):
-        return "Milliseconds"
+        return 'Milliseconds'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsHierarchicalKeyringInput(
-        branch_key_id=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big") for c in dafny_input.branchKeyId.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.branchKeyId.is_Some)
-            else None
-        ),
-        branch_key_id_supplier=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(
-                    dafny_input.branchKeyIdSupplier.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.branchKeyIdSupplier.UnwrapOr(None) is not None)
-            else None
-        ),
-        key_store=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyStoreReference(
-                    dafny_input.keyStore
-                )
-            )
-            if (dafny_input.keyStore is not None)
-            else None
-        ),
+        branch_key_id=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyId.value).decode('utf-16-be')) if (dafny_input.branchKeyId.is_Some) else None,
+        branch_key_id_supplier=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(dafny_input.branchKeyIdSupplier.UnwrapOr(None))) if (dafny_input.branchKeyIdSupplier.UnwrapOr(None) is not None) else None,
+        key_store=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyStoreReference(dafny_input.keyStore)) if (dafny_input.keyStore is not None) else None,
         ttl_seconds=dafny_input.ttlSeconds,
-        cache=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CacheType(
-                    dafny_input.cache.value
-                )
-            )
-            if (dafny_input.cache.is_Some)
-            else None
-        ),
-        partition_id=(
-            (
-                b"".join(
-                    ord(c).to_bytes(2, "big") for c in dafny_input.partitionId.value
-                ).decode("utf-16-be")
-            )
-            if (dafny_input.partitionId.is_Some)
-            else None
-        ),
+        cache=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CacheType(dafny_input.cache.value)) if (dafny_input.cache.is_Some) else None,
+        partition_id=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.partitionId.value).decode('utf-16-be')) if (dafny_input.partitionId.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsRsaKeyringInput(
-        public_key=(
-            (bytes(dafny_input.publicKey.value))
-            if (dafny_input.publicKey.is_Some)
-            else None
-        ),
-        kms_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.kmsKeyId
-        ).decode("utf-16-be"),
-        encryption_algorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.dafny_to_aws_sdk.com_amazonaws_kms_EncryptionAlgorithmSpec(
-            dafny_input.encryptionAlgorithm
-        ),
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.kmsClient.UnwrapOr(None) is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        public_key=(bytes(dafny_input.publicKey.value)) if (dafny_input.publicKey.is_Some) else None,
+        kms_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.kmsKeyId).decode('utf-16-be'),
+        encryption_algorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.dafny_to_aws_sdk.com_amazonaws_kms_EncryptionAlgorithmSpec(dafny_input.encryptionAlgorithm),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient.UnwrapOr(None))) if (dafny_input.kmsClient.UnwrapOr(None) is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(dafny_input):
     # Convert KmsEcdhStaticConfigurations
     if isinstance(dafny_input, KmsEcdhStaticConfigurations_KmsPublicKeyDiscovery):
-        KmsEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(
-                dafny_input.KmsPublicKeyDiscovery
-            )
-        )
-    elif isinstance(
-        dafny_input, KmsEcdhStaticConfigurations_KmsPrivateKeyToStaticPublicKey
-    ):
-        KmsEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(
-                dafny_input.KmsPrivateKeyToStaticPublicKey
-            )
-        )
+        KmsEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(dafny_input.KmsPublicKeyDiscovery))
+    elif isinstance(dafny_input, KmsEcdhStaticConfigurations_KmsPrivateKeyToStaticPublicKey):
+        KmsEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(dafny_input.KmsPrivateKeyToStaticPublicKey))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return KmsEcdhStaticConfigurations_union_value
 
-
 def aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsPublicKeyDiscoveryInput(
-        recipient_kms_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.recipientKmsIdentifier
-        ).decode("utf-16-be"),
+        recipient_kms_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.recipientKmsIdentifier).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsPrivateKeyToStaticPublicKeyInput(
-        sender_kms_identifier=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.senderKmsIdentifier
-        ).decode("utf-16-be"),
-        sender_public_key=(
-            (bytes(dafny_input.senderPublicKey.value))
-            if (dafny_input.senderPublicKey.is_Some)
-            else None
-        ),
+        sender_kms_identifier=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.senderKmsIdentifier).decode('utf-16-be'),
+        sender_public_key=(bytes(dafny_input.senderPublicKey.value)) if (dafny_input.senderPublicKey.is_Some) else None,
         recipient_public_key=bytes(dafny_input.recipientPublicKey),
     )
 
-
 def aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsEcdhKeyringInput(
-        key_agreement_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(
-            dafny_input.KeyAgreementScheme
-        ),
-        curve_spec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDHCurveSpec(
-            dafny_input.curveSpec
-        ),
-        kms_client=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(
-                    dafny_input.kmsClient
-                )
-            )
-            if (dafny_input.kmsClient is not None)
-            else None
-        ),
-        grant_tokens=(
-            (
-                [
-                    b"".join(ord(c).to_bytes(2, "big") for c in list_element).decode(
-                        "utf-16-be"
-                    )
-                    for list_element in dafny_input.grantTokens.value
-                ]
-            )
-            if (dafny_input.grantTokens.is_Some)
-            else None
-        ),
+        key_agreement_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(dafny_input.KeyAgreementScheme),
+        curve_spec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDHCurveSpec(dafny_input.curveSpec),
+        kms_client=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsClientReference(dafny_input.kmsClient)) if (dafny_input.kmsClient is not None) else None,
+        grant_tokens=([b''.join(ord(c).to_bytes(2, 'big') for c in list_element).decode('utf-16-be') for list_element in dafny_input.grantTokens.value]) if (dafny_input.grantTokens.is_Some) else None,
     )
 
-
 def aws_cryptography_materialproviders_KeyringReference(dafny_input):
-    if hasattr(dafny_input, "_native_impl"):
+    if hasattr(dafny_input, '_native_impl'):
         return dafny_input._native_impl
 
     else:
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            Keyring,
-        )
-
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import Keyring
         return Keyring(_impl=dafny_input)
-
 
 def aws_cryptography_materialproviders_CreateMultiKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateMultiKeyringInput(
-        generator=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(
-                    dafny_input.generator.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.generator.UnwrapOr(None) is not None)
-            else None
-        ),
-        child_keyrings=[
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(
-                list_element
-            )
-            for list_element in dafny_input.childKeyrings
-        ],
+        generator=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(dafny_input.generator.UnwrapOr(None))) if (dafny_input.generator.UnwrapOr(None) is not None) else None,
+        child_keyrings=[aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(list_element) for list_element in dafny_input.childKeyrings],
     )
-
 
 def aws_cryptography_materialproviders_AesWrappingAlg(dafny_input):
     if isinstance(dafny_input, AesWrappingAlg_ALG__AES128__GCM__IV12__TAG16):
-        return "ALG_AES128_GCM_IV12_TAG16"
+        return 'ALG_AES128_GCM_IV12_TAG16'
 
     elif isinstance(dafny_input, AesWrappingAlg_ALG__AES192__GCM__IV12__TAG16):
-        return "ALG_AES192_GCM_IV12_TAG16"
+        return 'ALG_AES192_GCM_IV12_TAG16'
 
     elif isinstance(dafny_input, AesWrappingAlg_ALG__AES256__GCM__IV12__TAG16):
-        return "ALG_AES256_GCM_IV12_TAG16"
+        return 'ALG_AES256_GCM_IV12_TAG16'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_CreateRawAesKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawAesKeyringInput(
-        key_namespace=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyNamespace
-        ).decode("utf-16-be"),
-        key_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyName
-        ).decode("utf-16-be"),
+        key_namespace=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyNamespace).decode('utf-16-be'),
+        key_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyName).decode('utf-16-be'),
         wrapping_key=bytes(dafny_input.wrappingKey),
-        wrapping_alg=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AesWrappingAlg(
-            dafny_input.wrappingAlg
-        ),
+        wrapping_alg=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AesWrappingAlg(dafny_input.wrappingAlg),
     )
-
 
 def aws_cryptography_materialproviders_PaddingScheme(dafny_input):
     if isinstance(dafny_input, PaddingScheme_PKCS1):
-        return "PKCS1"
+        return 'PKCS1'
 
     elif isinstance(dafny_input, PaddingScheme_OAEP__SHA1__MGF1):
-        return "OAEP_SHA1_MGF1"
+        return 'OAEP_SHA1_MGF1'
 
     elif isinstance(dafny_input, PaddingScheme_OAEP__SHA256__MGF1):
-        return "OAEP_SHA256_MGF1"
+        return 'OAEP_SHA256_MGF1'
 
     elif isinstance(dafny_input, PaddingScheme_OAEP__SHA384__MGF1):
-        return "OAEP_SHA384_MGF1"
+        return 'OAEP_SHA384_MGF1'
 
     elif isinstance(dafny_input, PaddingScheme_OAEP__SHA512__MGF1):
-        return "OAEP_SHA512_MGF1"
+        return 'OAEP_SHA512_MGF1'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviders_CreateRawRsaKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawRsaKeyringInput(
-        key_namespace=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyNamespace
-        ).decode("utf-16-be"),
-        key_name=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyName
-        ).decode("utf-16-be"),
-        padding_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PaddingScheme(
-            dafny_input.paddingScheme
-        ),
-        public_key=(
-            (bytes(dafny_input.publicKey.value))
-            if (dafny_input.publicKey.is_Some)
-            else None
-        ),
-        private_key=(
-            (bytes(dafny_input.privateKey.value))
-            if (dafny_input.privateKey.is_Some)
-            else None
-        ),
+        key_namespace=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyNamespace).decode('utf-16-be'),
+        key_name=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyName).decode('utf-16-be'),
+        padding_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PaddingScheme(dafny_input.paddingScheme),
+        public_key=(bytes(dafny_input.publicKey.value)) if (dafny_input.publicKey.is_Some) else None,
+        private_key=(bytes(dafny_input.privateKey.value)) if (dafny_input.privateKey.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_RawEcdhStaticConfigurations(dafny_input):
     # Convert RawEcdhStaticConfigurations
     if isinstance(dafny_input, RawEcdhStaticConfigurations_PublicKeyDiscovery):
-        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsPublicKeyDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PublicKeyDiscoveryInput(
-                dafny_input.PublicKeyDiscovery
-            )
-        )
-    elif isinstance(
-        dafny_input, RawEcdhStaticConfigurations_RawPrivateKeyToStaticPublicKey
-    ):
-        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(
-                dafny_input.RawPrivateKeyToStaticPublicKey
-            )
-        )
-    elif isinstance(
-        dafny_input, RawEcdhStaticConfigurations_EphemeralPrivateKeyToStaticPublicKey
-    ):
-        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(
-                dafny_input.EphemeralPrivateKeyToStaticPublicKey
-            )
-        )
+        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsPublicKeyDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PublicKeyDiscoveryInput(dafny_input.PublicKeyDiscovery))
+    elif isinstance(dafny_input, RawEcdhStaticConfigurations_RawPrivateKeyToStaticPublicKey):
+        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(dafny_input.RawPrivateKeyToStaticPublicKey))
+    elif isinstance(dafny_input, RawEcdhStaticConfigurations_EphemeralPrivateKeyToStaticPublicKey):
+        RawEcdhStaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(dafny_input.EphemeralPrivateKeyToStaticPublicKey))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return RawEcdhStaticConfigurations_union_value
 
-
 def aws_cryptography_materialproviders_PublicKeyDiscoveryInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PublicKeyDiscoveryInput(
         recipient_static_private_key=bytes(dafny_input.recipientStaticPrivateKey),
     )
-
 
 def aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawPrivateKeyToStaticPublicKeyInput(
@@ -1528,277 +707,141 @@ def aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(dafny
         recipient_public_key=bytes(dafny_input.recipientPublicKey),
     )
 
-
-def aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EphemeralPrivateKeyToStaticPublicKeyInput(
         recipient_public_key=bytes(dafny_input.recipientPublicKey),
     )
 
-
 def aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawEcdhKeyringInput(
-        key_agreement_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(
-            dafny_input.KeyAgreementScheme
-        ),
-        curve_spec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDHCurveSpec(
-            dafny_input.curveSpec
-        ),
+        key_agreement_scheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(dafny_input.KeyAgreementScheme),
+        curve_spec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.dafny_to_smithy.aws_cryptography_primitives_ECDHCurveSpec(dafny_input.curveSpec),
     )
 
-
-def aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultCryptographicMaterialsManagerInput(
-        keyring=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(
-                    dafny_input.keyring
-                )
-            )
-            if (dafny_input.keyring is not None)
-            else None
-        ),
+        keyring=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(dafny_input.keyring)) if (dafny_input.keyring is not None) else None,
     )
 
-
-def aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-    dafny_input,
-):
-    if hasattr(dafny_input, "_native_impl"):
+def aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(dafny_input):
+    if hasattr(dafny_input, '_native_impl'):
         return dafny_input._native_impl
 
     else:
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            CryptographicMaterialsManager,
-        )
-
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import CryptographicMaterialsManager
         return CryptographicMaterialsManager(_impl=dafny_input)
 
-
-def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRequiredEncryptionContextCMMInput(
-        underlying_cmm=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-                    dafny_input.underlyingCMM.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.underlyingCMM.UnwrapOr(None) is not None)
-            else None
-        ),
-        keyring=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(
-                    dafny_input.keyring.UnwrapOr(None)
-                )
-            )
-            if (dafny_input.keyring.UnwrapOr(None) is not None)
-            else None
-        ),
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
+        underlying_cmm=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(dafny_input.underlyingCMM.UnwrapOr(None))) if (dafny_input.underlyingCMM.UnwrapOr(None) is not None) else None,
+        keyring=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(dafny_input.keyring.UnwrapOr(None))) if (dafny_input.keyring.UnwrapOr(None) is not None) else None,
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
     )
 
-
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateCryptographicMaterialsCacheInput(
-        cache=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CacheType(
-            dafny_input.cache
-        ),
+        cache=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CacheType(dafny_input.cache),
     )
-
 
 def aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(dafny_input):
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultClientSupplierInput()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultClientSupplierInput(
     )
-
 
 def aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeEncryptionMaterialsInput(
-        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.algorithmSuiteId
-        ),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
-        signing_key=(
-            (bytes(dafny_input.signingKey.value))
-            if (dafny_input.signingKey.is_Some)
-            else None
-        ),
-        verification_key=(
-            (bytes(dafny_input.verificationKey.value))
-            if (dafny_input.verificationKey.is_Some)
-            else None
-        ),
+        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithmSuiteId),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
+        signing_key=(bytes(dafny_input.signingKey.value)) if (dafny_input.signingKey.is_Some) else None,
+        verification_key=(bytes(dafny_input.verificationKey.value)) if (dafny_input.verificationKey.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeDecryptionMaterialsInput(
-        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.algorithmSuiteId
-        ),
-        encryption_context={
-            bytes(key.Elements).decode("utf-8"): bytes(value.Elements).decode("utf-8")
-            for (key, value) in dafny_input.encryptionContext.items
-        },
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
+        algorithm_suite_id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithmSuiteId),
+        encryption_context={bytes(key.Elements).decode('utf-8'): bytes(value.Elements).decode('utf-8') for (key, value) in dafny_input.encryptionContext.items },
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
     )
 
-
-def aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidEncryptionMaterialsTransitionInput(
-        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-            dafny_input.start
-        ),
-        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-            dafny_input.stop
-        ),
+        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.start),
+        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(dafny_input.stop),
     )
 
-
-def aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidDecryptionMaterialsTransitionInput(
-        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-            dafny_input.start
-        ),
-        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-            dafny_input.stop
-        ),
+        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.start),
+        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(dafny_input.stop),
     )
-
 
 def aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(dafny_input):
     return bytes(dafny_input)
 
-
-def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnEncryptInput(
-        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.algorithm
-        ),
-        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(
-            dafny_input.commitmentPolicy
-        ),
+        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithm),
+        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(dafny_input.commitmentPolicy),
     )
 
-
-def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(dafny_input):
     return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnDecryptInput(
-        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            dafny_input.algorithm
-        ),
-        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(
-            dafny_input.commitmentPolicy
-        ),
+        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteId(dafny_input.algorithm),
+        commitment_policy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CommitmentPolicy(dafny_input.commitmentPolicy),
     )
 
+def aws_cryptography_materialproviders_GetCacheIdentifierInput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheIdentifierInput(
+        keyring=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(dafny_input.keyring)) if (dafny_input.keyring is not None) else None,
+        branch_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyId).decode('utf-16-be'),
+        branch_key_version=(b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.branchKeyVersion.value).decode('utf-16-be')) if (dafny_input.branchKeyVersion.is_Some) else None,
+    )
 
 def aws_cryptography_materialproviders_CreateKeyringOutput(dafny_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(
-        dafny_input
-    )
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KeyringReference(dafny_input)
 
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(dafny_input)
 
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(
-    dafny_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        dafny_input
-    )
+def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(dafny_input)
 
-
-def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(
-    dafny_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        dafny_input
-    )
-
-
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(
-    dafny_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-        dafny_input
-    )
-
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(dafny_input)
 
 def aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(dafny_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(
-        dafny_input
-    )
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ClientSupplierReference(dafny_input)
 
+def aws_cryptography_materialproviders_GetCacheIdentifierOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheIdentifierOutput(
+        identifier=bytes(dafny_input.identifier),
+    )
 
 def aws_cryptography_materialproviders_DdbClientReference(dafny_input):
     return dafny_input._impl
 
-
 def aws_cryptography_materialproviders_StaticConfigurations(dafny_input):
     # Convert StaticConfigurations
     if isinstance(dafny_input, StaticConfigurations_AWS__KMS__ECDH):
-        StaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsAWS_KMS_ECDH(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(
-                dafny_input.AWS__KMS__ECDH
-            )
-        )
+        StaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsAWS_KMS_ECDH(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(dafny_input.AWS__KMS__ECDH))
     elif isinstance(dafny_input, StaticConfigurations_RAW__ECDH):
-        StaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsRAW_ECDH(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(
-                dafny_input.RAW__ECDH
-            )
-        )
+        StaticConfigurations_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsRAW_ECDH(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(dafny_input.RAW__ECDH))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return StaticConfigurations_union_value
 
-
 def aws_cryptography_materialproviders_KeyAgreementScheme(dafny_input):
     # Convert KeyAgreementScheme
     if isinstance(dafny_input, KeyAgreementScheme_StaticConfiguration):
-        KeyAgreementScheme_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KeyAgreementSchemeStaticConfiguration(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_StaticConfigurations(
-                dafny_input.StaticConfiguration
-            )
-        )
+        KeyAgreementScheme_union_value = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KeyAgreementSchemeStaticConfiguration(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_StaticConfigurations(dafny_input.StaticConfiguration))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return KeyAgreementScheme_union_value
 
-
 def aws_cryptography_materialproviders_MaterialProvidersConfig(dafny_input):
     # Deferred import of .config to avoid circular dependency
     import aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.config
-
-    return (
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.config.MaterialProvidersConfig()
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.config.MaterialProvidersConfig(
     )

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/deserialize.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/deserialize.py
@@ -18,6 +18,7 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     Error_InvalidDecryptionMaterialsTransition,
     Error_InvalidEncryptionMaterials,
     Error_InvalidEncryptionMaterialsTransition,
+    GetCacheIdentifierOutput_GetCacheIdentifierOutput as DafnyGetCacheIdentifierOutput,
 )
 import aws_cryptographic_material_providers.internaldafny.generated.module_
 import aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy
@@ -63,342 +64,219 @@ from .config import Config
 
 def _deserialize_create_aws_kms_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_discovery_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_multi_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
+def _deserialize_create_aws_kms_discovery_multi_keyring(input: DafnyResponse, config: Config):
 
-def _deserialize_create_aws_kms_discovery_multi_keyring(
-    input: DafnyResponse, config: Config
-):
-
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_mrk_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_mrk_multi_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
+def _deserialize_create_aws_kms_mrk_discovery_keyring(input: DafnyResponse, config: Config):
 
-def _deserialize_create_aws_kms_mrk_discovery_keyring(
-    input: DafnyResponse, config: Config
-):
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
+def _deserialize_create_aws_kms_mrk_discovery_multi_keyring(input: DafnyResponse, config: Config):
 
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
-def _deserialize_create_aws_kms_mrk_discovery_multi_keyring(
-    input: DafnyResponse, config: Config
-):
+def _deserialize_create_aws_kms_hierarchical_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
-
-def _deserialize_create_aws_kms_hierarchical_keyring(
-    input: DafnyResponse, config: Config
-):
-
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_rsa_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_aws_kms_ecdh_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_multi_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_raw_aes_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_raw_rsa_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_raw_ecdh_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
+def _deserialize_create_default_cryptographic_materials_manager(input: DafnyResponse, config: Config):
 
-def _deserialize_create_default_cryptographic_materials_manager(
-    input: DafnyResponse, config: Config
-):
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(input.value)
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(
-        input.value
-    )
+def _deserialize_create_required_encryption_context_cmm(input: DafnyResponse, config: Config):
 
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(input.value)
 
-def _deserialize_create_required_encryption_context_cmm(
-    input: DafnyResponse, config: Config
-):
+def _deserialize_create_cryptographic_materials_cache(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(
-        input.value
-    )
-
-
-def _deserialize_create_cryptographic_materials_cache(
-    input: DafnyResponse, config: Config
-):
-
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(input.value)
 
 def _deserialize_create_default_client_supplier(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(input.value)
 
 def _deserialize_initialize_encryption_materials(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(input.value)
 
 def _deserialize_initialize_decryption_materials(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(input.value)
 
+def _deserialize_valid_encryption_materials_transition(input: DafnyResponse, config: Config):
 
-def _deserialize_valid_encryption_materials_transition(
-    input: DafnyResponse, config: Config
-):
+  return None
 
-    return None
+def _deserialize_valid_decryption_materials_transition(input: DafnyResponse, config: Config):
 
+  return None
 
-def _deserialize_valid_decryption_materials_transition(
-    input: DafnyResponse, config: Config
-):
+def _deserialize_encryption_materials_has_plaintext_data_key(input: DafnyResponse, config: Config):
 
-    return None
+  return None
 
+def _deserialize_decryption_materials_with_plaintext_data_key(input: DafnyResponse, config: Config):
 
-def _deserialize_encryption_materials_has_plaintext_data_key(
-    input: DafnyResponse, config: Config
-):
-
-    return None
-
-
-def _deserialize_decryption_materials_with_plaintext_data_key(
-    input: DafnyResponse, config: Config
-):
-
-    return None
-
+  return None
 
 def _deserialize_get_algorithm_suite_info(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(input.value)
 
 def _deserialize_valid_algorithm_suite_info(input: DafnyResponse, config: Config):
 
-    return None
+  return None
 
+def _deserialize_validate_commitment_policy_on_encrypt(input: DafnyResponse, config: Config):
 
-def _deserialize_validate_commitment_policy_on_encrypt(
-    input: DafnyResponse, config: Config
-):
+  return None
 
-    return None
+def _deserialize_validate_commitment_policy_on_decrypt(input: DafnyResponse, config: Config):
 
+  return None
 
-def _deserialize_validate_commitment_policy_on_decrypt(
-    input: DafnyResponse, config: Config
-):
+def _deserialize_get_cache_identifier(input: DafnyResponse, config: Config):
 
-    return None
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetCacheIdentifierOutput(input.value)
 
 def _deserialize_error(error: Error) -> ServiceError:
     if error.is_Opaque:
         return OpaqueError(obj=error.obj)
     elif error.is_OpaqueWithText:
-        return OpaqueWithTextError(
-            obj=error.obj, obj_message=_dafny.string_of(error.objMessage)
-        )
+        return OpaqueWithTextError(obj=error.obj, obj_message=_dafny.string_of(error.objMessage))
     elif error.is_CollectionOfErrors:
         return CollectionOfErrors(
             message=_dafny.string_of(error.message),
             list=[_deserialize_error(dafny_e) for dafny_e in error.list],
         )
     elif error.is_AwsCryptographicMaterialProvidersException:
-        return AwsCryptographicMaterialProvidersException(
-            message=_dafny.string_of(error.message)
-        )
+      return AwsCryptographicMaterialProvidersException(message=_dafny.string_of(error.message))
     elif error.is_EntryAlreadyExists:
-        return EntryAlreadyExists(message=_dafny.string_of(error.message))
+      return EntryAlreadyExists(message=_dafny.string_of(error.message))
     elif error.is_EntryDoesNotExist:
-        return EntryDoesNotExist(message=_dafny.string_of(error.message))
+      return EntryDoesNotExist(message=_dafny.string_of(error.message))
     elif error.is_InFlightTTLExceeded:
-        return InFlightTTLExceeded(message=_dafny.string_of(error.message))
+      return InFlightTTLExceeded(message=_dafny.string_of(error.message))
     elif error.is_InvalidAlgorithmSuiteInfo:
-        return InvalidAlgorithmSuiteInfo(message=_dafny.string_of(error.message))
+      return InvalidAlgorithmSuiteInfo(message=_dafny.string_of(error.message))
     elif error.is_InvalidAlgorithmSuiteInfoOnDecrypt:
-        return InvalidAlgorithmSuiteInfoOnDecrypt(
-            message=_dafny.string_of(error.message)
-        )
+      return InvalidAlgorithmSuiteInfoOnDecrypt(message=_dafny.string_of(error.message))
     elif error.is_InvalidAlgorithmSuiteInfoOnEncrypt:
-        return InvalidAlgorithmSuiteInfoOnEncrypt(
-            message=_dafny.string_of(error.message)
-        )
+      return InvalidAlgorithmSuiteInfoOnEncrypt(message=_dafny.string_of(error.message))
     elif error.is_InvalidDecryptionMaterials:
-        return InvalidDecryptionMaterials(message=_dafny.string_of(error.message))
+      return InvalidDecryptionMaterials(message=_dafny.string_of(error.message))
     elif error.is_InvalidDecryptionMaterialsTransition:
-        return InvalidDecryptionMaterialsTransition(
-            message=_dafny.string_of(error.message)
-        )
+      return InvalidDecryptionMaterialsTransition(message=_dafny.string_of(error.message))
     elif error.is_InvalidEncryptionMaterials:
-        return InvalidEncryptionMaterials(message=_dafny.string_of(error.message))
+      return InvalidEncryptionMaterials(message=_dafny.string_of(error.message))
     elif error.is_InvalidEncryptionMaterialsTransition:
-        return InvalidEncryptionMaterialsTransition(
-            message=_dafny.string_of(error.message)
-        )
+      return InvalidEncryptionMaterialsTransition(message=_dafny.string_of(error.message))
     elif error.is_AwsCryptographyPrimitives:
-        return AwsCryptographicPrimitives(
-            aws_cryptography_primitives_deserialize_error(
-                error.AwsCryptographyPrimitives
-            )
-        )
+        return AwsCryptographicPrimitives(aws_cryptography_primitives_deserialize_error(error.AwsCryptographyPrimitives))
     elif error.is_AwsCryptographyKeyStore:
-        return KeyStore(
-            aws_cryptography_keystore_deserialize_error(error.AwsCryptographyKeyStore)
-        )
+        return KeyStore(aws_cryptography_keystore_deserialize_error(error.AwsCryptographyKeyStore))
     elif error.is_ComAmazonawsKms:
         if hasattr(error.ComAmazonawsKms, "objMessage"):
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.objMessage)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.objMessage))
         elif hasattr(error.ComAmazonawsKms, "Message"):
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.Message)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.Message))
         else:
-            return ComAmazonawsKms(
-                message=_dafny.string_of(error.ComAmazonawsKms.message)
-            )
+            return ComAmazonawsKms(message=_dafny.string_of(error.ComAmazonawsKms.message))
     elif error.is_ComAmazonawsDynamodb:
         if hasattr(error.ComAmazonawsDynamodb, "objMessage"):
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.objMessage)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.objMessage))
         elif hasattr(error.ComAmazonawsDynamodb, "Message"):
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.Message)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.Message))
         else:
-            return ComAmazonawsDynamodb(
-                message=_dafny.string_of(error.ComAmazonawsDynamodb.message)
-            )
+            return ComAmazonawsDynamodb(message=_dafny.string_of(error.ComAmazonawsDynamodb.message))
     else:
         return OpaqueError(obj=error)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/errors.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/errors.py
@@ -22,38 +22,27 @@ from typing import Any, Dict, Generic, List, Literal, TypeVar
 
 
 class ServiceError(Exception):
-    """Base error for all errors in the service."""
-
+    """Base error for all errors in the service.
+    """
     pass
 
-
-T = TypeVar("T")
-
-
+T = TypeVar('T')
 class ApiError(ServiceError, Generic[T]):
-    """Base error for all api errors in the service."""
-
+    """Base error for all api errors in the service.
+    """
     code: T
-
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
 
+class UnknownApiError(ApiError[Literal['Unknown']]):
+    """Error representing any unknown api errors
+    """
+    code: Literal['Unknown'] = 'Unknown'
 
-class UnknownApiError(ApiError[Literal["Unknown"]]):
-    """Error representing any unknown api errors."""
-
-    code: Literal["Unknown"] = "Unknown"
-
-
-class AwsCryptographicMaterialProvidersException(
-    ApiError[Literal["AwsCryptographicMaterialProvidersException"]]
-):
-    code: Literal["AwsCryptographicMaterialProvidersException"] = (
-        "AwsCryptographicMaterialProvidersException"
-    )
+class AwsCryptographicMaterialProvidersException(ApiError[Literal["AwsCryptographicMaterialProvidersException"]]):
+    code: Literal["AwsCryptographicMaterialProvidersException"] = "AwsCryptographicMaterialProvidersException"
     message: str
-
     def __init__(
         self,
         *,
@@ -62,19 +51,21 @@ class AwsCryptographicMaterialProvidersException(
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the AwsCryptographicMaterialProvidersException to a
-        dictionary."""
+        """Converts the AwsCryptographicMaterialProvidersException to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "AwsCryptographicMaterialProvidersException":
-        """Creates a AwsCryptographicMaterialProvidersException from a
-        dictionary."""
+        """Creates a AwsCryptographicMaterialProvidersException from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return AwsCryptographicMaterialProvidersException(**kwargs)
@@ -89,41 +80,43 @@ class AwsCryptographicMaterialProvidersException(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, AwsCryptographicMaterialProvidersException):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class EntryDoesNotExist(ApiError[Literal["EntryDoesNotExist"]]):
     code: Literal["EntryDoesNotExist"] = "EntryDoesNotExist"
     message: str
-
     def __init__(
         self,
         *,
         message: str,
     ):
-        """The requested element is not in the cache; AWS Crypto Tools intends
-        to deprecate this for a non-error control scheme.
-
+        """The requested element is not in the cache; AWS Crypto Tools intends to deprecate
+        this for a non-error control scheme.
         :param message: A message associated with the specific error.
+
         """
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the EntryDoesNotExist to a dictionary."""
+        """Converts the EntryDoesNotExist to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EntryDoesNotExist":
-        """Creates a EntryDoesNotExist from a dictionary."""
+        """Creates a EntryDoesNotExist from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return EntryDoesNotExist(**kwargs)
@@ -138,27 +131,31 @@ class EntryDoesNotExist(ApiError[Literal["EntryDoesNotExist"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EntryDoesNotExist):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InFlightTTLExceeded(ApiError[Literal["InFlightTTLExceeded"]]):
     code: Literal["InFlightTTLExceeded"] = "InFlightTTLExceeded"
     message: str
-
     def __init__(
         self,
         *,
         message: str,
     ):
-        """Thrown if a request is waiting for longer than `inflightTTL`. The
-        Storm Tracking Cache protects against unbounded parallelism. The Storm
-        Tracking Cache will only work `fanOut` number of concurrent requests.
-        As requests are completed, queued requests are worked. If a request is
-        not worked in less than `inflightTTL`, this exception is thrown.
+        """Thrown if a request is waiting for longer than `inflightTTL`.
+        The Storm Tracking
+        Cache protects against unbounded parallelism.
+        The Storm Tracking Cache will only
+        work `fanOut` number of concurrent requests.
+        As requests are completed,
+        queued
+        requests are worked.
+        If a request is not worked in less than `inflightTTL`,
+        this
+        exception is thrown.
 
         Note that this exception does NOT imply that the material
         requested
@@ -168,21 +165,26 @@ class InFlightTTLExceeded(ApiError[Literal["InFlightTTLExceeded"]]):
         with the given `fanOut` and `inflightTTL`
         constraints.
         :param message: A message associated with the specific error.
+
         """
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InFlightTTLExceeded to a dictionary."""
+        """Converts the InFlightTTLExceeded to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InFlightTTLExceeded":
-        """Creates a InFlightTTLExceeded from a dictionary."""
+        """Creates a InFlightTTLExceeded from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InFlightTTLExceeded(**kwargs)
@@ -197,17 +199,15 @@ class InFlightTTLExceeded(ApiError[Literal["InFlightTTLExceeded"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InFlightTTLExceeded):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InvalidDecryptionMaterials(ApiError[Literal["InvalidDecryptionMaterials"]]):
     code: Literal["InvalidDecryptionMaterials"] = "InvalidDecryptionMaterials"
     message: str
-
     def __init__(
         self,
         *,
@@ -216,17 +216,21 @@ class InvalidDecryptionMaterials(ApiError[Literal["InvalidDecryptionMaterials"]]
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidDecryptionMaterials to a dictionary."""
+        """Converts the InvalidDecryptionMaterials to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidDecryptionMaterials":
-        """Creates a InvalidDecryptionMaterials from a dictionary."""
+        """Creates a InvalidDecryptionMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidDecryptionMaterials(**kwargs)
@@ -241,17 +245,15 @@ class InvalidDecryptionMaterials(ApiError[Literal["InvalidDecryptionMaterials"]]
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidDecryptionMaterials):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InvalidEncryptionMaterials(ApiError[Literal["InvalidEncryptionMaterials"]]):
     code: Literal["InvalidEncryptionMaterials"] = "InvalidEncryptionMaterials"
     message: str
-
     def __init__(
         self,
         *,
@@ -260,17 +262,21 @@ class InvalidEncryptionMaterials(ApiError[Literal["InvalidEncryptionMaterials"]]
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidEncryptionMaterials to a dictionary."""
+        """Converts the InvalidEncryptionMaterials to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidEncryptionMaterials":
-        """Creates a InvalidEncryptionMaterials from a dictionary."""
+        """Creates a InvalidEncryptionMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidEncryptionMaterials(**kwargs)
@@ -285,17 +291,15 @@ class InvalidEncryptionMaterials(ApiError[Literal["InvalidEncryptionMaterials"]]
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidEncryptionMaterials):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InvalidAlgorithmSuiteInfo(ApiError[Literal["InvalidAlgorithmSuiteInfo"]]):
     code: Literal["InvalidAlgorithmSuiteInfo"] = "InvalidAlgorithmSuiteInfo"
     message: str
-
     def __init__(
         self,
         *,
@@ -304,17 +308,21 @@ class InvalidAlgorithmSuiteInfo(ApiError[Literal["InvalidAlgorithmSuiteInfo"]]):
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidAlgorithmSuiteInfo to a dictionary."""
+        """Converts the InvalidAlgorithmSuiteInfo to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidAlgorithmSuiteInfo":
-        """Creates a InvalidAlgorithmSuiteInfo from a dictionary."""
+        """Creates a InvalidAlgorithmSuiteInfo from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidAlgorithmSuiteInfo(**kwargs)
@@ -329,21 +337,15 @@ class InvalidAlgorithmSuiteInfo(ApiError[Literal["InvalidAlgorithmSuiteInfo"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidAlgorithmSuiteInfo):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class InvalidAlgorithmSuiteInfoOnDecrypt(
-    ApiError[Literal["InvalidAlgorithmSuiteInfoOnDecrypt"]]
-):
-    code: Literal["InvalidAlgorithmSuiteInfoOnDecrypt"] = (
-        "InvalidAlgorithmSuiteInfoOnDecrypt"
-    )
+class InvalidAlgorithmSuiteInfoOnDecrypt(ApiError[Literal["InvalidAlgorithmSuiteInfoOnDecrypt"]]):
+    code: Literal["InvalidAlgorithmSuiteInfoOnDecrypt"] = "InvalidAlgorithmSuiteInfoOnDecrypt"
     message: str
-
     def __init__(
         self,
         *,
@@ -352,17 +354,21 @@ class InvalidAlgorithmSuiteInfoOnDecrypt(
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidAlgorithmSuiteInfoOnDecrypt to a dictionary."""
+        """Converts the InvalidAlgorithmSuiteInfoOnDecrypt to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidAlgorithmSuiteInfoOnDecrypt":
-        """Creates a InvalidAlgorithmSuiteInfoOnDecrypt from a dictionary."""
+        """Creates a InvalidAlgorithmSuiteInfoOnDecrypt from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidAlgorithmSuiteInfoOnDecrypt(**kwargs)
@@ -377,21 +383,15 @@ class InvalidAlgorithmSuiteInfoOnDecrypt(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidAlgorithmSuiteInfoOnDecrypt):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class InvalidAlgorithmSuiteInfoOnEncrypt(
-    ApiError[Literal["InvalidAlgorithmSuiteInfoOnEncrypt"]]
-):
-    code: Literal["InvalidAlgorithmSuiteInfoOnEncrypt"] = (
-        "InvalidAlgorithmSuiteInfoOnEncrypt"
-    )
+class InvalidAlgorithmSuiteInfoOnEncrypt(ApiError[Literal["InvalidAlgorithmSuiteInfoOnEncrypt"]]):
+    code: Literal["InvalidAlgorithmSuiteInfoOnEncrypt"] = "InvalidAlgorithmSuiteInfoOnEncrypt"
     message: str
-
     def __init__(
         self,
         *,
@@ -400,17 +400,21 @@ class InvalidAlgorithmSuiteInfoOnEncrypt(
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidAlgorithmSuiteInfoOnEncrypt to a dictionary."""
+        """Converts the InvalidAlgorithmSuiteInfoOnEncrypt to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidAlgorithmSuiteInfoOnEncrypt":
-        """Creates a InvalidAlgorithmSuiteInfoOnEncrypt from a dictionary."""
+        """Creates a InvalidAlgorithmSuiteInfoOnEncrypt from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidAlgorithmSuiteInfoOnEncrypt(**kwargs)
@@ -425,21 +429,15 @@ class InvalidAlgorithmSuiteInfoOnEncrypt(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidAlgorithmSuiteInfoOnEncrypt):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class InvalidDecryptionMaterialsTransition(
-    ApiError[Literal["InvalidDecryptionMaterialsTransition"]]
-):
-    code: Literal["InvalidDecryptionMaterialsTransition"] = (
-        "InvalidDecryptionMaterialsTransition"
-    )
+class InvalidDecryptionMaterialsTransition(ApiError[Literal["InvalidDecryptionMaterialsTransition"]]):
+    code: Literal["InvalidDecryptionMaterialsTransition"] = "InvalidDecryptionMaterialsTransition"
     message: str
-
     def __init__(
         self,
         *,
@@ -448,18 +446,21 @@ class InvalidDecryptionMaterialsTransition(
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidDecryptionMaterialsTransition to a
-        dictionary."""
+        """Converts the InvalidDecryptionMaterialsTransition to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidDecryptionMaterialsTransition":
-        """Creates a InvalidDecryptionMaterialsTransition from a dictionary."""
+        """Creates a InvalidDecryptionMaterialsTransition from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidDecryptionMaterialsTransition(**kwargs)
@@ -474,21 +475,15 @@ class InvalidDecryptionMaterialsTransition(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidDecryptionMaterialsTransition):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class InvalidEncryptionMaterialsTransition(
-    ApiError[Literal["InvalidEncryptionMaterialsTransition"]]
-):
-    code: Literal["InvalidEncryptionMaterialsTransition"] = (
-        "InvalidEncryptionMaterialsTransition"
-    )
+class InvalidEncryptionMaterialsTransition(ApiError[Literal["InvalidEncryptionMaterialsTransition"]]):
+    code: Literal["InvalidEncryptionMaterialsTransition"] = "InvalidEncryptionMaterialsTransition"
     message: str
-
     def __init__(
         self,
         *,
@@ -497,18 +492,21 @@ class InvalidEncryptionMaterialsTransition(
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InvalidEncryptionMaterialsTransition to a
-        dictionary."""
+        """Converts the InvalidEncryptionMaterialsTransition to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InvalidEncryptionMaterialsTransition":
-        """Creates a InvalidEncryptionMaterialsTransition from a dictionary."""
+        """Creates a InvalidEncryptionMaterialsTransition from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return InvalidEncryptionMaterialsTransition(**kwargs)
@@ -523,17 +521,15 @@ class InvalidEncryptionMaterialsTransition(
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InvalidEncryptionMaterialsTransition):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class EntryAlreadyExists(ApiError[Literal["EntryAlreadyExists"]]):
     code: Literal["EntryAlreadyExists"] = "EntryAlreadyExists"
     message: str
-
     def __init__(
         self,
         *,
@@ -542,17 +538,21 @@ class EntryAlreadyExists(ApiError[Literal["EntryAlreadyExists"]]):
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the EntryAlreadyExists to a dictionary."""
+        """Converts the EntryAlreadyExists to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EntryAlreadyExists":
-        """Creates a EntryAlreadyExists from a dictionary."""
+        """Creates a EntryAlreadyExists from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return EntryAlreadyExists(**kwargs)
@@ -567,143 +567,114 @@ class EntryAlreadyExists(ApiError[Literal["EntryAlreadyExists"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EntryAlreadyExists):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class AwsCryptographicMaterialProvidersException(
-    ApiError[Literal["AwsCryptographicMaterialProvidersException"]]
-):
-    code: Literal["AwsCryptographicMaterialProvidersException"] = (
-        "AwsCryptographicMaterialProvidersException"
-    )
+class AwsCryptographicMaterialProvidersException(ApiError[Literal["AwsCryptographicMaterialProvidersException"]]):
+    code: Literal["AwsCryptographicMaterialProvidersException"] = "AwsCryptographicMaterialProvidersException"
     message: str
-
 
 class EntryAlreadyExists(ApiError[Literal["EntryAlreadyExists"]]):
     code: Literal["EntryAlreadyExists"] = "EntryAlreadyExists"
     message: str
 
-
 class EntryDoesNotExist(ApiError[Literal["EntryDoesNotExist"]]):
     code: Literal["EntryDoesNotExist"] = "EntryDoesNotExist"
     message: str
-
 
 class InFlightTTLExceeded(ApiError[Literal["InFlightTTLExceeded"]]):
     code: Literal["InFlightTTLExceeded"] = "InFlightTTLExceeded"
     message: str
 
-
 class InvalidAlgorithmSuiteInfo(ApiError[Literal["InvalidAlgorithmSuiteInfo"]]):
     code: Literal["InvalidAlgorithmSuiteInfo"] = "InvalidAlgorithmSuiteInfo"
     message: str
 
-
-class InvalidAlgorithmSuiteInfoOnDecrypt(
-    ApiError[Literal["InvalidAlgorithmSuiteInfoOnDecrypt"]]
-):
-    code: Literal["InvalidAlgorithmSuiteInfoOnDecrypt"] = (
-        "InvalidAlgorithmSuiteInfoOnDecrypt"
-    )
+class InvalidAlgorithmSuiteInfoOnDecrypt(ApiError[Literal["InvalidAlgorithmSuiteInfoOnDecrypt"]]):
+    code: Literal["InvalidAlgorithmSuiteInfoOnDecrypt"] = "InvalidAlgorithmSuiteInfoOnDecrypt"
     message: str
 
-
-class InvalidAlgorithmSuiteInfoOnEncrypt(
-    ApiError[Literal["InvalidAlgorithmSuiteInfoOnEncrypt"]]
-):
-    code: Literal["InvalidAlgorithmSuiteInfoOnEncrypt"] = (
-        "InvalidAlgorithmSuiteInfoOnEncrypt"
-    )
+class InvalidAlgorithmSuiteInfoOnEncrypt(ApiError[Literal["InvalidAlgorithmSuiteInfoOnEncrypt"]]):
+    code: Literal["InvalidAlgorithmSuiteInfoOnEncrypt"] = "InvalidAlgorithmSuiteInfoOnEncrypt"
     message: str
-
 
 class InvalidDecryptionMaterials(ApiError[Literal["InvalidDecryptionMaterials"]]):
     code: Literal["InvalidDecryptionMaterials"] = "InvalidDecryptionMaterials"
     message: str
 
-
-class InvalidDecryptionMaterialsTransition(
-    ApiError[Literal["InvalidDecryptionMaterialsTransition"]]
-):
-    code: Literal["InvalidDecryptionMaterialsTransition"] = (
-        "InvalidDecryptionMaterialsTransition"
-    )
+class InvalidDecryptionMaterialsTransition(ApiError[Literal["InvalidDecryptionMaterialsTransition"]]):
+    code: Literal["InvalidDecryptionMaterialsTransition"] = "InvalidDecryptionMaterialsTransition"
     message: str
-
 
 class InvalidEncryptionMaterials(ApiError[Literal["InvalidEncryptionMaterials"]]):
     code: Literal["InvalidEncryptionMaterials"] = "InvalidEncryptionMaterials"
     message: str
 
-
-class InvalidEncryptionMaterialsTransition(
-    ApiError[Literal["InvalidEncryptionMaterialsTransition"]]
-):
-    code: Literal["InvalidEncryptionMaterialsTransition"] = (
-        "InvalidEncryptionMaterialsTransition"
-    )
+class InvalidEncryptionMaterialsTransition(ApiError[Literal["InvalidEncryptionMaterialsTransition"]]):
+    code: Literal["InvalidEncryptionMaterialsTransition"] = "InvalidEncryptionMaterialsTransition"
     message: str
-
 
 class AwsCryptographicPrimitives(ApiError[Literal["AwsCryptographicPrimitives"]]):
     AwsCryptographicPrimitives: Any
 
-
 class ComAmazonawsDynamodb(ApiError[Literal["ComAmazonawsDynamodb"]]):
     ComAmazonawsDynamodb: Any
-
 
 class ComAmazonawsKms(ApiError[Literal["ComAmazonawsKms"]]):
     ComAmazonawsKms: Any
 
-
 class KeyStore(ApiError[Literal["KeyStore"]]):
     KeyStore: Any
-
 
 class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
     code: Literal["CollectionOfErrors"] = "CollectionOfErrors"
     message: str
     list: List[ServiceError]
 
-    def __init__(self, *, message: str, list):
+    def __init__(
+        self,
+        *,
+        message: str,
+        list
+    ):
         super().__init__(message)
         self.list = list
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the CollectionOfErrors to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "list": self.list,
+            'message': self.message,
+            'code': self.code,
+            'list': self.list,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CollectionOfErrors":
         """Creates a CollectionOfErrors from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "list": d["list"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'list': d['list']
+        }
 
         return CollectionOfErrors(**kwargs)
 
     def __repr__(self) -> str:
         result = "CollectionOfErrors("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"list={self.list}"
+        result += f'list={self.list}'
         result += ")"
         return result
 
@@ -712,48 +683,56 @@ class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
             return False
         if not (self.list == other.list):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueError(ApiError[Literal["OpaqueError"]]):
     code: Literal["OpaqueError"] = "OpaqueError"
     obj: Any  # As an OpaqueError, type of obj is unknown
 
-    def __init__(self, *, obj):
+    def __init__(
+        self,
+        *,
+        obj
+    ):
         super().__init__("")
         self.obj = obj
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueError":
         """Creates a OpaqueError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "obj": d["obj"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'obj': d['obj']
+        }
 
         return OpaqueError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
+        result += f'obj={self.obj}'
         result += ")"
         return result
 
@@ -762,16 +741,23 @@ class OpaqueError(ApiError[Literal["OpaqueError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     code: Literal["OpaqueWithTextError"] = "OpaqueWithTextError"
     obj: Any  # As an OpaqueWithTextError, type of obj is unknown
-    obj_message: str  # obj_message is a message representing the details of obj
+    obj_message: str # obj_message is a message representing the details of obj
 
-    def __init__(self, *, obj, obj_message):
+    def __init__(
+        self,
+        *,
+        obj,
+        obj_message
+    ):
         super().__init__("")
         self.obj = obj
         self.obj_message = obj_message
@@ -779,39 +765,38 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueWithTextError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
-            "obj_message": self.obj_message,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
+            'obj_message': self.obj_message,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueWithTextError":
         """Creates a OpaqueWithTextError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
-            "obj": d["obj"],
-            "obj_message": d["obj_message"],
+            'message': d['message'],
+            'obj': d['obj'],
+            'obj_message': d['obj_message']
         }
 
         return OpaqueWithTextError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueWithTextError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
-        result += f"obj_message={self.obj_message}"
+        result += f'obj={self.obj}'
+        result += f'obj_message={self.obj_message}'
         result += ")"
         return result
 
@@ -820,140 +805,72 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def _smithy_error_to_dafny_error(e: ServiceError):
-    """Converts the provided native Smithy-modeled error into the corresponding
-    Dafny error."""
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.AwsCryptographicMaterialProvidersException,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographicMaterialProvidersException(
-            message=_dafny.Seq(e.message)
-        )
+    """
+    Converts the provided native Smithy-modeled error
+    into the corresponding Dafny error.
+    """
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.AwsCryptographicMaterialProvidersException):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographicMaterialProvidersException(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.EntryAlreadyExists,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_EntryAlreadyExists(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.EntryAlreadyExists):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_EntryAlreadyExists(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.EntryDoesNotExist,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_EntryDoesNotExist(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.EntryDoesNotExist):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_EntryDoesNotExist(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InFlightTTLExceeded,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InFlightTTLExceeded(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InFlightTTLExceeded):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InFlightTTLExceeded(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfo,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfo(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfo):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfo(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfoOnDecrypt,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfoOnDecrypt(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfoOnDecrypt):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfoOnDecrypt(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfoOnEncrypt,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfoOnEncrypt(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidAlgorithmSuiteInfoOnEncrypt):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidAlgorithmSuiteInfoOnEncrypt(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidDecryptionMaterials,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidDecryptionMaterials(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidDecryptionMaterials):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidDecryptionMaterials(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidDecryptionMaterialsTransition,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidDecryptionMaterialsTransition(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidDecryptionMaterialsTransition):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidDecryptionMaterialsTransition(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidEncryptionMaterials,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidEncryptionMaterials(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidEncryptionMaterials):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidEncryptionMaterials(message=_dafny.Seq(e.message))
 
-    if isinstance(
-        e,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidEncryptionMaterialsTransition,
-    ):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidEncryptionMaterialsTransition(
-            message=_dafny.Seq(e.message)
-        )
+    if isinstance(e, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.errors.InvalidEncryptionMaterialsTransition):
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_InvalidEncryptionMaterialsTransition(message=_dafny.Seq(e.message))
 
     if isinstance(e, AwsCryptographicPrimitives):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographyPrimitives(
-            aws_cryptography_primitives_smithy_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographyPrimitives(aws_cryptography_primitives_smithy_error_to_dafny_error(e.message))
 
     if isinstance(e, ComAmazonawsDynamodb):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_ComAmazonawsDynamodb(
-            com_amazonaws_dynamodb_sdk_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_ComAmazonawsDynamodb(com_amazonaws_dynamodb_sdk_error_to_dafny_error(e.message))
 
     if isinstance(e, ComAmazonawsKms):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_ComAmazonawsKms(
-            com_amazonaws_kms_sdk_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_ComAmazonawsKms(com_amazonaws_kms_sdk_error_to_dafny_error(e.message))
 
     if isinstance(e, KeyStore):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographyKeyStore(
-            aws_cryptography_keystore_smithy_error_to_dafny_error(e.message)
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_AwsCryptographyKeyStore(aws_cryptography_keystore_smithy_error_to_dafny_error(e.message))
 
     if isinstance(e, CollectionOfErrors):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_CollectionOfErrors(
-            message=_dafny.Seq(e.message),
-            list=_dafny.Seq(
-                _smithy_error_to_dafny_error(native_err) for native_err in e.list
-            ),
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_CollectionOfErrors(message=_dafny.Seq(e.message), list=_dafny.Seq(
+            _smithy_error_to_dafny_error(native_err) for native_err in e.list
+        ))
 
     if isinstance(e, OpaqueError):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_Opaque(
-            obj=e.obj
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_Opaque(obj=e.obj)
 
     if isinstance(e, OpaqueWithTextError):
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_OpaqueWithText(
-            obj=e.obj, objMessage=e.obj_message
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_OpaqueWithText(obj=e.obj, objMessage=e.obj_message)
 
     else:
-        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_Opaque(
-            obj=e
-        )
+        return aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.Error_Opaque(obj=e)

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/models.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/models.py
@@ -23,14 +23,7 @@ class AesWrappingAlg:
 
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
-    values = frozenset(
-        {
-            "ALG_AES128_GCM_IV12_TAG16",
-            "ALG_AES192_GCM_IV12_TAG16",
-            "ALG_AES256_GCM_IV12_TAG16",
-        }
-    )
-
+    values = frozenset({"ALG_AES128_GCM_IV12_TAG16", "ALG_AES192_GCM_IV12_TAG16", "ALG_AES256_GCM_IV12_TAG16"})
 
 class DBEAlgorithmSuiteId:
     ALG_AES_256_GCM_HKDF_SHA512_COMMIT_KEY_SYMSIG_HMAC_SHA384 = "0x6700"
@@ -40,7 +33,6 @@ class DBEAlgorithmSuiteId:
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
     values = frozenset({"0x6700", "0x6701"})
-
 
 class ESDKAlgorithmSuiteId:
     ALG_AES_128_GCM_IV12_TAG16_NO_KDF = "0x0014"
@@ -67,24 +59,9 @@ class ESDKAlgorithmSuiteId:
 
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
-    values = frozenset(
-        {
-            "0x0014",
-            "0x0046",
-            "0x0078",
-            "0x0114",
-            "0x0146",
-            "0x0178",
-            "0x0214",
-            "0x0346",
-            "0x0378",
-            "0x0478",
-            "0x0578",
-        }
-    )
+    values = frozenset({"0x0014", "0x0046", "0x0078", "0x0114", "0x0146", "0x0178", "0x0214", "0x0346", "0x0378", "0x0478", "0x0578"})
 
-
-class AlgorithmSuiteIdESDK:
+class AlgorithmSuiteIdESDK():
     def __init__(self, value: str):
         self.value = value
 
@@ -93,7 +70,7 @@ class AlgorithmSuiteIdESDK:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteIdESDK":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return AlgorithmSuiteIdESDK(d["ESDK"])
@@ -106,8 +83,7 @@ class AlgorithmSuiteIdESDK:
             return False
         return self.value == other.value
 
-
-class AlgorithmSuiteIdDBE:
+class AlgorithmSuiteIdDBE():
     def __init__(self, value: str):
         self.value = value
 
@@ -116,7 +92,7 @@ class AlgorithmSuiteIdDBE:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteIdDBE":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return AlgorithmSuiteIdDBE(d["DBE"])
@@ -129,12 +105,11 @@ class AlgorithmSuiteIdDBE:
             return False
         return self.value == other.value
 
-
-class AlgorithmSuiteIdUnknown:
+class AlgorithmSuiteIdUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -147,19 +122,14 @@ class AlgorithmSuiteIdUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteIdUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return AlgorithmSuiteIdUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"AlgorithmSuiteIdUnknown(tag={self.tag})"
 
-
-AlgorithmSuiteId = Union[
-    AlgorithmSuiteIdESDK, AlgorithmSuiteIdDBE, AlgorithmSuiteIdUnknown
-]
-
-
+AlgorithmSuiteId = Union[AlgorithmSuiteIdESDK, AlgorithmSuiteIdDBE, AlgorithmSuiteIdUnknown]
 def _algorithm_suite_id_from_dict(d: Dict[str, Any]) -> AlgorithmSuiteId:
     if "ESDK" in d:
         return AlgorithmSuiteIdESDK.from_dict(d)
@@ -167,15 +137,13 @@ def _algorithm_suite_id_from_dict(d: Dict[str, Any]) -> AlgorithmSuiteId:
     if "DBE" in d:
         return AlgorithmSuiteIdDBE.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class HKDF:
     hmac: str
     salt_length: int
     input_key_length: int
     output_key_length: int
-
     def __init__(
         self,
         *,
@@ -205,7 +173,9 @@ class HKDF:
         self.output_key_length = output_key_length
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the HKDF to a dictionary."""
+        """Converts the HKDF to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "hmac": self.hmac,
         }
@@ -223,7 +193,9 @@ class HKDF:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "HKDF":
-        """Creates a HKDF from a dictionary."""
+        """Creates a HKDF from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "hmac": d["hmac"],
         }
@@ -258,23 +230,24 @@ class HKDF:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, HKDF):
             return False
-        attributes: list[str] = [
-            "hmac",
-            "salt_length",
-            "input_key_length",
-            "output_key_length",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['hmac','salt_length','input_key_length','output_key_length',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class IDENTITY:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the IDENTITY to a dictionary."""
+        """Converts the IDENTITY to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "IDENTITY":
-        """Creates a IDENTITY from a dictionary."""
+        """Creates a IDENTITY from a dictionary.
+
+        """
         return IDENTITY()
 
     def __repr__(self) -> str:
@@ -285,15 +258,18 @@ class IDENTITY:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, IDENTITY)
 
-
 class None_:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the None_ to a dictionary."""
+        """Converts the None_ to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "None_":
-        """Creates a None_ from a dictionary."""
+        """Creates a None_ from a dictionary.
+
+        """
         return None_()
 
     def __repr__(self) -> str:
@@ -304,8 +280,7 @@ class None_:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, None_)
 
-
-class DerivationAlgorithmHKDF:
+class DerivationAlgorithmHKDF():
     def __init__(self, value: HKDF):
         self.value = value
 
@@ -314,7 +289,7 @@ class DerivationAlgorithmHKDF:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DerivationAlgorithmHKDF":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return DerivationAlgorithmHKDF(HKDF.from_dict(d["HKDF"]))
@@ -327,8 +302,7 @@ class DerivationAlgorithmHKDF:
             return False
         return self.value == other.value
 
-
-class DerivationAlgorithmIDENTITY:
+class DerivationAlgorithmIDENTITY():
     def __init__(self, value: IDENTITY):
         self.value = value
 
@@ -337,7 +311,7 @@ class DerivationAlgorithmIDENTITY:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DerivationAlgorithmIDENTITY":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return DerivationAlgorithmIDENTITY(IDENTITY.from_dict(d["IDENTITY"]))
@@ -350,8 +324,7 @@ class DerivationAlgorithmIDENTITY:
             return False
         return self.value == other.value
 
-
-class DerivationAlgorithmNone:
+class DerivationAlgorithmNone():
     def __init__(self, value: None_):
         self.value = value
 
@@ -360,7 +333,7 @@ class DerivationAlgorithmNone:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DerivationAlgorithmNone":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return DerivationAlgorithmNone(None_.from_dict(d["None"]))
@@ -373,12 +346,11 @@ class DerivationAlgorithmNone:
             return False
         return self.value == other.value
 
-
-class DerivationAlgorithmUnknown:
+class DerivationAlgorithmUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -391,22 +363,14 @@ class DerivationAlgorithmUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DerivationAlgorithmUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return DerivationAlgorithmUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"DerivationAlgorithmUnknown(tag={self.tag})"
 
-
-DerivationAlgorithm = Union[
-    DerivationAlgorithmHKDF,
-    DerivationAlgorithmIDENTITY,
-    DerivationAlgorithmNone,
-    DerivationAlgorithmUnknown,
-]
-
-
+DerivationAlgorithm = Union[DerivationAlgorithmHKDF, DerivationAlgorithmIDENTITY, DerivationAlgorithmNone, DerivationAlgorithmUnknown]
 def _derivation_algorithm_from_dict(d: Dict[str, Any]) -> DerivationAlgorithm:
     if "HKDF" in d:
         return DerivationAlgorithmHKDF.from_dict(d)
@@ -417,17 +381,20 @@ def _derivation_algorithm_from_dict(d: Dict[str, Any]) -> DerivationAlgorithm:
     if "None" in d:
         return DerivationAlgorithmNone.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class DIRECT_KEY_WRAPPING:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DIRECT_KEY_WRAPPING to a dictionary."""
+        """Converts the DIRECT_KEY_WRAPPING to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DIRECT_KEY_WRAPPING":
-        """Creates a DIRECT_KEY_WRAPPING from a dictionary."""
+        """Creates a DIRECT_KEY_WRAPPING from a dictionary.
+
+        """
         return DIRECT_KEY_WRAPPING()
 
     def __repr__(self) -> str:
@@ -438,8 +405,7 @@ class DIRECT_KEY_WRAPPING:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, DIRECT_KEY_WRAPPING)
 
-
-class EncryptAES_GCM:
+class EncryptAES_GCM():
     def __init__(self, value: AES_GCM):
         self.value = value
 
@@ -448,7 +414,7 @@ class EncryptAES_GCM:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EncryptAES_GCM":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return EncryptAES_GCM(AES_GCM.from_dict(d["AES_GCM"]))
@@ -461,12 +427,11 @@ class EncryptAES_GCM:
             return False
         return self.value == other.value
 
-
-class EncryptUnknown:
+class EncryptUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -479,29 +444,24 @@ class EncryptUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EncryptUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return EncryptUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"EncryptUnknown(tag={self.tag})"
 
-
 Encrypt = Union[EncryptAES_GCM, EncryptUnknown]
-
-
 def _encrypt_from_dict(d: Dict[str, Any]) -> Encrypt:
     if "AES_GCM" in d:
         return EncryptAES_GCM.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class IntermediateKeyWrapping:
     key_encryption_key_kdf: DerivationAlgorithm
     mac_key_kdf: DerivationAlgorithm
     pdk_encrypt_algorithm: Encrypt
-
     def __init__(
         self,
         *,
@@ -514,7 +474,9 @@ class IntermediateKeyWrapping:
         self.pdk_encrypt_algorithm = pdk_encrypt_algorithm
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the IntermediateKeyWrapping to a dictionary."""
+        """Converts the IntermediateKeyWrapping to a dictionary.
+
+        """
         return {
             "key_encryption_key_kdf": self.key_encryption_key_kdf.as_dict(),
             "mac_key_kdf": self.mac_key_kdf.as_dict(),
@@ -523,11 +485,11 @@ class IntermediateKeyWrapping:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "IntermediateKeyWrapping":
-        """Creates a IntermediateKeyWrapping from a dictionary."""
+        """Creates a IntermediateKeyWrapping from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "key_encryption_key_kdf": _derivation_algorithm_from_dict(
-                d["key_encryption_key_kdf"]
-            ),
+            "key_encryption_key_kdf": _derivation_algorithm_from_dict(d["key_encryption_key_kdf"]),
             "mac_key_kdf": _derivation_algorithm_from_dict(d["mac_key_kdf"]),
             "pdk_encrypt_algorithm": _encrypt_from_dict(d["pdk_encrypt_algorithm"]),
         }
@@ -550,15 +512,13 @@ class IntermediateKeyWrapping:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, IntermediateKeyWrapping):
             return False
-        attributes: list[str] = [
-            "key_encryption_key_kdf",
-            "mac_key_kdf",
-            "pdk_encrypt_algorithm",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['key_encryption_key_kdf','mac_key_kdf','pdk_encrypt_algorithm',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class EdkWrappingAlgorithmDIRECT_KEY_WRAPPING:
+class EdkWrappingAlgorithmDIRECT_KEY_WRAPPING():
     def __init__(self, value: DIRECT_KEY_WRAPPING):
         self.value = value
 
@@ -567,12 +527,10 @@ class EdkWrappingAlgorithmDIRECT_KEY_WRAPPING:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EdkWrappingAlgorithmDIRECT_KEY_WRAPPING":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return EdkWrappingAlgorithmDIRECT_KEY_WRAPPING(
-            DIRECT_KEY_WRAPPING.from_dict(d["DIRECT_KEY_WRAPPING"])
-        )
+        return EdkWrappingAlgorithmDIRECT_KEY_WRAPPING(DIRECT_KEY_WRAPPING.from_dict(d["DIRECT_KEY_WRAPPING"]))
 
     def __repr__(self) -> str:
         return f"EdkWrappingAlgorithmDIRECT_KEY_WRAPPING(value=repr(self.value))"
@@ -582,8 +540,7 @@ class EdkWrappingAlgorithmDIRECT_KEY_WRAPPING:
             return False
         return self.value == other.value
 
-
-class EdkWrappingAlgorithmIntermediateKeyWrapping:
+class EdkWrappingAlgorithmIntermediateKeyWrapping():
     def __init__(self, value: IntermediateKeyWrapping):
         self.value = value
 
@@ -592,12 +549,10 @@ class EdkWrappingAlgorithmIntermediateKeyWrapping:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EdkWrappingAlgorithmIntermediateKeyWrapping":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return EdkWrappingAlgorithmIntermediateKeyWrapping(
-            IntermediateKeyWrapping.from_dict(d["IntermediateKeyWrapping"])
-        )
+        return EdkWrappingAlgorithmIntermediateKeyWrapping(IntermediateKeyWrapping.from_dict(d["IntermediateKeyWrapping"]))
 
     def __repr__(self) -> str:
         return f"EdkWrappingAlgorithmIntermediateKeyWrapping(value=repr(self.value))"
@@ -607,12 +562,11 @@ class EdkWrappingAlgorithmIntermediateKeyWrapping:
             return False
         return self.value == other.value
 
-
-class EdkWrappingAlgorithmUnknown:
+class EdkWrappingAlgorithmUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -625,21 +579,14 @@ class EdkWrappingAlgorithmUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EdkWrappingAlgorithmUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return EdkWrappingAlgorithmUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"EdkWrappingAlgorithmUnknown(tag={self.tag})"
 
-
-EdkWrappingAlgorithm = Union[
-    EdkWrappingAlgorithmDIRECT_KEY_WRAPPING,
-    EdkWrappingAlgorithmIntermediateKeyWrapping,
-    EdkWrappingAlgorithmUnknown,
-]
-
-
+EdkWrappingAlgorithm = Union[EdkWrappingAlgorithmDIRECT_KEY_WRAPPING, EdkWrappingAlgorithmIntermediateKeyWrapping, EdkWrappingAlgorithmUnknown]
 def _edk_wrapping_algorithm_from_dict(d: Dict[str, Any]) -> EdkWrappingAlgorithm:
     if "DIRECT_KEY_WRAPPING" in d:
         return EdkWrappingAlgorithmDIRECT_KEY_WRAPPING.from_dict(d)
@@ -647,12 +594,10 @@ def _edk_wrapping_algorithm_from_dict(d: Dict[str, Any]) -> EdkWrappingAlgorithm
     if "IntermediateKeyWrapping" in d:
         return EdkWrappingAlgorithmIntermediateKeyWrapping.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class ECDSA:
     curve: str
-
     def __init__(
         self,
         *,
@@ -661,14 +606,18 @@ class ECDSA:
         self.curve = curve
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the ECDSA to a dictionary."""
+        """Converts the ECDSA to a dictionary.
+
+        """
         return {
             "curve": self.curve,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "ECDSA":
-        """Creates a ECDSA from a dictionary."""
+        """Creates a ECDSA from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "curve": d["curve"],
         }
@@ -685,13 +634,13 @@ class ECDSA:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ECDSA):
             return False
-        attributes: list[str] = [
-            "curve",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['curve',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class SignatureAlgorithmECDSA:
+class SignatureAlgorithmECDSA():
     def __init__(self, value: ECDSA):
         self.value = value
 
@@ -700,7 +649,7 @@ class SignatureAlgorithmECDSA:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SignatureAlgorithmECDSA":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return SignatureAlgorithmECDSA(ECDSA.from_dict(d["ECDSA"]))
@@ -713,8 +662,7 @@ class SignatureAlgorithmECDSA:
             return False
         return self.value == other.value
 
-
-class SignatureAlgorithmNone:
+class SignatureAlgorithmNone():
     def __init__(self, value: None_):
         self.value = value
 
@@ -723,7 +671,7 @@ class SignatureAlgorithmNone:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SignatureAlgorithmNone":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return SignatureAlgorithmNone(None_.from_dict(d["None"]))
@@ -736,12 +684,11 @@ class SignatureAlgorithmNone:
             return False
         return self.value == other.value
 
-
-class SignatureAlgorithmUnknown:
+class SignatureAlgorithmUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -754,19 +701,14 @@ class SignatureAlgorithmUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SignatureAlgorithmUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return SignatureAlgorithmUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"SignatureAlgorithmUnknown(tag={self.tag})"
 
-
-SignatureAlgorithm = Union[
-    SignatureAlgorithmECDSA, SignatureAlgorithmNone, SignatureAlgorithmUnknown
-]
-
-
+SignatureAlgorithm = Union[SignatureAlgorithmECDSA, SignatureAlgorithmNone, SignatureAlgorithmUnknown]
 def _signature_algorithm_from_dict(d: Dict[str, Any]) -> SignatureAlgorithm:
     if "ECDSA" in d:
         return SignatureAlgorithmECDSA.from_dict(d)
@@ -774,10 +716,9 @@ def _signature_algorithm_from_dict(d: Dict[str, Any]) -> SignatureAlgorithm:
     if "None" in d:
         return SignatureAlgorithmNone.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
-
-class SymmetricSignatureAlgorithmHMAC:
+class SymmetricSignatureAlgorithmHMAC():
     def __init__(self, value: str):
         self.value = value
 
@@ -786,7 +727,7 @@ class SymmetricSignatureAlgorithmHMAC:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SymmetricSignatureAlgorithmHMAC":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return SymmetricSignatureAlgorithmHMAC(d["HMAC"])
@@ -799,8 +740,7 @@ class SymmetricSignatureAlgorithmHMAC:
             return False
         return self.value == other.value
 
-
-class SymmetricSignatureAlgorithmNone:
+class SymmetricSignatureAlgorithmNone():
     def __init__(self, value: None_):
         self.value = value
 
@@ -809,7 +749,7 @@ class SymmetricSignatureAlgorithmNone:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SymmetricSignatureAlgorithmNone":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return SymmetricSignatureAlgorithmNone(None_.from_dict(d["None"]))
@@ -822,12 +762,11 @@ class SymmetricSignatureAlgorithmNone:
             return False
         return self.value == other.value
 
-
-class SymmetricSignatureAlgorithmUnknown:
+class SymmetricSignatureAlgorithmUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -840,32 +779,22 @@ class SymmetricSignatureAlgorithmUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SymmetricSignatureAlgorithmUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return SymmetricSignatureAlgorithmUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"SymmetricSignatureAlgorithmUnknown(tag={self.tag})"
 
-
-SymmetricSignatureAlgorithm = Union[
-    SymmetricSignatureAlgorithmHMAC,
-    SymmetricSignatureAlgorithmNone,
-    SymmetricSignatureAlgorithmUnknown,
-]
-
-
-def _symmetric_signature_algorithm_from_dict(
-    d: Dict[str, Any],
-) -> SymmetricSignatureAlgorithm:
+SymmetricSignatureAlgorithm = Union[SymmetricSignatureAlgorithmHMAC, SymmetricSignatureAlgorithmNone, SymmetricSignatureAlgorithmUnknown]
+def _symmetric_signature_algorithm_from_dict(d: Dict[str, Any]) -> SymmetricSignatureAlgorithm:
     if "HMAC" in d:
         return SymmetricSignatureAlgorithmHMAC.from_dict(d)
 
     if "None" in d:
         return SymmetricSignatureAlgorithmNone.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class AlgorithmSuiteInfo:
     id: AlgorithmSuiteId
@@ -877,7 +806,6 @@ class AlgorithmSuiteInfo:
     signature: SignatureAlgorithm
     symmetric_signature: SymmetricSignatureAlgorithm
     edk_wrapping: EdkWrappingAlgorithm
-
     def __init__(
         self,
         *,
@@ -902,7 +830,9 @@ class AlgorithmSuiteInfo:
         self.edk_wrapping = edk_wrapping
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the AlgorithmSuiteInfo to a dictionary."""
+        """Converts the AlgorithmSuiteInfo to a dictionary.
+
+        """
         return {
             "id": self.id.as_dict(),
             "binary_id": self.binary_id,
@@ -917,7 +847,9 @@ class AlgorithmSuiteInfo:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "AlgorithmSuiteInfo":
-        """Creates a AlgorithmSuiteInfo from a dictionary."""
+        """Creates a AlgorithmSuiteInfo from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "id": _algorithm_suite_id_from_dict(d["id"]),
             "binary_id": d["binary_id"],
@@ -926,9 +858,7 @@ class AlgorithmSuiteInfo:
             "kdf": _derivation_algorithm_from_dict(d["kdf"]),
             "commitment": _derivation_algorithm_from_dict(d["commitment"]),
             "signature": _signature_algorithm_from_dict(d["signature"]),
-            "symmetric_signature": _symmetric_signature_algorithm_from_dict(
-                d["symmetric_signature"]
-            ),
+            "symmetric_signature": _symmetric_signature_algorithm_from_dict(d["symmetric_signature"]),
             "edk_wrapping": _edk_wrapping_algorithm_from_dict(d["edk_wrapping"]),
         }
 
@@ -968,45 +898,40 @@ class AlgorithmSuiteInfo:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, AlgorithmSuiteInfo):
             return False
-        attributes: list[str] = [
-            "id",
-            "binary_id",
-            "message_version",
-            "encrypt",
-            "kdf",
-            "commitment",
-            "signature",
-            "symmetric_signature",
-            "edk_wrapping",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['id','binary_id','message_version','encrypt','kdf','commitment','signature','symmetric_signature','edk_wrapping',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBranchKeyIdInput:
     encryption_context: dict[str, str]
-
     def __init__(
         self,
         *,
         encryption_context: dict[str, str],
     ):
-        """Inputs for determining the Branch Key which should be used to wrap
-        or unwrap the data key for this encryption or decryption.
+        """Inputs for determining the Branch Key which should be used to wrap or unwrap the
+        data key for this encryption or decryption
 
-        :param encryption_context: The Encryption Context used with this
-            encryption or decryption.
+        :param encryption_context: The Encryption Context used with this encryption or
+        decryption.
         """
         self.encryption_context = encryption_context
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBranchKeyIdInput to a dictionary."""
+        """Converts the GetBranchKeyIdInput to a dictionary.
+
+        """
         return {
             "encryption_context": self.encryption_context,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBranchKeyIdInput":
-        """Creates a GetBranchKeyIdInput from a dictionary."""
+        """Creates a GetBranchKeyIdInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "encryption_context": d["encryption_context"],
         }
@@ -1023,38 +948,41 @@ class GetBranchKeyIdInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBranchKeyIdInput):
             return False
-        attributes: list[str] = [
-            "encryption_context",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['encryption_context',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetBranchKeyIdOutput:
     branch_key_id: str
-
     def __init__(
         self,
         *,
         branch_key_id: str,
     ):
-        """Outputs for the Branch Key responsible for wrapping or unwrapping
-        the data key in this encryption or decryption.
+        """Outputs for the Branch Key responsible for wrapping or unwrapping the data key
+        in this encryption or decryption.
 
-        :param branch_key_id: The identifier of the Branch Key that
-            should be responsible for wrapping or unwrapping the data
-            key in this encryption or decryption.
+        :param branch_key_id: The identifier of the Branch Key that should be
+        responsible for wrapping or unwrapping the data key in this encryption or
+        decryption.
         """
         self.branch_key_id = branch_key_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetBranchKeyIdOutput to a dictionary."""
+        """Converts the GetBranchKeyIdOutput to a dictionary.
+
+        """
         return {
             "branch_key_id": self.branch_key_id,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetBranchKeyIdOutput":
-        """Creates a GetBranchKeyIdOutput from a dictionary."""
+        """Creates a GetBranchKeyIdOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "branch_key_id": d["branch_key_id"],
         }
@@ -1071,15 +999,14 @@ class GetBranchKeyIdOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetBranchKeyIdOutput):
             return False
-        attributes: list[str] = [
-            "branch_key_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetClientInput:
     region: str
-
     def __init__(
         self,
         *,
@@ -1092,14 +1019,18 @@ class GetClientInput:
         self.region = region
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetClientInput to a dictionary."""
+        """Converts the GetClientInput to a dictionary.
+
+        """
         return {
             "region": self.region,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetClientInput":
-        """Creates a GetClientInput from a dictionary."""
+        """Creates a GetClientInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "region": d["region"],
         }
@@ -1116,24 +1047,23 @@ class GetClientInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetClientInput):
             return False
-        attributes: list[str] = [
-            "region",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['region',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DiscoveryFilter:
     account_ids: list[str]
     partition: str
-
     def __init__(
         self,
         *,
         account_ids: list[str],
         partition: str,
     ):
-        """A filter which defines what AWS partition and AWS accounts a KMS Key
-        may be in for a Keyring to be allowed to attempt to decrypt it.
+        """A filter which defines what AWS partition and AWS accounts a KMS Key may be in
+        for a Keyring to be allowed to attempt to decrypt it.
 
         :param account_ids: A list of allowed AWS account IDs.
         :param partition: The AWS partition which is allowed.
@@ -1142,7 +1072,9 @@ class DiscoveryFilter:
         self.partition = partition
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DiscoveryFilter to a dictionary."""
+        """Converts the DiscoveryFilter to a dictionary.
+
+        """
         return {
             "account_ids": self.account_ids,
             "partition": self.partition,
@@ -1150,7 +1082,9 @@ class DiscoveryFilter:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DiscoveryFilter":
-        """Creates a DiscoveryFilter from a dictionary."""
+        """Creates a DiscoveryFilter from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "account_ids": d["account_ids"],
             "partition": d["partition"],
@@ -1171,18 +1105,16 @@ class DiscoveryFilter:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DiscoveryFilter):
             return False
-        attributes: list[str] = [
-            "account_ids",
-            "partition",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['account_ids','partition',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsDiscoveryKeyringInput:
     kms_client: BaseClient
     discovery_filter: Optional[DiscoveryFilter]
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -1192,20 +1124,19 @@ class CreateAwsKmsDiscoveryKeyringInput:
     ):
         """Inputs for for creating a AWS KMS Discovery Keyring.
 
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
-        :param discovery_filter: A filter which restricts which KMS Keys
-            this Keyring may attempt to decrypt with by AWS partition
-            and account.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
+        :param discovery_filter: A filter which restricts which KMS Keys this Keyring
+        may attempt to decrypt with by AWS partition and account.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.kms_client = kms_client
         self.discovery_filter = discovery_filter
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsDiscoveryKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsDiscoveryKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "kms_client": self.kms_client,
         }
@@ -1220,15 +1151,15 @@ class CreateAwsKmsDiscoveryKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsDiscoveryKeyringInput":
-        """Creates a CreateAwsKmsDiscoveryKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsDiscoveryKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "kms_client": d["kms_client"],
         }
 
         if "discovery_filter" in d:
-            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(
-                d["discovery_filter"]
-            )
+            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(d["discovery_filter"])
 
         if "grant_tokens" in d:
             kwargs["grant_tokens"] = d["grant_tokens"]
@@ -1251,46 +1182,35 @@ class CreateAwsKmsDiscoveryKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsDiscoveryKeyringInput):
             return False
-        attributes: list[str] = [
-            "kms_client",
-            "discovery_filter",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['kms_client','discovery_filter','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsDiscoveryMultiKeyringInput:
     regions: list[str]
     discovery_filter: Optional[DiscoveryFilter]
-    client_supplier: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-    ]
+    client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier']
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
         regions: list[str],
         discovery_filter: Optional[DiscoveryFilter] = None,
-        client_supplier: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-        ] = None,
+        client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier'] = None,
         grant_tokens: Optional[list[str]] = None,
     ):
         """Inputs for for creating an AWS KMS Discovery Multi-Keyring.
 
-        :param regions: The list of regions this Keyring will creates
-            KMS clients for.
-        :param discovery_filter: A filter which restricts which KMS Keys
-            this Keyring may attempt to decrypt with by AWS partition
-            and account.
-        :param client_supplier: The Client Supplier which will be used
-            to get KMS Clients for use with this Keyring. If not
-            specified on input, a Default Client Supplier is created
-            which creates a KMS Client for each region in the 'regions'
-            input.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param regions: The list of regions this Keyring will creates KMS clients for.
+        :param discovery_filter: A filter which restricts which KMS Keys this Keyring
+        may attempt to decrypt with by AWS partition and account.
+        :param client_supplier: The Client Supplier which will be used to get KMS
+        Clients for use with this Keyring. If not specified on input, a Default Client
+        Supplier is created which creates a KMS Client for each region in the 'regions'
+        input.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.regions = regions
         self.discovery_filter = discovery_filter
@@ -1298,8 +1218,9 @@ class CreateAwsKmsDiscoveryMultiKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsDiscoveryMultiKeyringInput to a
-        dictionary."""
+        """Converts the CreateAwsKmsDiscoveryMultiKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "regions": self.regions,
         }
@@ -1317,20 +1238,16 @@ class CreateAwsKmsDiscoveryMultiKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsDiscoveryMultiKeyringInput":
-        """Creates a CreateAwsKmsDiscoveryMultiKeyringInput from a
-        dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            ClientSupplier,
-        )
+        """Creates a CreateAwsKmsDiscoveryMultiKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import ClientSupplier
         kwargs: Dict[str, Any] = {
             "regions": d["regions"],
         }
 
         if "discovery_filter" in d:
-            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(
-                d["discovery_filter"]
-            )
+            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(d["discovery_filter"])
 
         if "client_supplier" in d:
             kwargs["client_supplier"] = ClientSupplier.from_dict(d["client_supplier"])
@@ -1359,20 +1276,16 @@ class CreateAwsKmsDiscoveryMultiKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsDiscoveryMultiKeyringInput):
             return False
-        attributes: list[str] = [
-            "regions",
-            "discovery_filter",
-            "client_supplier",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['regions','discovery_filter','client_supplier','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsPrivateKeyToStaticPublicKeyInput:
     sender_kms_identifier: str
     sender_public_key: Optional[bytes | bytearray]
     recipient_public_key: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -1382,20 +1295,20 @@ class KmsPrivateKeyToStaticPublicKeyInput:
     ):
         """Inputs for creating a KmsPrivateKeyToStaticPublicKey Configuration.
 
-        :param sender_kms_identifier: AWS KMS Key Identifier belonging
-            to the sender.
-        :param recipient_public_key: Recipient Public Key. This MUST be
-            a raw public ECC key in DER format.
-        :param sender_public_key: Sender Public Key. This is the raw
-            public ECC key in DER format that belongs to the
-            senderKmsIdentifier.
+        :param sender_kms_identifier: AWS KMS Key Identifier belonging to the sender.
+        :param recipient_public_key: Recipient Public Key. This MUST be a raw public ECC
+        key in DER format.
+        :param sender_public_key: Sender Public Key. This is the raw public ECC key in
+        DER format that belongs to the senderKmsIdentifier.
         """
         self.sender_kms_identifier = sender_kms_identifier
         self.recipient_public_key = recipient_public_key
         self.sender_public_key = sender_public_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsPrivateKeyToStaticPublicKeyInput to a dictionary."""
+        """Converts the KmsPrivateKeyToStaticPublicKeyInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "sender_kms_identifier": self.sender_kms_identifier,
             "recipient_public_key": self.recipient_public_key,
@@ -1408,7 +1321,9 @@ class KmsPrivateKeyToStaticPublicKeyInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsPrivateKeyToStaticPublicKeyInput":
-        """Creates a KmsPrivateKeyToStaticPublicKeyInput from a dictionary."""
+        """Creates a KmsPrivateKeyToStaticPublicKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "sender_kms_identifier": d["sender_kms_identifier"],
             "recipient_public_key": d["recipient_public_key"],
@@ -1435,39 +1350,40 @@ class KmsPrivateKeyToStaticPublicKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsPrivateKeyToStaticPublicKeyInput):
             return False
-        attributes: list[str] = [
-            "sender_kms_identifier",
-            "sender_public_key",
-            "recipient_public_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['sender_kms_identifier','sender_public_key','recipient_public_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsPublicKeyDiscoveryInput:
     recipient_kms_identifier: str
-
     def __init__(
         self,
         *,
         recipient_kms_identifier: str,
     ):
-        """Inputs for creating a KmsPublicKeyDiscovery Configuration. This is a
-        DECRYPT ONLY configuration.
+        """Inputs for creating a KmsPublicKeyDiscovery Configuration. This is a DECRYPT
+        ONLY configuration.
 
-        :param recipient_kms_identifier: AWS KMS key identifier
-            belonging to the recipient.
+        :param recipient_kms_identifier: AWS KMS key identifier belonging to the
+        recipient.
         """
         self.recipient_kms_identifier = recipient_kms_identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsPublicKeyDiscoveryInput to a dictionary."""
+        """Converts the KmsPublicKeyDiscoveryInput to a dictionary.
+
+        """
         return {
             "recipient_kms_identifier": self.recipient_kms_identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsPublicKeyDiscoveryInput":
-        """Creates a KmsPublicKeyDiscoveryInput from a dictionary."""
+        """Creates a KmsPublicKeyDiscoveryInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "recipient_kms_identifier": d["recipient_kms_identifier"],
         }
@@ -1484,18 +1400,16 @@ class KmsPublicKeyDiscoveryInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsPublicKeyDiscoveryInput):
             return False
-        attributes: list[str] = [
-            "recipient_kms_identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['recipient_kms_identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery:
-    """Inputs for creating a KmsPublicKeyDiscovery Configuration.
-
-    This is a DECRYPT ONLY configuration.
+class KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery():
+    """Inputs for creating a KmsPublicKeyDiscovery Configuration. This is a DECRYPT
+    ONLY configuration.
     """
-
     def __init__(self, value: KmsPublicKeyDiscoveryInput):
         self.value = value
 
@@ -1503,30 +1417,23 @@ class KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery:
         return {"KmsPublicKeyDiscovery": self.value.as_dict()}
 
     @staticmethod
-    def from_dict(
-        d: Dict[str, Any],
-    ) -> "KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery":
-        if len(d) != 1:
+    def from_dict(d: Dict[str, Any]) -> "KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery":
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(
-            KmsPublicKeyDiscoveryInput.from_dict(d["KmsPublicKeyDiscovery"])
-        )
+        return KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(KmsPublicKeyDiscoveryInput.from_dict(d["KmsPublicKeyDiscovery"]))
 
     def __repr__(self) -> str:
-        return (
-            f"KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(value=repr(self.value))"
-        )
+        return f"KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery(value=repr(self.value))"
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery):
             return False
         return self.value == other.value
 
-
-class KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey:
-    """Inputs for creating a KmsPrivateKeyToStaticPublicKey Configuration."""
-
+class KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey():
+    """Inputs for creating a KmsPrivateKeyToStaticPublicKey Configuration.
+    """
     def __init__(self, value: KmsPrivateKeyToStaticPublicKeyInput):
         self.value = value
 
@@ -1534,34 +1441,25 @@ class KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey:
         return {"KmsPrivateKeyToStaticPublicKey": self.value.as_dict()}
 
     @staticmethod
-    def from_dict(
-        d: Dict[str, Any],
-    ) -> "KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey":
-        if len(d) != 1:
+    def from_dict(d: Dict[str, Any]) -> "KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey":
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey(
-            KmsPrivateKeyToStaticPublicKeyInput.from_dict(
-                d["KmsPrivateKeyToStaticPublicKey"]
-            )
-        )
+        return KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey(KmsPrivateKeyToStaticPublicKeyInput.from_dict(d["KmsPrivateKeyToStaticPublicKey"]))
 
     def __repr__(self) -> str:
         return f"KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey(value=repr(self.value))"
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(
-            other, KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey
-        ):
+        if not isinstance(other, KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey):
             return False
         return self.value == other.value
 
-
-class KmsEcdhStaticConfigurationsUnknown:
+class KmsEcdhStaticConfigurationsUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -1574,40 +1472,29 @@ class KmsEcdhStaticConfigurationsUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsEcdhStaticConfigurationsUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return KmsEcdhStaticConfigurationsUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"KmsEcdhStaticConfigurationsUnknown(tag={self.tag})"
 
-
 # Allowed configurations when using KmsEcdhStaticConfigurations.
-KmsEcdhStaticConfigurations = Union[
-    KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery,
-    KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey,
-    KmsEcdhStaticConfigurationsUnknown,
-]
-
-
-def _kms_ecdh_static_configurations_from_dict(
-    d: Dict[str, Any],
-) -> KmsEcdhStaticConfigurations:
+KmsEcdhStaticConfigurations = Union[KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery, KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey, KmsEcdhStaticConfigurationsUnknown]
+def _kms_ecdh_static_configurations_from_dict(d: Dict[str, Any]) -> KmsEcdhStaticConfigurations:
     if "KmsPublicKeyDiscovery" in d:
         return KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery.from_dict(d)
 
     if "KmsPrivateKeyToStaticPublicKey" in d:
         return KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class CreateAwsKmsEcdhKeyringInput:
     key_agreement_scheme: KmsEcdhStaticConfigurations
     curve_spec: str
     kms_client: BaseClient
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -1618,16 +1505,12 @@ class CreateAwsKmsEcdhKeyringInput:
     ):
         """Inputs for creating an AWS KMS ECDH Keyring.
 
-        :param key_agreement_scheme: The Key Agreement Scheme
-            configuration that is responsible for how the shared secret
-            is calculated.
-        :param curve_spec: The named curve that corresponds to the curve
-            on which the sender's private and recipient's public key
-            lie.
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param key_agreement_scheme: The Key Agreement Scheme configuration that is
+        responsible for how the shared secret is calculated.
+        :param curve_spec: The named curve that corresponds to the curve on which the
+        sender's private and recipient's public key lie.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.key_agreement_scheme = key_agreement_scheme
         self.curve_spec = curve_spec
@@ -1635,7 +1518,9 @@ class CreateAwsKmsEcdhKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsEcdhKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsEcdhKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "key_agreement_scheme": self.key_agreement_scheme.as_dict(),
             "curve_spec": self.curve_spec,
@@ -1649,11 +1534,11 @@ class CreateAwsKmsEcdhKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsEcdhKeyringInput":
-        """Creates a CreateAwsKmsEcdhKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsEcdhKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "key_agreement_scheme": _kms_ecdh_static_configurations_from_dict(
-                d["key_agreement_scheme"]
-            ),
+            "key_agreement_scheme": _kms_ecdh_static_configurations_from_dict(d["key_agreement_scheme"]),
             "curve_spec": d["curve_spec"],
             "kms_client": d["kms_client"],
         }
@@ -1682,18 +1567,14 @@ class CreateAwsKmsEcdhKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsEcdhKeyringInput):
             return False
-        attributes: list[str] = [
-            "key_agreement_scheme",
-            "curve_spec",
-            "kms_client",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_agreement_scheme','curve_spec','kms_client','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DefaultCache:
     entry_capacity: int
-
     def __init__(
         self,
         *,
@@ -1709,7 +1590,9 @@ class DefaultCache:
         self.entry_capacity = entry_capacity
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DefaultCache to a dictionary."""
+        """Converts the DefaultCache to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.entry_capacity is not None:
@@ -1719,7 +1602,9 @@ class DefaultCache:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DefaultCache":
-        """Creates a DefaultCache from a dictionary."""
+        """Creates a DefaultCache from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {}
 
         if "entry_capacity" in d:
@@ -1737,42 +1622,40 @@ class DefaultCache:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DefaultCache):
             return False
-        attributes: list[str] = [
-            "entry_capacity",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['entry_capacity',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class MultiThreadedCache:
     entry_capacity: int
     entry_pruning_tail_size: int
-
     def __init__(
         self,
         *,
         entry_capacity: int = 0,
         entry_pruning_tail_size: int = 0,
     ):
-        """A cache that is safe for use in a multi threaded environment, but no
-        extra functionality.
+        """A cache that is safe for use in a multi threaded environment, but no extra
+        functionality.
 
         :param entry_capacity: Maximum number of entries cached.
-        :param entry_pruning_tail_size: Number of entries to prune at a
-            time.
+        :param entry_pruning_tail_size: Number of entries to prune at a time.
         """
         if (entry_capacity is not None) and (entry_capacity < 1):
             raise ValueError("entry_capacity must be greater than or equal to 1")
 
         self.entry_capacity = entry_capacity
         if (entry_pruning_tail_size is not None) and (entry_pruning_tail_size < 1):
-            raise ValueError(
-                "entry_pruning_tail_size must be greater than or equal to 1"
-            )
+            raise ValueError("entry_pruning_tail_size must be greater than or equal to 1")
 
         self.entry_pruning_tail_size = entry_pruning_tail_size
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the MultiThreadedCache to a dictionary."""
+        """Converts the MultiThreadedCache to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.entry_capacity is not None:
@@ -1785,7 +1668,9 @@ class MultiThreadedCache:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MultiThreadedCache":
-        """Creates a MultiThreadedCache from a dictionary."""
+        """Creates a MultiThreadedCache from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {}
 
         if "entry_capacity" in d:
@@ -1809,23 +1694,26 @@ class MultiThreadedCache:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MultiThreadedCache):
             return False
-        attributes: list[str] = [
-            "entry_capacity",
-            "entry_pruning_tail_size",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['entry_capacity','entry_pruning_tail_size',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class NoCache:
-    """Nothing should ever be cached."""
-
+    """Nothing should ever be cached.
+    """
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the NoCache to a dictionary."""
+        """Converts the NoCache to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "NoCache":
-        """Creates a NoCache from a dictionary."""
+        """Creates a NoCache from a dictionary.
+
+        """
         return NoCache()
 
     def __repr__(self) -> str:
@@ -1836,11 +1724,9 @@ class NoCache:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, NoCache)
 
-
 class SingleThreadedCache:
     entry_capacity: int
     entry_pruning_tail_size: int
-
     def __init__(
         self,
         *,
@@ -1850,22 +1736,21 @@ class SingleThreadedCache:
         """A cache that is NOT safe for use in a multi threaded environment.
 
         :param entry_capacity: Maximum number of entries cached.
-        :param entry_pruning_tail_size: Number of entries to prune at a
-            time.
+        :param entry_pruning_tail_size: Number of entries to prune at a time.
         """
         if (entry_capacity is not None) and (entry_capacity < 1):
             raise ValueError("entry_capacity must be greater than or equal to 1")
 
         self.entry_capacity = entry_capacity
         if (entry_pruning_tail_size is not None) and (entry_pruning_tail_size < 1):
-            raise ValueError(
-                "entry_pruning_tail_size must be greater than or equal to 1"
-            )
+            raise ValueError("entry_pruning_tail_size must be greater than or equal to 1")
 
         self.entry_pruning_tail_size = entry_pruning_tail_size
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the SingleThreadedCache to a dictionary."""
+        """Converts the SingleThreadedCache to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.entry_capacity is not None:
@@ -1878,7 +1763,9 @@ class SingleThreadedCache:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SingleThreadedCache":
-        """Creates a SingleThreadedCache from a dictionary."""
+        """Creates a SingleThreadedCache from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {}
 
         if "entry_capacity" in d:
@@ -1902,12 +1789,11 @@ class SingleThreadedCache:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SingleThreadedCache):
             return False
-        attributes: list[str] = [
-            "entry_capacity",
-            "entry_pruning_tail_size",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['entry_capacity','entry_pruning_tail_size',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class TimeUnits:
     SECONDS = "Seconds"
@@ -1918,7 +1804,6 @@ class TimeUnits:
     # values may be added in the future.
     values = frozenset({"Seconds", "Milliseconds"})
 
-
 class StormTrackingCache:
     entry_capacity: int
     entry_pruning_tail_size: int
@@ -1928,7 +1813,6 @@ class StormTrackingCache:
     in_flight_ttl: int
     sleep_milli: int
     time_units: Optional[str]
-
     def __init__(
         self,
         *,
@@ -1941,36 +1825,33 @@ class StormTrackingCache:
         sleep_milli: int = 0,
         time_units: Optional[str] = None,
     ):
-        """A cache that is safe for use in a multi threaded environment, and
-        tries to prevent redundant or overly parallel backend calls.
+        """A cache that is safe for use in a multi threaded environment,
+        and tries to
+        prevent redundant or overly parallel backend calls.
 
         :param entry_capacity: Maximum number of entries cached.
-        :param entry_pruning_tail_size: Number of entries to prune at a
-            time.
-        :param grace_period: How much time before expiration should an
-            attempt be made to refresh the materials. If zero, use a
-            simple cache with no storm tracking.
-        :param grace_interval: How much time between attempts to refresh
-            the materials.
-        :param fan_out: How many simultaneous attempts to refresh the
-            materials.
-        :param in_flight_ttl: How much time until an attempt to refresh
-            the materials should be forgotten.
-        :param sleep_milli: How many milliseconds should a thread sleep
-            if fanOut is exceeded.
-        :param time_units: The time unit for gracePeriod, graceInterval,
-            and inFlightTTL. The default is seconds. If this is set to
-            milliseconds, then these values will be treated as
-            milliseconds.
+        :param entry_pruning_tail_size: Number of entries to prune at a time.
+        :param grace_period: How much time before expiration should an attempt be made
+        to refresh the materials.
+          If zero, use a simple cache with no storm tracking.
+        :param grace_interval: How much time between attempts to refresh the materials.
+        :param fan_out: How many simultaneous attempts to refresh the materials.
+        :param in_flight_ttl: How much time until an attempt to refresh the materials
+        should be forgotten.
+        :param sleep_milli: How many milliseconds should a thread sleep if fanOut is
+        exceeded.
+        :param time_units: The time unit for gracePeriod, graceInterval, and
+        inFlightTTL.
+          The default is seconds.
+          If this is set to milliseconds, then
+        these values will be treated as milliseconds.
         """
         if (entry_capacity is not None) and (entry_capacity < 1):
             raise ValueError("entry_capacity must be greater than or equal to 1")
 
         self.entry_capacity = entry_capacity
         if (entry_pruning_tail_size is not None) and (entry_pruning_tail_size < 1):
-            raise ValueError(
-                "entry_pruning_tail_size must be greater than or equal to 1"
-            )
+            raise ValueError("entry_pruning_tail_size must be greater than or equal to 1")
 
         self.entry_pruning_tail_size = entry_pruning_tail_size
         if (grace_period is not None) and (grace_period < 1):
@@ -1996,7 +1877,9 @@ class StormTrackingCache:
         self.time_units = time_units
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the StormTrackingCache to a dictionary."""
+        """Converts the StormTrackingCache to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.entry_capacity is not None:
@@ -2027,7 +1910,9 @@ class StormTrackingCache:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "StormTrackingCache":
-        """Creates a StormTrackingCache from a dictionary."""
+        """Creates a StormTrackingCache from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {}
 
         if "entry_capacity" in d:
@@ -2087,25 +1972,15 @@ class StormTrackingCache:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, StormTrackingCache):
             return False
-        attributes: list[str] = [
-            "entry_capacity",
-            "entry_pruning_tail_size",
-            "grace_period",
-            "grace_interval",
-            "fan_out",
-            "in_flight_ttl",
-            "sleep_milli",
-            "time_units",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['entry_capacity','entry_pruning_tail_size','grace_period','grace_interval','fan_out','in_flight_ttl','sleep_milli','time_units',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class CacheTypeDefault:
-    """The best choice for most situations.
-
-    Probably a StormTrackingCache.
+class CacheTypeDefault():
+    """The best choice for most situations. Probably a StormTrackingCache.
     """
-
     def __init__(self, value: DefaultCache):
         self.value = value
 
@@ -2114,7 +1989,7 @@ class CacheTypeDefault:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeDefault":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CacheTypeDefault(DefaultCache.from_dict(d["Default"]))
@@ -2127,10 +2002,9 @@ class CacheTypeDefault:
             return False
         return self.value == other.value
 
-
-class CacheTypeNo:
-    """Nothing should ever be cached."""
-
+class CacheTypeNo():
+    """Nothing should ever be cached.
+    """
     def __init__(self, value: NoCache):
         self.value = value
 
@@ -2139,7 +2013,7 @@ class CacheTypeNo:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeNo":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CacheTypeNo(NoCache.from_dict(d["No"]))
@@ -2152,10 +2026,9 @@ class CacheTypeNo:
             return False
         return self.value == other.value
 
-
-class CacheTypeSingleThreaded:
-    """A cache that is NOT safe for use in a multi threaded environment."""
-
+class CacheTypeSingleThreaded():
+    """A cache that is NOT safe for use in a multi threaded environment.
+    """
     def __init__(self, value: SingleThreadedCache):
         self.value = value
 
@@ -2164,12 +2037,10 @@ class CacheTypeSingleThreaded:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeSingleThreaded":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return CacheTypeSingleThreaded(
-            SingleThreadedCache.from_dict(d["SingleThreaded"])
-        )
+        return CacheTypeSingleThreaded(SingleThreadedCache.from_dict(d["SingleThreaded"]))
 
     def __repr__(self) -> str:
         return f"CacheTypeSingleThreaded(value=repr(self.value))"
@@ -2179,11 +2050,10 @@ class CacheTypeSingleThreaded:
             return False
         return self.value == other.value
 
-
-class CacheTypeMultiThreaded:
-    """A cache that is safe for use in a multi threaded environment, but no
-    extra functionality."""
-
+class CacheTypeMultiThreaded():
+    """A cache that is safe for use in a multi threaded environment, but no extra
+    functionality.
+    """
     def __init__(self, value: MultiThreadedCache):
         self.value = value
 
@@ -2192,7 +2062,7 @@ class CacheTypeMultiThreaded:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeMultiThreaded":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CacheTypeMultiThreaded(MultiThreadedCache.from_dict(d["MultiThreaded"]))
@@ -2205,11 +2075,11 @@ class CacheTypeMultiThreaded:
             return False
         return self.value == other.value
 
-
-class CacheTypeStormTracking:
-    """A cache that is safe for use in a multi threaded environment, and tries
-    to prevent redundant or overly parallel backend calls."""
-
+class CacheTypeStormTracking():
+    """A cache that is safe for use in a multi threaded environment,
+    and tries to
+    prevent redundant or overly parallel backend calls.
+    """
     def __init__(self, value: StormTrackingCache):
         self.value = value
 
@@ -2218,7 +2088,7 @@ class CacheTypeStormTracking:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeStormTracking":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CacheTypeStormTracking(StormTrackingCache.from_dict(d["StormTracking"]))
@@ -2231,19 +2101,12 @@ class CacheTypeStormTracking:
             return False
         return self.value == other.value
 
-
-class CacheTypeShared:
-    """Shared cache across multiple Hierarchical Keyrings.
-
-    For this cache type, the user should provide an already constructed
-    CryptographicMaterialsCache to the Hierarchical Keyring at
-    initialization.
+class CacheTypeShared():
+    """Shared cache across multiple Hierarchical Keyrings. For this cache type, the
+    user should provide an already constructed CryptographicMaterialsCache to the
+    Hierarchical Keyring at initialization.
     """
-
-    def __init__(
-        self,
-        value: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsCache",
-    ):
+    def __init__(self, value: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsCache'):
         self.value = value
 
     def as_dict(self) -> Dict[str, Any]:
@@ -2251,11 +2114,8 @@ class CacheTypeShared:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeShared":
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            CryptographicMaterialsCache,
-        )
-
-        if len(d) != 1:
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import CryptographicMaterialsCache
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CacheTypeShared(CryptographicMaterialsCache.from_dict(d["Shared"]))
@@ -2268,12 +2128,11 @@ class CacheTypeShared:
             return False
         return self.value == other.value
 
-
-class CacheTypeUnknown:
+class CacheTypeUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -2286,25 +2145,14 @@ class CacheTypeUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CacheTypeUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return CacheTypeUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"CacheTypeUnknown(tag={self.tag})"
 
-
-CacheType = Union[
-    CacheTypeDefault,
-    CacheTypeNo,
-    CacheTypeSingleThreaded,
-    CacheTypeMultiThreaded,
-    CacheTypeStormTracking,
-    CacheTypeShared,
-    CacheTypeUnknown,
-]
-
-
+CacheType = Union[CacheTypeDefault, CacheTypeNo, CacheTypeSingleThreaded, CacheTypeMultiThreaded, CacheTypeStormTracking, CacheTypeShared, CacheTypeUnknown]
 def _cache_type_from_dict(d: Dict[str, Any]) -> CacheType:
     if "Default" in d:
         return CacheTypeDefault.from_dict(d)
@@ -2324,62 +2172,51 @@ def _cache_type_from_dict(d: Dict[str, Any]) -> CacheType:
     if "Shared" in d:
         return CacheTypeShared.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class CreateAwsKmsHierarchicalKeyringInput:
     branch_key_id: Optional[str]
-    branch_key_id_supplier: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.BranchKeyIdSupplier"
-    ]
-    key_store: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client.KeyStore"
+    branch_key_id_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.BranchKeyIdSupplier']
+    key_store: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client.KeyStore'
     ttl_seconds: int
     cache: Optional[CacheType]
     partition_id: Optional[str]
-
     def __init__(
         self,
         *,
-        key_store: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client.KeyStore",
+        key_store: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client.KeyStore',
         branch_key_id: Optional[str] = None,
-        branch_key_id_supplier: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.BranchKeyIdSupplier"
-        ] = None,
+        branch_key_id_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.BranchKeyIdSupplier'] = None,
         ttl_seconds: int = 0,
         cache: Optional[CacheType] = None,
         partition_id: Optional[str] = None,
     ):
         """Inputs for creating a Hierarchical Keyring.
 
-        :param key_store: The Key Store which contains the Branch Key(s)
-            responsible for wrapping and unwrapping data keys.
-        :param branch_key_id: The identifier for the single Branch Key
-            responsible for wrapping and unwrapping the data key. Either
-            a Branch Key ID or Branch Key Supplier must be specified.
-        :param branch_key_id_supplier: A Branch Key Supplier which
-            determines what Branch Key to use to wrap and unwrap the
-            data key. Either a Branch Key ID or Branch Key Supplier must
-            be specified.
-        :param ttl_seconds: How many seconds the Branch Key material is
-            allowed to be reused within the local cache before it is re-
-            retrieved from Amazon DynamoDB and re-authenticated with AWS
-            KMS.
-        :param cache: Sets the type of cache for this Hierarchical
-            Keyring. By providing an already initialized 'Shared' cache,
-            users can determine the scope of the cache. That is, if the
-            cache is shared across other Cryptographic Material
-            Providers, for instance other Hierarchical Keyrings or
-            Caching Cryptographic Materials Managers (Caching CMMs). If
-            any other type of cache in the CacheType union is provided,
-            the Hierarchical Keyring will initialize a cache of that
-            type, to be used with only this Hierarchical Keyring. If not
-            set, a DefaultCache is initialized to be used with only this
-            Hierarchical Keyring with entryCapacity = 1000.
-        :param partition_id: Partition ID to distinguish Cryptographic
-            Material Providers (i.e: Keyrings) writing to a cache. If
-            the Partition ID is the same for two Hierarchical Keyrings
-            (or another Material Provider), they can share the same
-            cache entries in the cache.
+        :param key_store: The Key Store which contains the Branch Key(s) responsible for
+        wrapping and unwrapping data keys.
+        :param branch_key_id: The identifier for the single Branch Key responsible for
+        wrapping and unwrapping the data key. Either a Branch Key ID or Branch Key
+        Supplier must be specified.
+        :param branch_key_id_supplier: A Branch Key Supplier which determines what
+        Branch Key to use to wrap and unwrap the data key. Either a Branch Key ID or
+        Branch Key Supplier must be specified.
+        :param ttl_seconds: How many seconds the Branch Key material is allowed to be
+        reused within the local cache before it is re-retrieved from Amazon DynamoDB and
+        re-authenticated with AWS KMS.
+        :param cache: Sets the type of cache for this Hierarchical Keyring. By providing
+        an already initialized 'Shared' cache, users can determine the scope of the
+        cache. That is, if the cache is shared across other Cryptographic Material
+        Providers, for instance other Hierarchical Keyrings or Caching Cryptographic
+        Materials Managers (Caching CMMs). If any other type of cache in the CacheType
+        union is provided, the Hierarchical Keyring will initialize a cache of that
+        type, to be used with only this Hierarchical Keyring. If not set, a DefaultCache
+        is initialized to be used with only this Hierarchical Keyring with entryCapacity
+        = 1000.
+        :param partition_id: Partition ID to distinguish Cryptographic Material
+        Providers (i.e: Keyrings) writing to a cache. If the Partition ID is the same
+        for two Hierarchical Keyrings (or another Material Provider), they can share the
+        same cache entries in the cache.
         """
         self.key_store = key_store
         self.branch_key_id = branch_key_id
@@ -2392,8 +2229,9 @@ class CreateAwsKmsHierarchicalKeyringInput:
         self.partition_id = partition_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsHierarchicalKeyringInput to a
-        dictionary."""
+        """Converts the CreateAwsKmsHierarchicalKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "key_store": self.key_store.as_dict(),
         }
@@ -2417,14 +2255,11 @@ class CreateAwsKmsHierarchicalKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsHierarchicalKeyringInput":
-        """Creates a CreateAwsKmsHierarchicalKeyringInput from a dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            BranchKeyIdSupplier,
-        )
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client import (
-            KeyStore,
-        )
+        """Creates a CreateAwsKmsHierarchicalKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import BranchKeyIdSupplier
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.client import KeyStore
         kwargs: Dict[str, Any] = {
             "key_store": KeyStore.from_dict(d["key_store"]),
         }
@@ -2433,15 +2268,13 @@ class CreateAwsKmsHierarchicalKeyringInput:
             kwargs["branch_key_id"] = d["branch_key_id"]
 
         if "branch_key_id_supplier" in d:
-            kwargs["branch_key_id_supplier"] = BranchKeyIdSupplier.from_dict(
-                d["branch_key_id_supplier"]
-            )
+            kwargs["branch_key_id_supplier"] = BranchKeyIdSupplier.from_dict(d["branch_key_id_supplier"])
 
         if "ttl_seconds" in d:
             kwargs["ttl_seconds"] = d["ttl_seconds"]
 
         if "cache" in d:
-            kwargs["cache"] = (_cache_type_from_dict(d["cache"]),)
+            kwargs["cache"] = _cache_type_from_dict(d["cache"]),
 
         if "partition_id" in d:
             kwargs["partition_id"] = d["partition_id"]
@@ -2473,22 +2306,16 @@ class CreateAwsKmsHierarchicalKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsHierarchicalKeyringInput):
             return False
-        attributes: list[str] = [
-            "branch_key_id",
-            "branch_key_id_supplier",
-            "key_store",
-            "ttl_seconds",
-            "cache",
-            "partition_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['branch_key_id','branch_key_id_supplier','key_store','ttl_seconds','cache','partition_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsKeyringInput:
     kms_key_id: str
     kms_client: BaseClient
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -2498,20 +2325,20 @@ class CreateAwsKmsKeyringInput:
     ):
         """Inputs for for creating a AWS KMS Keyring.
 
-        :param kms_key_id: The identifier for the symmetric AWS KMS Key
-            responsible for wrapping and unwrapping data keys. This
-            should not be a AWS KMS Multi-Region Key.
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param kms_key_id: The identifier for the symmetric AWS KMS Key responsible for
+        wrapping and unwrapping data keys. This should not be a AWS KMS Multi-Region
+        Key.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.kms_key_id = kms_key_id
         self.kms_client = kms_client
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "kms_key_id": self.kms_key_id,
             "kms_client": self.kms_client,
@@ -2524,7 +2351,9 @@ class CreateAwsKmsKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsKeyringInput":
-        """Creates a CreateAwsKmsKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "kms_key_id": d["kms_key_id"],
             "kms_client": d["kms_client"],
@@ -2551,20 +2380,17 @@ class CreateAwsKmsKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsKeyringInput):
             return False
-        attributes: list[str] = [
-            "kms_key_id",
-            "kms_client",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['kms_key_id','kms_client','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsMrkDiscoveryKeyringInput:
     kms_client: BaseClient
     discovery_filter: Optional[DiscoveryFilter]
     grant_tokens: Optional[list[str]]
     region: str
-
     def __init__(
         self,
         *,
@@ -2575,14 +2401,11 @@ class CreateAwsKmsMrkDiscoveryKeyringInput:
     ):
         """Inputs for for creating a AWS KMS MRK Discovery Keyring.
 
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
         :param region: The region the input 'kmsClient' is in.
-        :param discovery_filter: A filter which restricts which KMS Keys
-            this Keyring may attempt to decrypt with by AWS partition
-            and account.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param discovery_filter: A filter which restricts which KMS Keys this Keyring
+        may attempt to decrypt with by AWS partition and account.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.kms_client = kms_client
         self.region = region
@@ -2590,8 +2413,9 @@ class CreateAwsKmsMrkDiscoveryKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsMrkDiscoveryKeyringInput to a
-        dictionary."""
+        """Converts the CreateAwsKmsMrkDiscoveryKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "kms_client": self.kms_client,
             "region": self.region,
@@ -2607,16 +2431,16 @@ class CreateAwsKmsMrkDiscoveryKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsMrkDiscoveryKeyringInput":
-        """Creates a CreateAwsKmsMrkDiscoveryKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsMrkDiscoveryKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "kms_client": d["kms_client"],
             "region": d["region"],
         }
 
         if "discovery_filter" in d:
-            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(
-                d["discovery_filter"]
-            )
+            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(d["discovery_filter"])
 
         if "grant_tokens" in d:
             kwargs["grant_tokens"] = d["grant_tokens"]
@@ -2642,47 +2466,35 @@ class CreateAwsKmsMrkDiscoveryKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsMrkDiscoveryKeyringInput):
             return False
-        attributes: list[str] = [
-            "kms_client",
-            "discovery_filter",
-            "grant_tokens",
-            "region",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['kms_client','discovery_filter','grant_tokens','region',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsMrkDiscoveryMultiKeyringInput:
     regions: list[str]
     discovery_filter: Optional[DiscoveryFilter]
-    client_supplier: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-    ]
+    client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier']
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
         regions: list[str],
         discovery_filter: Optional[DiscoveryFilter] = None,
-        client_supplier: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-        ] = None,
+        client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier'] = None,
         grant_tokens: Optional[list[str]] = None,
     ):
         """Inputs for for creating a AWS KMS MRK Discovery Multi-Keyring.
 
-        :param regions: The list of regions this Keyring will creates
-            KMS clients for.
-        :param discovery_filter: A filter which restricts which KMS Keys
-            this Keyring may attempt to decrypt with by AWS partition
-            and account.
-        :param client_supplier: The Client Supplier which will be used
-            to get KMS Clients for use with this Keyring. If not
-            specified on input, a Default Client Supplier is created
-            which creates a KMS Client for each region in the 'regions'
-            input.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param regions: The list of regions this Keyring will creates KMS clients for.
+        :param discovery_filter: A filter which restricts which KMS Keys this Keyring
+        may attempt to decrypt with by AWS partition and account.
+        :param client_supplier: The Client Supplier which will be used to get KMS
+        Clients for use with this Keyring. If not specified on input, a Default Client
+        Supplier is created which creates a KMS Client for each region in the 'regions'
+        input.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.regions = regions
         self.discovery_filter = discovery_filter
@@ -2690,8 +2502,9 @@ class CreateAwsKmsMrkDiscoveryMultiKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsMrkDiscoveryMultiKeyringInput to a
-        dictionary."""
+        """Converts the CreateAwsKmsMrkDiscoveryMultiKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "regions": self.regions,
         }
@@ -2709,20 +2522,16 @@ class CreateAwsKmsMrkDiscoveryMultiKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsMrkDiscoveryMultiKeyringInput":
-        """Creates a CreateAwsKmsMrkDiscoveryMultiKeyringInput from a
-        dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            ClientSupplier,
-        )
+        """Creates a CreateAwsKmsMrkDiscoveryMultiKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import ClientSupplier
         kwargs: Dict[str, Any] = {
             "regions": d["regions"],
         }
 
         if "discovery_filter" in d:
-            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(
-                d["discovery_filter"]
-            )
+            kwargs["discovery_filter"] = DiscoveryFilter.from_dict(d["discovery_filter"])
 
         if "client_supplier" in d:
             kwargs["client_supplier"] = ClientSupplier.from_dict(d["client_supplier"])
@@ -2751,20 +2560,16 @@ class CreateAwsKmsMrkDiscoveryMultiKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsMrkDiscoveryMultiKeyringInput):
             return False
-        attributes: list[str] = [
-            "regions",
-            "discovery_filter",
-            "client_supplier",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['regions','discovery_filter','client_supplier','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsMrkKeyringInput:
     kms_key_id: str
     kms_client: BaseClient
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -2774,20 +2579,19 @@ class CreateAwsKmsMrkKeyringInput:
     ):
         """Inputs for for creating an AWS KMS MRK Keyring.
 
-        :param kms_key_id: The identifier for the symmetric AWS KMS Key
-            or AWS KMS Multi-Region Key responsible for wrapping and
-            unwrapping data keys.
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param kms_key_id: The identifier for the symmetric AWS KMS Key or AWS KMS
+        Multi-Region Key responsible for wrapping and unwrapping data keys.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.kms_key_id = kms_key_id
         self.kms_client = kms_client
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsMrkKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsMrkKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "kms_key_id": self.kms_key_id,
             "kms_client": self.kms_client,
@@ -2800,7 +2604,9 @@ class CreateAwsKmsMrkKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsMrkKeyringInput":
-        """Creates a CreateAwsKmsMrkKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsMrkKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "kms_key_id": d["kms_key_id"],
             "kms_client": d["kms_client"],
@@ -2827,49 +2633,39 @@ class CreateAwsKmsMrkKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsMrkKeyringInput):
             return False
-        attributes: list[str] = [
-            "kms_key_id",
-            "kms_client",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['kms_key_id','kms_client','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsMrkMultiKeyringInput:
     generator: Optional[str]
     kms_key_ids: Optional[list[str]]
-    client_supplier: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-    ]
+    client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier']
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
         generator: Optional[str] = None,
         kms_key_ids: Optional[list[str]] = None,
-        client_supplier: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-        ] = None,
+        client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier'] = None,
         grant_tokens: Optional[list[str]] = None,
     ):
         """Inputs for for creating a AWS KMS MRK Multi-Keyring.
 
-        :param generator: A symmetric AWS KMS Key or AWS KMS Multi-
-            Region Key responsible for wrapping and unwrapping data
-            keys. KMS.GenerateDataKey may be called with this key if the
-            data key has not already been generated by another Keyring.
-        :param kms_key_ids: A list of identifiers for the symmetric AWS
-            KMS Keys and/or AWS KMS Multi-Region Keys (other than the
-            generator) responsible for wrapping and unwrapping data
-            keys.
-        :param client_supplier: The Client Supplier which will be used
-            to get KMS Clients for use with this Keyring. The Client
-            Supplier will create a client for each region specified in
-            the generator and kmsKeyIds ARNs. If not specified on input,
-            the Default Client Supplier is used.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param generator: A symmetric AWS KMS Key or AWS KMS Multi-Region Key
+        responsible for wrapping and unwrapping data keys. KMS.GenerateDataKey may be
+        called with this key if the data key has not already been generated by another
+        Keyring.
+        :param kms_key_ids: A list of identifiers for the symmetric AWS KMS Keys and/or
+        AWS KMS Multi-Region Keys (other than the generator) responsible for wrapping
+        and unwrapping data keys.
+        :param client_supplier: The Client Supplier which will be used to get KMS
+        Clients for use with this Keyring. The Client Supplier will create a client for
+        each region specified in the generator and kmsKeyIds ARNs. If not specified on
+        input, the Default Client Supplier is used.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.generator = generator
         self.kms_key_ids = kms_key_ids
@@ -2877,7 +2673,9 @@ class CreateAwsKmsMrkMultiKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsMrkMultiKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsMrkMultiKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.generator is not None:
@@ -2896,11 +2694,10 @@ class CreateAwsKmsMrkMultiKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsMrkMultiKeyringInput":
-        """Creates a CreateAwsKmsMrkMultiKeyringInput from a dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            ClientSupplier,
-        )
+        """Creates a CreateAwsKmsMrkMultiKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import ClientSupplier
         kwargs: Dict[str, Any] = {}
 
         if "generator" in d:
@@ -2936,51 +2733,39 @@ class CreateAwsKmsMrkMultiKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsMrkMultiKeyringInput):
             return False
-        attributes: list[str] = [
-            "generator",
-            "kms_key_ids",
-            "client_supplier",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['generator','kms_key_ids','client_supplier','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsMultiKeyringInput:
     generator: Optional[str]
     kms_key_ids: Optional[list[str]]
-    client_supplier: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-    ]
+    client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier']
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
         generator: Optional[str] = None,
         kms_key_ids: Optional[list[str]] = None,
-        client_supplier: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier"
-        ] = None,
+        client_supplier: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.ClientSupplier'] = None,
         grant_tokens: Optional[list[str]] = None,
     ):
         """Inputs for for creating a AWS KMS Multi-Keyring.
 
-        :param generator: A identifier for a symmetric AWS KMS Key
-            responsible for wrapping and unwrapping data keys.
-            KMS.GenerateDataKey may be called with this key if the data
-            key has not already been generated by another Keyring. This
-            should not be a AWS KMS Multi-Region Key.
-        :param kms_key_ids: A list of identifiers for the symmetric AWS
-            KMS Keys (other than the generator) responsible for wrapping
-            and unwrapping data keys. This list should not contain AWS
-            KMS Multi-Region Keys.
-        :param client_supplier: The Client Supplier which will be used
-            to get KMS Clients for use with this Keyring. The Client
-            Supplier will create a client for each region specified in
-            the generator and kmsKeyIds ARNs. If not specified on input,
-            the Default Client Supplier is used.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param generator: A identifier for a symmetric AWS KMS Key responsible for
+        wrapping and unwrapping data keys. KMS.GenerateDataKey may be called with this
+        key if the data key has not already been generated by another Keyring. This
+        should not be a AWS KMS Multi-Region Key.
+        :param kms_key_ids: A list of identifiers for the symmetric AWS KMS Keys (other
+        than the generator) responsible for wrapping and unwrapping data keys. This list
+        should not contain AWS KMS Multi-Region Keys.
+        :param client_supplier: The Client Supplier which will be used to get KMS
+        Clients for use with this Keyring. The Client Supplier will create a client for
+        each region specified in the generator and kmsKeyIds ARNs. If not specified on
+        input, the Default Client Supplier is used.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.generator = generator
         self.kms_key_ids = kms_key_ids
@@ -2988,7 +2773,9 @@ class CreateAwsKmsMultiKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsMultiKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsMultiKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {}
 
         if self.generator is not None:
@@ -3007,11 +2794,10 @@ class CreateAwsKmsMultiKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsMultiKeyringInput":
-        """Creates a CreateAwsKmsMultiKeyringInput from a dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            ClientSupplier,
-        )
+        """Creates a CreateAwsKmsMultiKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import ClientSupplier
         kwargs: Dict[str, Any] = {}
 
         if "generator" in d:
@@ -3047,14 +2833,11 @@ class CreateAwsKmsMultiKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsMultiKeyringInput):
             return False
-        attributes: list[str] = [
-            "generator",
-            "kms_key_ids",
-            "client_supplier",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['generator','kms_key_ids','client_supplier','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateAwsKmsRsaKeyringInput:
     public_key: Optional[bytes | bytearray]
@@ -3062,7 +2845,6 @@ class CreateAwsKmsRsaKeyringInput:
     encryption_algorithm: str
     kms_client: Optional[BaseClient]
     grant_tokens: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -3074,19 +2856,16 @@ class CreateAwsKmsRsaKeyringInput:
     ):
         """Inputs for creating a AWS KMS RSA Keyring.
 
-        :param kms_key_id: The ARN for the asymmetric AWS KMS Key for
-            RSA responsible for wrapping and unwrapping data keys.
-        :param encryption_algorithm: The RSA algorithm used to wrap and
-            unwrap data keys.
-        :param public_key: The public RSA Key responsible for wrapping
-            data keys, as a UTF8 encoded, PEM encoded X.509
-            SubjectPublicKeyInfo structure. This should be the public
-            key as exported from KMS. If not specified, this Keyring
-            cannot be used on encrypt.
-        :param kms_client: The KMS Client this Keyring will use to call
-            KMS.
-        :param grant_tokens: A list of grant tokens to be used when
-            calling KMS.
+        :param kms_key_id: The ARN for the asymmetric AWS KMS Key for RSA responsible
+        for wrapping and unwrapping data keys.
+        :param encryption_algorithm: The RSA algorithm used to wrap and unwrap data
+        keys.
+        :param public_key: The public RSA Key responsible for wrapping data keys, as a
+        UTF8 encoded, PEM encoded X.509 SubjectPublicKeyInfo structure. This should be
+        the public key as exported from KMS. If not specified, this Keyring cannot be
+        used on encrypt.
+        :param kms_client: The KMS Client this Keyring will use to call KMS.
+        :param grant_tokens: A list of grant tokens to be used when calling KMS.
         """
         self.kms_key_id = kms_key_id
         self.encryption_algorithm = encryption_algorithm
@@ -3095,7 +2874,9 @@ class CreateAwsKmsRsaKeyringInput:
         self.grant_tokens = grant_tokens
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateAwsKmsRsaKeyringInput to a dictionary."""
+        """Converts the CreateAwsKmsRsaKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "kms_key_id": self.kms_key_id,
             "encryption_algorithm": self.encryption_algorithm,
@@ -3114,7 +2895,9 @@ class CreateAwsKmsRsaKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateAwsKmsRsaKeyringInput":
-        """Creates a CreateAwsKmsRsaKeyringInput from a dictionary."""
+        """Creates a CreateAwsKmsRsaKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "kms_key_id": d["kms_key_id"],
             "encryption_algorithm": d["encryption_algorithm"],
@@ -3153,19 +2936,14 @@ class CreateAwsKmsRsaKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateAwsKmsRsaKeyringInput):
             return False
-        attributes: list[str] = [
-            "public_key",
-            "kms_key_id",
-            "encryption_algorithm",
-            "kms_client",
-            "grant_tokens",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['public_key','kms_key_id','encryption_algorithm','kms_client','grant_tokens',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateCryptographicMaterialsCacheInput:
     cache: CacheType
-
     def __init__(
         self,
         *,
@@ -3177,16 +2955,18 @@ class CreateCryptographicMaterialsCacheInput:
         self.cache = cache
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateCryptographicMaterialsCacheInput to a
-        dictionary."""
+        """Converts the CreateCryptographicMaterialsCacheInput to a dictionary.
+
+        """
         return {
             "cache": self.cache.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateCryptographicMaterialsCacheInput":
-        """Creates a CreateCryptographicMaterialsCacheInput from a
-        dictionary."""
+        """Creates a CreateCryptographicMaterialsCacheInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "cache": _cache_type_from_dict(d["cache"]),
         }
@@ -3203,20 +2983,24 @@ class CreateCryptographicMaterialsCacheInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateCryptographicMaterialsCacheInput):
             return False
-        attributes: list[str] = [
-            "cache",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['cache',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateDefaultClientSupplierInput:
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateDefaultClientSupplierInput to a dictionary."""
+        """Converts the CreateDefaultClientSupplierInput to a dictionary.
+
+        """
         return {}
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateDefaultClientSupplierInput":
-        """Creates a CreateDefaultClientSupplierInput from a dictionary."""
+        """Creates a CreateDefaultClientSupplierInput from a dictionary.
+
+        """
         return CreateDefaultClientSupplierInput()
 
     def __repr__(self) -> str:
@@ -3227,39 +3011,34 @@ class CreateDefaultClientSupplierInput:
     def __eq__(self, other: Any) -> bool:
         return isinstance(other, CreateDefaultClientSupplierInput)
 
-
 class CreateDefaultCryptographicMaterialsManagerInput:
-    keyring: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-
+    keyring: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring'
     def __init__(
         self,
         *,
-        keyring: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring",
+        keyring: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring',
     ):
         """Inputs for creating a Default Cryptographic Materials Manager.
 
-        :param keyring: The Keyring that the created Default
-            Cryptographic Materials Manager will use to wrap data keys.
+        :param keyring: The Keyring that the created Default Cryptographic Materials
+        Manager will use to wrap data keys.
         """
         self.keyring = keyring
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateDefaultCryptographicMaterialsManagerInput to a
-        dictionary."""
+        """Converts the CreateDefaultCryptographicMaterialsManagerInput to a dictionary.
+
+        """
         return {
             "keyring": self.keyring.as_dict(),
         }
 
     @staticmethod
-    def from_dict(
-        d: Dict[str, Any],
-    ) -> "CreateDefaultCryptographicMaterialsManagerInput":
-        """Creates a CreateDefaultCryptographicMaterialsManagerInput from a
-        dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            Keyring,
-        )
+    def from_dict(d: Dict[str, Any]) -> "CreateDefaultCryptographicMaterialsManagerInput":
+        """Creates a CreateDefaultCryptographicMaterialsManagerInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import Keyring
         kwargs: Dict[str, Any] = {
             "keyring": Keyring.from_dict(d["keyring"]),
         }
@@ -3276,45 +3055,36 @@ class CreateDefaultCryptographicMaterialsManagerInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateDefaultCryptographicMaterialsManagerInput):
             return False
-        attributes: list[str] = [
-            "keyring",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['keyring',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateMultiKeyringInput:
-    generator: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-    ]
-    child_keyrings: list[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-    ]
-
+    generator: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring']
+    child_keyrings: list['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring']
     def __init__(
         self,
         *,
-        child_keyrings: list[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-        ],
-        generator: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-        ] = None,
+        child_keyrings: list['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring'],
+        generator: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring'] = None,
     ):
         """Inputs for creating a Multi-Keyring.
 
-        :param child_keyrings: A list of keyrings (other than the
-            generator) responsible for wrapping and unwrapping the data
-            key.
-        :param generator: A keyring responsible for wrapping and
-            unwrapping the data key. This is the first keyring that will
-            be used to wrap the data key, and may be responsible for
-            additionally generating the data key.
+        :param child_keyrings: A list of keyrings (other than the generator) responsible
+        for wrapping and unwrapping the data key.
+        :param generator: A keyring responsible for wrapping and unwrapping the data
+        key. This is the first keyring that will be used to wrap the data key, and may
+        be responsible for additionally generating the data key.
         """
         self.child_keyrings = child_keyrings
         self.generator = generator
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateMultiKeyringInput to a dictionary."""
+        """Converts the CreateMultiKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "child_keyrings": self.child_keyrings,
         }
@@ -3326,11 +3096,10 @@ class CreateMultiKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateMultiKeyringInput":
-        """Creates a CreateMultiKeyringInput from a dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            Keyring,
-        )
+        """Creates a CreateMultiKeyringInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import Keyring
         kwargs: Dict[str, Any] = {
             "child_keyrings": d["child_keyrings"],
         }
@@ -3353,19 +3122,17 @@ class CreateMultiKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateMultiKeyringInput):
             return False
-        attributes: list[str] = [
-            "generator",
-            "child_keyrings",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['generator','child_keyrings',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateRawAesKeyringInput:
     key_namespace: str
     key_name: str
     wrapping_key: bytes | bytearray
     wrapping_alg: str
-
     def __init__(
         self,
         *,
@@ -3376,13 +3143,11 @@ class CreateRawAesKeyringInput:
     ):
         """Inputs for creating a Raw AES Keyring.
 
-        :param key_namespace: A namespace associated with this wrapping
-            key.
+        :param key_namespace: A namespace associated with this wrapping key.
         :param key_name: A name associated with this wrapping key.
-        :param wrapping_key: The AES key used with AES_GCM encryption
-            and decryption.
-        :param wrapping_alg: The AES_GCM algorithm this Keyring uses to
-            wrap and unwrap data keys.
+        :param wrapping_key: The AES key used with AES_GCM encryption and decryption.
+        :param wrapping_alg: The AES_GCM algorithm this Keyring uses to wrap and unwrap
+        data keys.
         """
         self.key_namespace = key_namespace
         self.key_name = key_name
@@ -3390,7 +3155,9 @@ class CreateRawAesKeyringInput:
         self.wrapping_alg = wrapping_alg
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateRawAesKeyringInput to a dictionary."""
+        """Converts the CreateRawAesKeyringInput to a dictionary.
+
+        """
         return {
             "key_namespace": self.key_namespace,
             "key_name": self.key_name,
@@ -3400,7 +3167,9 @@ class CreateRawAesKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateRawAesKeyringInput":
-        """Creates a CreateRawAesKeyringInput from a dictionary."""
+        """Creates a CreateRawAesKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_namespace": d["key_namespace"],
             "key_name": d["key_name"],
@@ -3429,42 +3198,38 @@ class CreateRawAesKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateRawAesKeyringInput):
             return False
-        attributes: list[str] = [
-            "key_namespace",
-            "key_name",
-            "wrapping_key",
-            "wrapping_alg",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_namespace','key_name','wrapping_key','wrapping_alg',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class EphemeralPrivateKeyToStaticPublicKeyInput:
     recipient_public_key: bytes | bytearray
-
     def __init__(
         self,
         *,
         recipient_public_key: bytes | bytearray,
     ):
-        """Inputs for creating a EphemeralPrivateKeyToStaticPublicKey
-        Configuration.
+        """Inputs for creating a EphemeralPrivateKeyToStaticPublicKey Configuration.
 
-        :param recipient_public_key: The recipient's public key. MUST be
-            DER encoded.
+        :param recipient_public_key: The recipient's public key. MUST be DER encoded.
         """
         self.recipient_public_key = recipient_public_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the EphemeralPrivateKeyToStaticPublicKeyInput to a
-        dictionary."""
+        """Converts the EphemeralPrivateKeyToStaticPublicKeyInput to a dictionary.
+
+        """
         return {
             "recipient_public_key": self.recipient_public_key,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EphemeralPrivateKeyToStaticPublicKeyInput":
-        """Creates a EphemeralPrivateKeyToStaticPublicKeyInput from a
-        dictionary."""
+        """Creates a EphemeralPrivateKeyToStaticPublicKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "recipient_public_key": d["recipient_public_key"],
         }
@@ -3481,15 +3246,14 @@ class EphemeralPrivateKeyToStaticPublicKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EphemeralPrivateKeyToStaticPublicKeyInput):
             return False
-        attributes: list[str] = [
-            "recipient_public_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['recipient_public_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class PublicKeyDiscoveryInput:
     recipient_static_private_key: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -3497,20 +3261,24 @@ class PublicKeyDiscoveryInput:
     ):
         """Inputs for creating a PublicKeyDiscovery Configuration.
 
-        :param recipient_static_private_key: The sender's private key.
-            MUST be PEM encoded.
+        :param recipient_static_private_key: The sender's private key. MUST be PEM
+        encoded.
         """
         self.recipient_static_private_key = recipient_static_private_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the PublicKeyDiscoveryInput to a dictionary."""
+        """Converts the PublicKeyDiscoveryInput to a dictionary.
+
+        """
         return {
             "recipient_static_private_key": self.recipient_static_private_key,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "PublicKeyDiscoveryInput":
-        """Creates a PublicKeyDiscoveryInput from a dictionary."""
+        """Creates a PublicKeyDiscoveryInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "recipient_static_private_key": d["recipient_static_private_key"],
         }
@@ -3527,16 +3295,15 @@ class PublicKeyDiscoveryInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, PublicKeyDiscoveryInput):
             return False
-        attributes: list[str] = [
-            "recipient_static_private_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['recipient_static_private_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class RawPrivateKeyToStaticPublicKeyInput:
     sender_static_private_key: bytes | bytearray
     recipient_public_key: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -3545,16 +3312,16 @@ class RawPrivateKeyToStaticPublicKeyInput:
     ):
         """Inputs for creating a RawPrivateKeyToStaticPublicKey Configuration.
 
-        :param sender_static_private_key: The sender's private key. MUST
-            be PEM encoded.
-        :param recipient_public_key: The recipient's public key. MUST be
-            DER encoded.
+        :param sender_static_private_key: The sender's private key. MUST be PEM encoded.
+        :param recipient_public_key: The recipient's public key. MUST be DER encoded.
         """
         self.sender_static_private_key = sender_static_private_key
         self.recipient_public_key = recipient_public_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the RawPrivateKeyToStaticPublicKeyInput to a dictionary."""
+        """Converts the RawPrivateKeyToStaticPublicKeyInput to a dictionary.
+
+        """
         return {
             "sender_static_private_key": self.sender_static_private_key,
             "recipient_public_key": self.recipient_public_key,
@@ -3562,7 +3329,9 @@ class RawPrivateKeyToStaticPublicKeyInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawPrivateKeyToStaticPublicKeyInput":
-        """Creates a RawPrivateKeyToStaticPublicKeyInput from a dictionary."""
+        """Creates a RawPrivateKeyToStaticPublicKeyInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "sender_static_private_key": d["sender_static_private_key"],
             "recipient_public_key": d["recipient_public_key"],
@@ -3573,9 +3342,7 @@ class RawPrivateKeyToStaticPublicKeyInput:
     def __repr__(self) -> str:
         result = "RawPrivateKeyToStaticPublicKeyInput("
         if self.sender_static_private_key is not None:
-            result += (
-                f"sender_static_private_key={repr(self.sender_static_private_key)}, "
-            )
+            result += f"sender_static_private_key={repr(self.sender_static_private_key)}, "
 
         if self.recipient_public_key is not None:
             result += f"recipient_public_key={repr(self.recipient_public_key)}"
@@ -3585,16 +3352,15 @@ class RawPrivateKeyToStaticPublicKeyInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RawPrivateKeyToStaticPublicKeyInput):
             return False
-        attributes: list[str] = [
-            "sender_static_private_key",
-            "recipient_public_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['sender_static_private_key','recipient_public_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class RawEcdhStaticConfigurationsPublicKeyDiscovery:
-    """Inputs for creating a PublicKeyDiscovery Configuration."""
-
+class RawEcdhStaticConfigurationsPublicKeyDiscovery():
+    """Inputs for creating a PublicKeyDiscovery Configuration.
+    """
     def __init__(self, value: PublicKeyDiscoveryInput):
         self.value = value
 
@@ -3603,12 +3369,10 @@ class RawEcdhStaticConfigurationsPublicKeyDiscovery:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawEcdhStaticConfigurationsPublicKeyDiscovery":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return RawEcdhStaticConfigurationsPublicKeyDiscovery(
-            PublicKeyDiscoveryInput.from_dict(d["PublicKeyDiscovery"])
-        )
+        return RawEcdhStaticConfigurationsPublicKeyDiscovery(PublicKeyDiscoveryInput.from_dict(d["PublicKeyDiscovery"]))
 
     def __repr__(self) -> str:
         return f"RawEcdhStaticConfigurationsPublicKeyDiscovery(value=repr(self.value))"
@@ -3618,10 +3382,9 @@ class RawEcdhStaticConfigurationsPublicKeyDiscovery:
             return False
         return self.value == other.value
 
-
-class RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey:
-    """Inputs for creating a RawPrivateKeyToStaticPublicKey Configuration."""
-
+class RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey():
+    """Inputs for creating a RawPrivateKeyToStaticPublicKey Configuration.
+    """
     def __init__(self, value: RawPrivateKeyToStaticPublicKeyInput):
         self.value = value
 
@@ -3629,33 +3392,23 @@ class RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey:
         return {"RawPrivateKeyToStaticPublicKey": self.value.as_dict()}
 
     @staticmethod
-    def from_dict(
-        d: Dict[str, Any],
-    ) -> "RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey":
-        if len(d) != 1:
+    def from_dict(d: Dict[str, Any]) -> "RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey":
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey(
-            RawPrivateKeyToStaticPublicKeyInput.from_dict(
-                d["RawPrivateKeyToStaticPublicKey"]
-            )
-        )
+        return RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey(RawPrivateKeyToStaticPublicKeyInput.from_dict(d["RawPrivateKeyToStaticPublicKey"]))
 
     def __repr__(self) -> str:
         return f"RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey(value=repr(self.value))"
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(
-            other, RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey
-        ):
+        if not isinstance(other, RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey):
             return False
         return self.value == other.value
 
-
-class RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey:
-    """Inputs for creating a EphemeralPrivateKeyToStaticPublicKey
-    Configuration."""
-
+class RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey():
+    """Inputs for creating a EphemeralPrivateKeyToStaticPublicKey Configuration.
+    """
     def __init__(self, value: EphemeralPrivateKeyToStaticPublicKeyInput):
         self.value = value
 
@@ -3663,34 +3416,25 @@ class RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey:
         return {"EphemeralPrivateKeyToStaticPublicKey": self.value.as_dict()}
 
     @staticmethod
-    def from_dict(
-        d: Dict[str, Any],
-    ) -> "RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey":
-        if len(d) != 1:
+    def from_dict(d: Dict[str, Any]) -> "RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey":
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey(
-            EphemeralPrivateKeyToStaticPublicKeyInput.from_dict(
-                d["EphemeralPrivateKeyToStaticPublicKey"]
-            )
-        )
+        return RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey(EphemeralPrivateKeyToStaticPublicKeyInput.from_dict(d["EphemeralPrivateKeyToStaticPublicKey"]))
 
     def __repr__(self) -> str:
         return f"RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey(value=repr(self.value))"
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(
-            other, RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey
-        ):
+        if not isinstance(other, RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey):
             return False
         return self.value == other.value
 
-
-class RawEcdhStaticConfigurationsUnknown:
+class RawEcdhStaticConfigurationsUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -3703,26 +3447,16 @@ class RawEcdhStaticConfigurationsUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawEcdhStaticConfigurationsUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return RawEcdhStaticConfigurationsUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"RawEcdhStaticConfigurationsUnknown(tag={self.tag})"
 
-
 # List of configurations when using RawEcdhStaticConfigurations.
-RawEcdhStaticConfigurations = Union[
-    RawEcdhStaticConfigurationsPublicKeyDiscovery,
-    RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey,
-    RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey,
-    RawEcdhStaticConfigurationsUnknown,
-]
-
-
-def _raw_ecdh_static_configurations_from_dict(
-    d: Dict[str, Any],
-) -> RawEcdhStaticConfigurations:
+RawEcdhStaticConfigurations = Union[RawEcdhStaticConfigurationsPublicKeyDiscovery, RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey, RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey, RawEcdhStaticConfigurationsUnknown]
+def _raw_ecdh_static_configurations_from_dict(d: Dict[str, Any]) -> RawEcdhStaticConfigurations:
     if "PublicKeyDiscovery" in d:
         return RawEcdhStaticConfigurationsPublicKeyDiscovery.from_dict(d)
 
@@ -3730,17 +3464,13 @@ def _raw_ecdh_static_configurations_from_dict(
         return RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey.from_dict(d)
 
     if "EphemeralPrivateKeyToStaticPublicKey" in d:
-        return (
-            RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey.from_dict(d)
-        )
+        return RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class CreateRawEcdhKeyringInput:
     key_agreement_scheme: RawEcdhStaticConfigurations
     curve_spec: str
-
     def __init__(
         self,
         *,
@@ -3749,17 +3479,18 @@ class CreateRawEcdhKeyringInput:
     ):
         """Inputs for creating a raw ECDH Keyring.
 
-        :param key_agreement_scheme: The Key Agreement Scheme
-            configuration that is responsible for how the shared secret
-            is calculated.
-        :param curve_spec: The the curve on which the points for the
-            sender's private and recipient's public key lie.
+        :param key_agreement_scheme: The Key Agreement Scheme configuration that is
+        responsible for how the shared secret is calculated.
+        :param curve_spec: The the curve on which the points for the sender's private
+        and recipient's public key lie.
         """
         self.key_agreement_scheme = key_agreement_scheme
         self.curve_spec = curve_spec
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateRawEcdhKeyringInput to a dictionary."""
+        """Converts the CreateRawEcdhKeyringInput to a dictionary.
+
+        """
         return {
             "key_agreement_scheme": self.key_agreement_scheme.as_dict(),
             "curve_spec": self.curve_spec,
@@ -3767,11 +3498,11 @@ class CreateRawEcdhKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateRawEcdhKeyringInput":
-        """Creates a CreateRawEcdhKeyringInput from a dictionary."""
+        """Creates a CreateRawEcdhKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "key_agreement_scheme": _raw_ecdh_static_configurations_from_dict(
-                d["key_agreement_scheme"]
-            ),
+            "key_agreement_scheme": _raw_ecdh_static_configurations_from_dict(d["key_agreement_scheme"]),
             "curve_spec": d["curve_spec"],
         }
 
@@ -3790,12 +3521,11 @@ class CreateRawEcdhKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateRawEcdhKeyringInput):
             return False
-        attributes: list[str] = [
-            "key_agreement_scheme",
-            "curve_spec",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_agreement_scheme','curve_spec',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class PaddingScheme:
     PKCS1 = "PKCS1"
@@ -3810,16 +3540,7 @@ class PaddingScheme:
 
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
-    values = frozenset(
-        {
-            "PKCS1",
-            "OAEP_SHA1_MGF1",
-            "OAEP_SHA256_MGF1",
-            "OAEP_SHA384_MGF1",
-            "OAEP_SHA512_MGF1",
-        }
-    )
-
+    values = frozenset({"PKCS1", "OAEP_SHA1_MGF1", "OAEP_SHA256_MGF1", "OAEP_SHA384_MGF1", "OAEP_SHA512_MGF1"})
 
 class CreateRawRsaKeyringInput:
     key_namespace: str
@@ -3827,7 +3548,6 @@ class CreateRawRsaKeyringInput:
     padding_scheme: str
     public_key: Optional[bytes | bytearray]
     private_key: Optional[bytes | bytearray]
-
     def __init__(
         self,
         *,
@@ -3839,21 +3559,17 @@ class CreateRawRsaKeyringInput:
     ):
         """Inputs for creating a Raw RAW Keyring.
 
-        :param key_namespace: A namespace associated with this wrapping
-            key.
+        :param key_namespace: A namespace associated with this wrapping key.
         :param key_name: A name associated with this wrapping key.
-        :param padding_scheme: The RSA padding scheme to use with this
-            keyring.
-        :param public_key: The public RSA Key responsible for wrapping
-            data keys, as a UTF8 encoded, PEM encoded X.509
-            SubjectPublicKeyInfo structure. If not specified, this
-            Keyring cannot be used on encrypt. A public key and/or a
-            private key must be specified.
-        :param private_key: The private RSA Key responsible for wrapping
-            data keys, as a UTF8 encoded, PEM encoded PKCS #8
-            PrivateKeyInfo structure. If not specified, this Keyring
-            cannot be used on decrypt. A public key and/or a private key
-            must be specified.
+        :param padding_scheme: The RSA padding scheme to use with this keyring.
+        :param public_key: The public RSA Key responsible for wrapping data keys, as a
+        UTF8 encoded, PEM encoded X.509 SubjectPublicKeyInfo structure. If not
+        specified, this Keyring cannot be used on encrypt. A public key and/or a private
+        key must be specified.
+        :param private_key: The private RSA Key responsible for wrapping data keys, as a
+        UTF8 encoded, PEM encoded PKCS #8 PrivateKeyInfo structure. If not specified,
+        this Keyring cannot be used on decrypt. A public key and/or a private key must
+        be specified.
         """
         self.key_namespace = key_namespace
         self.key_name = key_name
@@ -3862,7 +3578,9 @@ class CreateRawRsaKeyringInput:
         self.private_key = private_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateRawRsaKeyringInput to a dictionary."""
+        """Converts the CreateRawRsaKeyringInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "key_namespace": self.key_namespace,
             "key_name": self.key_name,
@@ -3879,7 +3597,9 @@ class CreateRawRsaKeyringInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateRawRsaKeyringInput":
-        """Creates a CreateRawRsaKeyringInput from a dictionary."""
+        """Creates a CreateRawRsaKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_namespace": d["key_namespace"],
             "key_name": d["key_name"],
@@ -3916,63 +3636,48 @@ class CreateRawRsaKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateRawRsaKeyringInput):
             return False
-        attributes: list[str] = [
-            "key_namespace",
-            "key_name",
-            "padding_scheme",
-            "public_key",
-            "private_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_namespace','key_name','padding_scheme','public_key','private_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class CreateRequiredEncryptionContextCMMInput:
-    underlying_cmm: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager"
-    ]
-    keyring: Optional[
-        "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-    ]
+    underlying_cmm: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager']
+    keyring: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring']
     required_encryption_context_keys: list[str]
-
     def __init__(
         self,
         *,
         required_encryption_context_keys: list[str],
-        underlying_cmm: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager"
-        ] = None,
-        keyring: Optional[
-            "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring"
-        ] = None,
+        underlying_cmm: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager'] = None,
+        keyring: Optional['aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring'] = None,
     ):
-        """Inputs for creating an Required Encryption Context Cryptographic
-        Materials Manager.
+        """Inputs for creating an Required Encryption Context Cryptographic Materials
+        Manager.
 
-        :param required_encryption_context_keys: A list of Encryption
-            Context keys which are required to be supplied during
-            encryption and decryption, and correspond to Encryption
-            Context key-value pairs which are not stored on the
-            resulting message.
-        :param underlying_cmm: The Cryptographic Materials Manager that
-            the created Required Encryption Context Cryptographic
-            Materials Manager will delegate to. Either a Keyring or
-            underlying Cryptographic Materials Manager must be
-            specified.
-        :param keyring: The Keyring that the created Cryptographic
-            Materials Manager will use to wrap data keys. The created
-            Required Encryption Context CMM will delegate to a Default
-            Cryptographic Materials Manager created with this Keyring.
-            Either a Keyring or an underlying Cryptographic Materials
-            Manager must be specified as input.
+        :param required_encryption_context_keys: A list of Encryption Context keys which
+        are required to be supplied during encryption and decryption, and correspond to
+        Encryption Context key-value pairs which are not stored on the resulting
+        message.
+        :param underlying_cmm: The Cryptographic Materials Manager that the created
+        Required Encryption Context Cryptographic Materials Manager will delegate to.
+        Either a Keyring or underlying Cryptographic Materials Manager must be
+        specified.
+        :param keyring: The Keyring that the created Cryptographic Materials Manager
+        will use to wrap data keys. The created Required Encryption Context CMM will
+        delegate to a Default Cryptographic Materials Manager created with this Keyring.
+        Either a Keyring or an underlying Cryptographic Materials Manager must be
+        specified as input.
         """
         self.required_encryption_context_keys = required_encryption_context_keys
         self.underlying_cmm = underlying_cmm
         self.keyring = keyring
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the CreateRequiredEncryptionContextCMMInput to a
-        dictionary."""
+        """Converts the CreateRequiredEncryptionContextCMMInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "required_encryption_context_keys": self.required_encryption_context_keys,
         }
@@ -3987,23 +3692,17 @@ class CreateRequiredEncryptionContextCMMInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CreateRequiredEncryptionContextCMMInput":
-        """Creates a CreateRequiredEncryptionContextCMMInput from a
-        dictionary."""
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            CryptographicMaterialsManager,
-        )
-        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import (
-            Keyring,
-        )
+        """Creates a CreateRequiredEncryptionContextCMMInput from a dictionary.
 
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import CryptographicMaterialsManager
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import Keyring
         kwargs: Dict[str, Any] = {
             "required_encryption_context_keys": d["required_encryption_context_keys"],
         }
 
         if "underlying_cmm" in d:
-            kwargs["underlying_cmm"] = CryptographicMaterialsManager.from_dict(
-                d["underlying_cmm"]
-            )
+            kwargs["underlying_cmm"] = CryptographicMaterialsManager.from_dict(d["underlying_cmm"])
 
         if "keyring" in d:
             kwargs["keyring"] = Keyring.from_dict(d["keyring"])
@@ -4026,17 +3725,14 @@ class CreateRequiredEncryptionContextCMMInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, CreateRequiredEncryptionContextCMMInput):
             return False
-        attributes: list[str] = [
-            "underlying_cmm",
-            "keyring",
-            "required_encryption_context_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['underlying_cmm','keyring','required_encryption_context_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DeleteCacheEntryInput:
     identifier: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -4045,14 +3741,18 @@ class DeleteCacheEntryInput:
         self.identifier = identifier
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DeleteCacheEntryInput to a dictionary."""
+        """Converts the DeleteCacheEntryInput to a dictionary.
+
+        """
         return {
             "identifier": self.identifier,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DeleteCacheEntryInput":
-        """Creates a DeleteCacheEntryInput from a dictionary."""
+        """Creates a DeleteCacheEntryInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "identifier": d["identifier"],
         }
@@ -4069,16 +3769,15 @@ class DeleteCacheEntryInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DeleteCacheEntryInput):
             return False
-        attributes: list[str] = [
-            "identifier",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetCacheEntryInput:
     identifier: bytes | bytearray
     bytes_used: Optional[int]
-
     def __init__(
         self,
         *,
@@ -4089,7 +3788,9 @@ class GetCacheEntryInput:
         self.bytes_used = bytes_used
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetCacheEntryInput to a dictionary."""
+        """Converts the GetCacheEntryInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "identifier": self.identifier,
         }
@@ -4101,7 +3802,9 @@ class GetCacheEntryInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetCacheEntryInput":
-        """Creates a GetCacheEntryInput from a dictionary."""
+        """Creates a GetCacheEntryInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "identifier": d["identifier"],
         }
@@ -4124,12 +3827,11 @@ class GetCacheEntryInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetCacheEntryInput):
             return False
-        attributes: list[str] = [
-            "identifier",
-            "bytes_used",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['identifier','bytes_used',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DecryptionMaterials:
     algorithm_suite: AlgorithmSuiteInfo
@@ -4138,7 +3840,6 @@ class DecryptionMaterials:
     plaintext_data_key: Optional[bytes | bytearray]
     verification_key: Optional[bytes | bytearray]
     symmetric_signing_key: Optional[bytes | bytearray]
-
     def __init__(
         self,
         *,
@@ -4157,7 +3858,9 @@ class DecryptionMaterials:
         self.symmetric_signing_key = symmetric_signing_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DecryptionMaterials to a dictionary."""
+        """Converts the DecryptionMaterials to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "algorithm_suite": self.algorithm_suite.as_dict(),
             "encryption_context": self.encryption_context,
@@ -4177,7 +3880,9 @@ class DecryptionMaterials:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DecryptionMaterials":
-        """Creates a DecryptionMaterials from a dictionary."""
+        """Creates a DecryptionMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "algorithm_suite": AlgorithmSuiteInfo.from_dict(d["algorithm_suite"]),
             "encryption_context": d["encryption_context"],
@@ -4220,22 +3925,16 @@ class DecryptionMaterials:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DecryptionMaterials):
             return False
-        attributes: list[str] = [
-            "algorithm_suite",
-            "encryption_context",
-            "required_encryption_context_keys",
-            "plaintext_data_key",
-            "verification_key",
-            "symmetric_signing_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm_suite','encryption_context','required_encryption_context_keys','plaintext_data_key','verification_key','symmetric_signing_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class EncryptedDataKey:
     key_provider_id: str
     key_provider_info: bytes | bytearray
     ciphertext: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -4248,7 +3947,9 @@ class EncryptedDataKey:
         self.ciphertext = ciphertext
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the EncryptedDataKey to a dictionary."""
+        """Converts the EncryptedDataKey to a dictionary.
+
+        """
         return {
             "key_provider_id": self.key_provider_id,
             "key_provider_info": self.key_provider_info,
@@ -4257,7 +3958,9 @@ class EncryptedDataKey:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EncryptedDataKey":
-        """Creates a EncryptedDataKey from a dictionary."""
+        """Creates a EncryptedDataKey from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_provider_id": d["key_provider_id"],
             "key_provider_info": d["key_provider_info"],
@@ -4282,13 +3985,11 @@ class EncryptedDataKey:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EncryptedDataKey):
             return False
-        attributes: list[str] = [
-            "key_provider_id",
-            "key_provider_info",
-            "ciphertext",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_provider_id','key_provider_info','ciphertext',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class EncryptionMaterials:
     algorithm_suite: AlgorithmSuiteInfo
@@ -4298,7 +3999,6 @@ class EncryptionMaterials:
     plaintext_data_key: Optional[bytes | bytearray]
     signing_key: Optional[bytes | bytearray]
     symmetric_signing_keys: Optional[list[bytes | bytearray]]
-
     def __init__(
         self,
         *,
@@ -4319,13 +4019,13 @@ class EncryptionMaterials:
         self.symmetric_signing_keys = symmetric_signing_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the EncryptionMaterials to a dictionary."""
+        """Converts the EncryptionMaterials to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "algorithm_suite": self.algorithm_suite.as_dict(),
             "encryption_context": self.encryption_context,
-            "encrypted_data_keys": _encrypted_data_key_list_as_dict(
-                self.encrypted_data_keys
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_as_dict(self.encrypted_data_keys),
             "required_encryption_context_keys": self.required_encryption_context_keys,
         }
 
@@ -4342,13 +4042,13 @@ class EncryptionMaterials:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "EncryptionMaterials":
-        """Creates a EncryptionMaterials from a dictionary."""
+        """Creates a EncryptionMaterials from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "algorithm_suite": AlgorithmSuiteInfo.from_dict(d["algorithm_suite"]),
             "encryption_context": d["encryption_context"],
-            "encrypted_data_keys": _encrypted_data_key_list_from_dict(
-                d["encrypted_data_keys"]
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_from_dict(d["encrypted_data_keys"]),
             "required_encryption_context_keys": d["required_encryption_context_keys"],
         }
 
@@ -4391,19 +4091,13 @@ class EncryptionMaterials:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, EncryptionMaterials):
             return False
-        attributes: list[str] = [
-            "algorithm_suite",
-            "encryption_context",
-            "encrypted_data_keys",
-            "required_encryption_context_keys",
-            "plaintext_data_key",
-            "signing_key",
-            "symmetric_signing_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['algorithm_suite','encryption_context','encrypted_data_keys','required_encryption_context_keys','plaintext_data_key','signing_key','symmetric_signing_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class MaterialsEncryption:
+class MaterialsEncryption():
     def __init__(self, value: EncryptionMaterials):
         self.value = value
 
@@ -4412,7 +4106,7 @@ class MaterialsEncryption:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialsEncryption":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return MaterialsEncryption(EncryptionMaterials.from_dict(d["Encryption"]))
@@ -4425,8 +4119,7 @@ class MaterialsEncryption:
             return False
         return self.value == other.value
 
-
-class MaterialsDecryption:
+class MaterialsDecryption():
     def __init__(self, value: DecryptionMaterials):
         self.value = value
 
@@ -4435,7 +4128,7 @@ class MaterialsDecryption:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialsDecryption":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return MaterialsDecryption(DecryptionMaterials.from_dict(d["Decryption"]))
@@ -4448,8 +4141,7 @@ class MaterialsDecryption:
             return False
         return self.value == other.value
 
-
-class MaterialsBranchKey:
+class MaterialsBranchKey():
     def __init__(self, value: BranchKeyMaterials):
         self.value = value
 
@@ -4458,7 +4150,7 @@ class MaterialsBranchKey:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialsBranchKey":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return MaterialsBranchKey(BranchKeyMaterials.from_dict(d["BranchKey"]))
@@ -4471,8 +4163,7 @@ class MaterialsBranchKey:
             return False
         return self.value == other.value
 
-
-class MaterialsBeaconKey:
+class MaterialsBeaconKey():
     def __init__(self, value: BeaconKeyMaterials):
         self.value = value
 
@@ -4481,7 +4172,7 @@ class MaterialsBeaconKey:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialsBeaconKey":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return MaterialsBeaconKey(BeaconKeyMaterials.from_dict(d["BeaconKey"]))
@@ -4494,12 +4185,11 @@ class MaterialsBeaconKey:
             return False
         return self.value == other.value
 
-
-class MaterialsUnknown:
+class MaterialsUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -4512,23 +4202,14 @@ class MaterialsUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MaterialsUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return MaterialsUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"MaterialsUnknown(tag={self.tag})"
 
-
-Materials = Union[
-    MaterialsEncryption,
-    MaterialsDecryption,
-    MaterialsBranchKey,
-    MaterialsBeaconKey,
-    MaterialsUnknown,
-]
-
-
+Materials = Union[MaterialsEncryption, MaterialsDecryption, MaterialsBranchKey, MaterialsBeaconKey, MaterialsUnknown]
 def _materials_from_dict(d: Dict[str, Any]) -> Materials:
     if "Encryption" in d:
         return MaterialsEncryption.from_dict(d)
@@ -4542,8 +4223,7 @@ def _materials_from_dict(d: Dict[str, Any]) -> Materials:
     if "BeaconKey" in d:
         return MaterialsBeaconKey.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class GetCacheEntryOutput:
     materials: Materials
@@ -4551,7 +4231,6 @@ class GetCacheEntryOutput:
     expiry_time: int
     messages_used: int
     bytes_used: int
-
     def __init__(
         self,
         *,
@@ -4580,7 +4259,9 @@ class GetCacheEntryOutput:
         self.bytes_used = bytes_used
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetCacheEntryOutput to a dictionary."""
+        """Converts the GetCacheEntryOutput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "materials": self.materials.as_dict(),
         }
@@ -4601,7 +4282,9 @@ class GetCacheEntryOutput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetCacheEntryOutput":
-        """Creates a GetCacheEntryOutput from a dictionary."""
+        """Creates a GetCacheEntryOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "materials": _materials_from_dict(d["materials"]),
         }
@@ -4642,15 +4325,11 @@ class GetCacheEntryOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetCacheEntryOutput):
             return False
-        attributes: list[str] = [
-            "materials",
-            "creation_time",
-            "expiry_time",
-            "messages_used",
-            "bytes_used",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['materials','creation_time','expiry_time','messages_used','bytes_used',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class PutCacheEntryInput:
     identifier: bytes | bytearray
@@ -4659,7 +4338,6 @@ class PutCacheEntryInput:
     expiry_time: int
     messages_used: int
     bytes_used: int
-
     def __init__(
         self,
         *,
@@ -4690,7 +4368,9 @@ class PutCacheEntryInput:
         self.bytes_used = bytes_used
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the PutCacheEntryInput to a dictionary."""
+        """Converts the PutCacheEntryInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "identifier": self.identifier,
             "materials": self.materials.as_dict(),
@@ -4712,7 +4392,9 @@ class PutCacheEntryInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "PutCacheEntryInput":
-        """Creates a PutCacheEntryInput from a dictionary."""
+        """Creates a PutCacheEntryInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "identifier": d["identifier"],
             "materials": _materials_from_dict(d["materials"]),
@@ -4757,21 +4439,15 @@ class PutCacheEntryInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, PutCacheEntryInput):
             return False
-        attributes: list[str] = [
-            "identifier",
-            "materials",
-            "creation_time",
-            "expiry_time",
-            "messages_used",
-            "bytes_used",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['identifier','materials','creation_time','expiry_time','messages_used','bytes_used',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class UpdateUsageMetadataInput:
     identifier: bytes | bytearray
     bytes_used: int
-
     def __init__(
         self,
         *,
@@ -4785,7 +4461,9 @@ class UpdateUsageMetadataInput:
         self.bytes_used = bytes_used
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the UpdateUsageMetadataInput to a dictionary."""
+        """Converts the UpdateUsageMetadataInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "identifier": self.identifier,
         }
@@ -4797,7 +4475,9 @@ class UpdateUsageMetadataInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "UpdateUsageMetadataInput":
-        """Creates a UpdateUsageMetadataInput from a dictionary."""
+        """Creates a UpdateUsageMetadataInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "identifier": d["identifier"],
         }
@@ -4820,12 +4500,11 @@ class UpdateUsageMetadataInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, UpdateUsageMetadataInput):
             return False
-        attributes: list[str] = [
-            "identifier",
-            "bytes_used",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['identifier','bytes_used',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DBECommitmentPolicy:
     REQUIRE_ENCRYPT_REQUIRE_DECRYPT = "REQUIRE_ENCRYPT_REQUIRE_DECRYPT"
@@ -4833,7 +4512,6 @@ class DBECommitmentPolicy:
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
     values = frozenset({"REQUIRE_ENCRYPT_REQUIRE_DECRYPT"})
-
 
 class ESDKCommitmentPolicy:
     FORBID_ENCRYPT_ALLOW_DECRYPT = "FORBID_ENCRYPT_ALLOW_DECRYPT"
@@ -4844,16 +4522,9 @@ class ESDKCommitmentPolicy:
 
     # This set contains every possible value known at the time this was generated. New
     # values may be added in the future.
-    values = frozenset(
-        {
-            "FORBID_ENCRYPT_ALLOW_DECRYPT",
-            "REQUIRE_ENCRYPT_ALLOW_DECRYPT",
-            "REQUIRE_ENCRYPT_REQUIRE_DECRYPT",
-        }
-    )
+    values = frozenset({"FORBID_ENCRYPT_ALLOW_DECRYPT", "REQUIRE_ENCRYPT_ALLOW_DECRYPT", "REQUIRE_ENCRYPT_REQUIRE_DECRYPT"})
 
-
-class CommitmentPolicyESDK:
+class CommitmentPolicyESDK():
     def __init__(self, value: str):
         self.value = value
 
@@ -4862,7 +4533,7 @@ class CommitmentPolicyESDK:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CommitmentPolicyESDK":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CommitmentPolicyESDK(d["ESDK"])
@@ -4875,8 +4546,7 @@ class CommitmentPolicyESDK:
             return False
         return self.value == other.value
 
-
-class CommitmentPolicyDBE:
+class CommitmentPolicyDBE():
     def __init__(self, value: str):
         self.value = value
 
@@ -4885,7 +4555,7 @@ class CommitmentPolicyDBE:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CommitmentPolicyDBE":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return CommitmentPolicyDBE(d["DBE"])
@@ -4898,12 +4568,11 @@ class CommitmentPolicyDBE:
             return False
         return self.value == other.value
 
-
-class CommitmentPolicyUnknown:
+class CommitmentPolicyUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -4916,19 +4585,14 @@ class CommitmentPolicyUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CommitmentPolicyUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return CommitmentPolicyUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"CommitmentPolicyUnknown(tag={self.tag})"
 
-
-CommitmentPolicy = Union[
-    CommitmentPolicyESDK, CommitmentPolicyDBE, CommitmentPolicyUnknown
-]
-
-
+CommitmentPolicy = Union[CommitmentPolicyESDK, CommitmentPolicyDBE, CommitmentPolicyUnknown]
 def _commitment_policy_from_dict(d: Dict[str, Any]) -> CommitmentPolicy:
     if "ESDK" in d:
         return CommitmentPolicyESDK.from_dict(d)
@@ -4936,8 +4600,7 @@ def _commitment_policy_from_dict(d: Dict[str, Any]) -> CommitmentPolicy:
     if "DBE" in d:
         return CommitmentPolicyDBE.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class DecryptMaterialsInput:
     algorithm_suite_id: AlgorithmSuiteId
@@ -4945,7 +4608,6 @@ class DecryptMaterialsInput:
     encrypted_data_keys: list[EncryptedDataKey]
     encryption_context: dict[str, str]
     reproduced_encryption_context: Optional[dict[str, str]]
-
     def __init__(
         self,
         *,
@@ -4962,13 +4624,13 @@ class DecryptMaterialsInput:
         self.reproduced_encryption_context = reproduced_encryption_context
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DecryptMaterialsInput to a dictionary."""
+        """Converts the DecryptMaterialsInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "algorithm_suite_id": self.algorithm_suite_id.as_dict(),
             "commitment_policy": self.commitment_policy.as_dict(),
-            "encrypted_data_keys": _encrypted_data_key_list_as_dict(
-                self.encrypted_data_keys
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_as_dict(self.encrypted_data_keys),
             "encryption_context": self.encryption_context,
         }
 
@@ -4979,15 +4641,13 @@ class DecryptMaterialsInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DecryptMaterialsInput":
-        """Creates a DecryptMaterialsInput from a dictionary."""
+        """Creates a DecryptMaterialsInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "algorithm_suite_id": _algorithm_suite_id_from_dict(
-                d["algorithm_suite_id"]
-            ),
+            "algorithm_suite_id": _algorithm_suite_id_from_dict(d["algorithm_suite_id"]),
             "commitment_policy": _commitment_policy_from_dict(d["commitment_policy"]),
-            "encrypted_data_keys": _encrypted_data_key_list_from_dict(
-                d["encrypted_data_keys"]
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_from_dict(d["encrypted_data_keys"]),
             "encryption_context": d["encryption_context"],
         }
 
@@ -5018,19 +4678,14 @@ class DecryptMaterialsInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DecryptMaterialsInput):
             return False
-        attributes: list[str] = [
-            "algorithm_suite_id",
-            "commitment_policy",
-            "encrypted_data_keys",
-            "encryption_context",
-            "reproduced_encryption_context",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm_suite_id','commitment_policy','encrypted_data_keys','encryption_context','reproduced_encryption_context',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class DecryptMaterialsOutput:
     decryption_materials: DecryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5039,18 +4694,20 @@ class DecryptMaterialsOutput:
         self.decryption_materials = decryption_materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the DecryptMaterialsOutput to a dictionary."""
+        """Converts the DecryptMaterialsOutput to a dictionary.
+
+        """
         return {
             "decryption_materials": self.decryption_materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "DecryptMaterialsOutput":
-        """Creates a DecryptMaterialsOutput from a dictionary."""
+        """Creates a DecryptMaterialsOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "decryption_materials": DecryptionMaterials.from_dict(
-                d["decryption_materials"]
-            ),
+            "decryption_materials": DecryptionMaterials.from_dict(d["decryption_materials"]),
         }
 
         return DecryptMaterialsOutput(**kwargs)
@@ -5065,11 +4722,11 @@ class DecryptMaterialsOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, DecryptMaterialsOutput):
             return False
-        attributes: list[str] = [
-            "decryption_materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['decryption_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetEncryptionMaterialsInput:
     encryption_context: dict[str, str]
@@ -5077,7 +4734,6 @@ class GetEncryptionMaterialsInput:
     algorithm_suite_id: Optional[AlgorithmSuiteId]
     max_plaintext_length: Optional[int]
     required_encryption_context_keys: Optional[list[str]]
-
     def __init__(
         self,
         *,
@@ -5094,7 +4750,9 @@ class GetEncryptionMaterialsInput:
         self.required_encryption_context_keys = required_encryption_context_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetEncryptionMaterialsInput to a dictionary."""
+        """Converts the GetEncryptionMaterialsInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "encryption_context": self.encryption_context,
             "commitment_policy": self.commitment_policy.as_dict(),
@@ -5107,32 +4765,28 @@ class GetEncryptionMaterialsInput:
             d["max_plaintext_length"] = self.max_plaintext_length
 
         if self.required_encryption_context_keys is not None:
-            d["required_encryption_context_keys"] = (
-                self.required_encryption_context_keys
-            )
+            d["required_encryption_context_keys"] = self.required_encryption_context_keys
 
         return d
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetEncryptionMaterialsInput":
-        """Creates a GetEncryptionMaterialsInput from a dictionary."""
+        """Creates a GetEncryptionMaterialsInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "encryption_context": d["encryption_context"],
             "commitment_policy": _commitment_policy_from_dict(d["commitment_policy"]),
         }
 
         if "algorithm_suite_id" in d:
-            kwargs["algorithm_suite_id"] = (
-                _algorithm_suite_id_from_dict(d["algorithm_suite_id"]),
-            )
+            kwargs["algorithm_suite_id"] = _algorithm_suite_id_from_dict(d["algorithm_suite_id"]),
 
         if "max_plaintext_length" in d:
             kwargs["max_plaintext_length"] = d["max_plaintext_length"]
 
         if "required_encryption_context_keys" in d:
-            kwargs["required_encryption_context_keys"] = d[
-                "required_encryption_context_keys"
-            ]
+            kwargs["required_encryption_context_keys"] = d["required_encryption_context_keys"]
 
         return GetEncryptionMaterialsInput(**kwargs)
 
@@ -5158,19 +4812,14 @@ class GetEncryptionMaterialsInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetEncryptionMaterialsInput):
             return False
-        attributes: list[str] = [
-            "encryption_context",
-            "commitment_policy",
-            "algorithm_suite_id",
-            "max_plaintext_length",
-            "required_encryption_context_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['encryption_context','commitment_policy','algorithm_suite_id','max_plaintext_length','required_encryption_context_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetEncryptionMaterialsOutput:
     encryption_materials: EncryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5179,18 +4828,20 @@ class GetEncryptionMaterialsOutput:
         self.encryption_materials = encryption_materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetEncryptionMaterialsOutput to a dictionary."""
+        """Converts the GetEncryptionMaterialsOutput to a dictionary.
+
+        """
         return {
             "encryption_materials": self.encryption_materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetEncryptionMaterialsOutput":
-        """Creates a GetEncryptionMaterialsOutput from a dictionary."""
+        """Creates a GetEncryptionMaterialsOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "encryption_materials": EncryptionMaterials.from_dict(
-                d["encryption_materials"]
-            ),
+            "encryption_materials": EncryptionMaterials.from_dict(d["encryption_materials"]),
         }
 
         return GetEncryptionMaterialsOutput(**kwargs)
@@ -5205,17 +4856,140 @@ class GetEncryptionMaterialsOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetEncryptionMaterialsOutput):
             return False
-        attributes: list[str] = [
-            "encryption_materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['encryption_materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
+class GetCacheIdentifierInput:
+    keyring: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring'
+    branch_key_id: str
+    branch_key_version: Optional[str]
+    def __init__(
+        self,
+        *,
+        keyring: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring',
+        branch_key_id: str,
+        branch_key_version: Optional[str] = None,
+    ):
+        """Inputs for computing a cache identifier.
+
+        :param keyring: The Hierarchical Keyring whose internal state is used to compute
+        the cache identifier.
+        :param branch_key_id: The branch key identifier.
+        :param branch_key_version: The branch key version. If provided, computes the
+        decrypt-path cache identifier. If omitted, computes the encrypt-path cache
+        identifier.
+        """
+        self.keyring = keyring
+        self.branch_key_id = branch_key_id
+        self.branch_key_version = branch_key_version
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Converts the GetCacheIdentifierInput to a dictionary.
+
+        """
+        d: Dict[str, Any] = {
+            "keyring": self.keyring.as_dict(),
+            "branch_key_id": self.branch_key_id,
+        }
+
+        if self.branch_key_version is not None:
+            d["branch_key_version"] = self.branch_key_version
+
+        return d
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "GetCacheIdentifierInput":
+        """Creates a GetCacheIdentifierInput from a dictionary.
+
+        """
+        from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references import Keyring
+        kwargs: Dict[str, Any] = {
+            "keyring": Keyring.from_dict(d["keyring"]),
+            "branch_key_id": d["branch_key_id"],
+        }
+
+        if "branch_key_version" in d:
+            kwargs["branch_key_version"] = d["branch_key_version"]
+
+        return GetCacheIdentifierInput(**kwargs)
+
+    def __repr__(self) -> str:
+        result = "GetCacheIdentifierInput("
+        if self.keyring is not None:
+            result += f"keyring={repr(self.keyring)}, "
+
+        if self.branch_key_id is not None:
+            result += f"branch_key_id={repr(self.branch_key_id)}, "
+
+        if self.branch_key_version is not None:
+            result += f"branch_key_version={repr(self.branch_key_version)}"
+
+        return result + ")"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, GetCacheIdentifierInput):
+            return False
+        attributes: list[str] = ['keyring','branch_key_id','branch_key_version',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
+
+class GetCacheIdentifierOutput:
+    identifier: bytes | bytearray
+    def __init__(
+        self,
+        *,
+        identifier: bytes | bytearray,
+    ):
+        """Outputs for computing a cache identifier.
+
+        :param identifier: The computed cache entry identifier.
+        """
+        self.identifier = identifier
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Converts the GetCacheIdentifierOutput to a dictionary.
+
+        """
+        return {
+            "identifier": self.identifier,
+        }
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "GetCacheIdentifierOutput":
+        """Creates a GetCacheIdentifierOutput from a dictionary.
+
+        """
+        kwargs: Dict[str, Any] = {
+            "identifier": d["identifier"],
+        }
+
+        return GetCacheIdentifierOutput(**kwargs)
+
+    def __repr__(self) -> str:
+        result = "GetCacheIdentifierOutput("
+        if self.identifier is not None:
+            result += f"identifier={repr(self.identifier)}"
+
+        return result + ")"
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, GetCacheIdentifierOutput):
+            return False
+        attributes: list[str] = ['identifier',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InitializeDecryptionMaterialsInput:
     algorithm_suite_id: AlgorithmSuiteId
     encryption_context: dict[str, str]
     required_encryption_context_keys: list[str]
-
     def __init__(
         self,
         *,
@@ -5228,7 +5002,9 @@ class InitializeDecryptionMaterialsInput:
         self.required_encryption_context_keys = required_encryption_context_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InitializeDecryptionMaterialsInput to a dictionary."""
+        """Converts the InitializeDecryptionMaterialsInput to a dictionary.
+
+        """
         return {
             "algorithm_suite_id": self.algorithm_suite_id.as_dict(),
             "encryption_context": self.encryption_context,
@@ -5237,11 +5013,11 @@ class InitializeDecryptionMaterialsInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InitializeDecryptionMaterialsInput":
-        """Creates a InitializeDecryptionMaterialsInput from a dictionary."""
+        """Creates a InitializeDecryptionMaterialsInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "algorithm_suite_id": _algorithm_suite_id_from_dict(
-                d["algorithm_suite_id"]
-            ),
+            "algorithm_suite_id": _algorithm_suite_id_from_dict(d["algorithm_suite_id"]),
             "encryption_context": d["encryption_context"],
             "required_encryption_context_keys": d["required_encryption_context_keys"],
         }
@@ -5264,13 +5040,11 @@ class InitializeDecryptionMaterialsInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InitializeDecryptionMaterialsInput):
             return False
-        attributes: list[str] = [
-            "algorithm_suite_id",
-            "encryption_context",
-            "required_encryption_context_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm_suite_id','encryption_context','required_encryption_context_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class InitializeEncryptionMaterialsInput:
     algorithm_suite_id: AlgorithmSuiteId
@@ -5278,7 +5052,6 @@ class InitializeEncryptionMaterialsInput:
     required_encryption_context_keys: list[str]
     signing_key: Optional[bytes | bytearray]
     verification_key: Optional[bytes | bytearray]
-
     def __init__(
         self,
         *,
@@ -5295,7 +5068,9 @@ class InitializeEncryptionMaterialsInput:
         self.verification_key = verification_key
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the InitializeEncryptionMaterialsInput to a dictionary."""
+        """Converts the InitializeEncryptionMaterialsInput to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "algorithm_suite_id": self.algorithm_suite_id.as_dict(),
             "encryption_context": self.encryption_context,
@@ -5312,11 +5087,11 @@ class InitializeEncryptionMaterialsInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "InitializeEncryptionMaterialsInput":
-        """Creates a InitializeEncryptionMaterialsInput from a dictionary."""
+        """Creates a InitializeEncryptionMaterialsInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "algorithm_suite_id": _algorithm_suite_id_from_dict(
-                d["algorithm_suite_id"]
-            ),
+            "algorithm_suite_id": _algorithm_suite_id_from_dict(d["algorithm_suite_id"]),
             "encryption_context": d["encryption_context"],
             "required_encryption_context_keys": d["required_encryption_context_keys"],
         }
@@ -5351,20 +5126,15 @@ class InitializeEncryptionMaterialsInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, InitializeEncryptionMaterialsInput):
             return False
-        attributes: list[str] = [
-            "algorithm_suite_id",
-            "encryption_context",
-            "required_encryption_context_keys",
-            "signing_key",
-            "verification_key",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm_suite_id','encryption_context','required_encryption_context_keys','signing_key','verification_key',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OnDecryptInput:
     materials: DecryptionMaterials
     encrypted_data_keys: list[EncryptedDataKey]
-
     def __init__(
         self,
         *,
@@ -5375,22 +5145,22 @@ class OnDecryptInput:
         self.encrypted_data_keys = encrypted_data_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the OnDecryptInput to a dictionary."""
+        """Converts the OnDecryptInput to a dictionary.
+
+        """
         return {
             "materials": self.materials.as_dict(),
-            "encrypted_data_keys": _encrypted_data_key_list_as_dict(
-                self.encrypted_data_keys
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_as_dict(self.encrypted_data_keys),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OnDecryptInput":
-        """Creates a OnDecryptInput from a dictionary."""
+        """Creates a OnDecryptInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "materials": DecryptionMaterials.from_dict(d["materials"]),
-            "encrypted_data_keys": _encrypted_data_key_list_from_dict(
-                d["encrypted_data_keys"]
-            ),
+            "encrypted_data_keys": _encrypted_data_key_list_from_dict(d["encrypted_data_keys"]),
         }
 
         return OnDecryptInput(**kwargs)
@@ -5408,16 +5178,14 @@ class OnDecryptInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OnDecryptInput):
             return False
-        attributes: list[str] = [
-            "materials",
-            "encrypted_data_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['materials','encrypted_data_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OnDecryptOutput:
     materials: DecryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5426,14 +5194,18 @@ class OnDecryptOutput:
         self.materials = materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the OnDecryptOutput to a dictionary."""
+        """Converts the OnDecryptOutput to a dictionary.
+
+        """
         return {
             "materials": self.materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OnDecryptOutput":
-        """Creates a OnDecryptOutput from a dictionary."""
+        """Creates a OnDecryptOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "materials": DecryptionMaterials.from_dict(d["materials"]),
         }
@@ -5450,15 +5222,14 @@ class OnDecryptOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OnDecryptOutput):
             return False
-        attributes: list[str] = [
-            "materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OnEncryptInput:
     materials: EncryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5467,14 +5238,18 @@ class OnEncryptInput:
         self.materials = materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the OnEncryptInput to a dictionary."""
+        """Converts the OnEncryptInput to a dictionary.
+
+        """
         return {
             "materials": self.materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OnEncryptInput":
-        """Creates a OnEncryptInput from a dictionary."""
+        """Creates a OnEncryptInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "materials": EncryptionMaterials.from_dict(d["materials"]),
         }
@@ -5491,15 +5266,14 @@ class OnEncryptInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OnEncryptInput):
             return False
-        attributes: list[str] = [
-            "materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OnEncryptOutput:
     materials: EncryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5508,14 +5282,18 @@ class OnEncryptOutput:
         self.materials = materials
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the OnEncryptOutput to a dictionary."""
+        """Converts the OnEncryptOutput to a dictionary.
+
+        """
         return {
             "materials": self.materials.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OnEncryptOutput":
-        """Creates a OnEncryptOutput from a dictionary."""
+        """Creates a OnEncryptOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "materials": EncryptionMaterials.from_dict(d["materials"]),
         }
@@ -5532,16 +5310,15 @@ class OnEncryptOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, OnEncryptOutput):
             return False
-        attributes: list[str] = [
-            "materials",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['materials',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class ValidateCommitmentPolicyOnDecryptInput:
     algorithm: AlgorithmSuiteId
     commitment_policy: CommitmentPolicy
-
     def __init__(
         self,
         *,
@@ -5552,8 +5329,9 @@ class ValidateCommitmentPolicyOnDecryptInput:
         self.commitment_policy = commitment_policy
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the ValidateCommitmentPolicyOnDecryptInput to a
-        dictionary."""
+        """Converts the ValidateCommitmentPolicyOnDecryptInput to a dictionary.
+
+        """
         return {
             "algorithm": self.algorithm.as_dict(),
             "commitment_policy": self.commitment_policy.as_dict(),
@@ -5561,8 +5339,9 @@ class ValidateCommitmentPolicyOnDecryptInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "ValidateCommitmentPolicyOnDecryptInput":
-        """Creates a ValidateCommitmentPolicyOnDecryptInput from a
-        dictionary."""
+        """Creates a ValidateCommitmentPolicyOnDecryptInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "algorithm": _algorithm_suite_id_from_dict(d["algorithm"]),
             "commitment_policy": _commitment_policy_from_dict(d["commitment_policy"]),
@@ -5583,17 +5362,15 @@ class ValidateCommitmentPolicyOnDecryptInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ValidateCommitmentPolicyOnDecryptInput):
             return False
-        attributes: list[str] = [
-            "algorithm",
-            "commitment_policy",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm','commitment_policy',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class ValidateCommitmentPolicyOnEncryptInput:
     algorithm: AlgorithmSuiteId
     commitment_policy: CommitmentPolicy
-
     def __init__(
         self,
         *,
@@ -5604,8 +5381,9 @@ class ValidateCommitmentPolicyOnEncryptInput:
         self.commitment_policy = commitment_policy
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the ValidateCommitmentPolicyOnEncryptInput to a
-        dictionary."""
+        """Converts the ValidateCommitmentPolicyOnEncryptInput to a dictionary.
+
+        """
         return {
             "algorithm": self.algorithm.as_dict(),
             "commitment_policy": self.commitment_policy.as_dict(),
@@ -5613,8 +5391,9 @@ class ValidateCommitmentPolicyOnEncryptInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "ValidateCommitmentPolicyOnEncryptInput":
-        """Creates a ValidateCommitmentPolicyOnEncryptInput from a
-        dictionary."""
+        """Creates a ValidateCommitmentPolicyOnEncryptInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "algorithm": _algorithm_suite_id_from_dict(d["algorithm"]),
             "commitment_policy": _commitment_policy_from_dict(d["commitment_policy"]),
@@ -5635,17 +5414,15 @@ class ValidateCommitmentPolicyOnEncryptInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ValidateCommitmentPolicyOnEncryptInput):
             return False
-        attributes: list[str] = [
-            "algorithm",
-            "commitment_policy",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['algorithm','commitment_policy',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class ValidDecryptionMaterialsTransitionInput:
     start: DecryptionMaterials
     stop: DecryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5656,8 +5433,9 @@ class ValidDecryptionMaterialsTransitionInput:
         self.stop = stop
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the ValidDecryptionMaterialsTransitionInput to a
-        dictionary."""
+        """Converts the ValidDecryptionMaterialsTransitionInput to a dictionary.
+
+        """
         return {
             "start": self.start.as_dict(),
             "stop": self.stop.as_dict(),
@@ -5665,8 +5443,9 @@ class ValidDecryptionMaterialsTransitionInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "ValidDecryptionMaterialsTransitionInput":
-        """Creates a ValidDecryptionMaterialsTransitionInput from a
-        dictionary."""
+        """Creates a ValidDecryptionMaterialsTransitionInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "start": DecryptionMaterials.from_dict(d["start"]),
             "stop": DecryptionMaterials.from_dict(d["stop"]),
@@ -5687,17 +5466,15 @@ class ValidDecryptionMaterialsTransitionInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ValidDecryptionMaterialsTransitionInput):
             return False
-        attributes: list[str] = [
-            "start",
-            "stop",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['start','stop',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class ValidEncryptionMaterialsTransitionInput:
     start: EncryptionMaterials
     stop: EncryptionMaterials
-
     def __init__(
         self,
         *,
@@ -5708,8 +5485,9 @@ class ValidEncryptionMaterialsTransitionInput:
         self.stop = stop
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the ValidEncryptionMaterialsTransitionInput to a
-        dictionary."""
+        """Converts the ValidEncryptionMaterialsTransitionInput to a dictionary.
+
+        """
         return {
             "start": self.start.as_dict(),
             "stop": self.stop.as_dict(),
@@ -5717,8 +5495,9 @@ class ValidEncryptionMaterialsTransitionInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "ValidEncryptionMaterialsTransitionInput":
-        """Creates a ValidEncryptionMaterialsTransitionInput from a
-        dictionary."""
+        """Creates a ValidEncryptionMaterialsTransitionInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "start": EncryptionMaterials.from_dict(d["start"]),
             "stop": EncryptionMaterials.from_dict(d["stop"]),
@@ -5739,16 +5518,15 @@ class ValidEncryptionMaterialsTransitionInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, ValidEncryptionMaterialsTransitionInput):
             return False
-        attributes: list[str] = [
-            "start",
-            "stop",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['start','stop',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class StaticConfigurationsAWS_KMS_ECDH:
-    """Allowed configurations when using KmsEcdhStaticConfigurations."""
-
+class StaticConfigurationsAWS_KMS_ECDH():
+    """Allowed configurations when using KmsEcdhStaticConfigurations.
+    """
     def __init__(self, value: KmsEcdhStaticConfigurations):
         self.value = value
 
@@ -5757,12 +5535,10 @@ class StaticConfigurationsAWS_KMS_ECDH:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "StaticConfigurationsAWS_KMS_ECDH":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return StaticConfigurationsAWS_KMS_ECDH(
-            _kms_ecdh_static_configurations_from_dict(d["AWS_KMS_ECDH"])
-        )
+        return StaticConfigurationsAWS_KMS_ECDH(_kms_ecdh_static_configurations_from_dict(d["AWS_KMS_ECDH"]))
 
     def __repr__(self) -> str:
         return f"StaticConfigurationsAWS_KMS_ECDH(value=repr(self.value))"
@@ -5772,10 +5548,9 @@ class StaticConfigurationsAWS_KMS_ECDH:
             return False
         return self.value == other.value
 
-
-class StaticConfigurationsRAW_ECDH:
-    """List of configurations when using RawEcdhStaticConfigurations."""
-
+class StaticConfigurationsRAW_ECDH():
+    """List of configurations when using RawEcdhStaticConfigurations.
+    """
     def __init__(self, value: RawEcdhStaticConfigurations):
         self.value = value
 
@@ -5784,12 +5559,10 @@ class StaticConfigurationsRAW_ECDH:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "StaticConfigurationsRAW_ECDH":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return StaticConfigurationsRAW_ECDH(
-            _raw_ecdh_static_configurations_from_dict(d["RAW_ECDH"])
-        )
+        return StaticConfigurationsRAW_ECDH(_raw_ecdh_static_configurations_from_dict(d["RAW_ECDH"]))
 
     def __repr__(self) -> str:
         return f"StaticConfigurationsRAW_ECDH(value=repr(self.value))"
@@ -5799,12 +5572,11 @@ class StaticConfigurationsRAW_ECDH:
             return False
         return self.value == other.value
 
-
-class StaticConfigurationsUnknown:
+class StaticConfigurationsUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -5817,22 +5589,15 @@ class StaticConfigurationsUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "StaticConfigurationsUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return StaticConfigurationsUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"StaticConfigurationsUnknown(tag={self.tag})"
 
-
 # Supported configurations for the StaticConfiguration Key Agreement Scheme.
-StaticConfigurations = Union[
-    StaticConfigurationsAWS_KMS_ECDH,
-    StaticConfigurationsRAW_ECDH,
-    StaticConfigurationsUnknown,
-]
-
-
+StaticConfigurations = Union[StaticConfigurationsAWS_KMS_ECDH, StaticConfigurationsRAW_ECDH, StaticConfigurationsUnknown]
 def _static_configurations_from_dict(d: Dict[str, Any]) -> StaticConfigurations:
     if "AWS_KMS_ECDH" in d:
         return StaticConfigurationsAWS_KMS_ECDH.from_dict(d)
@@ -5840,13 +5605,11 @@ def _static_configurations_from_dict(d: Dict[str, Any]) -> StaticConfigurations:
     if "RAW_ECDH" in d:
         return StaticConfigurationsRAW_ECDH.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
-
-class KeyAgreementSchemeStaticConfiguration:
-    """Supported configurations for the StaticConfiguration Key Agreement
-    Scheme."""
-
+class KeyAgreementSchemeStaticConfiguration():
+    """Supported configurations for the StaticConfiguration Key Agreement Scheme.
+    """
     def __init__(self, value: StaticConfigurations):
         self.value = value
 
@@ -5855,12 +5618,10 @@ class KeyAgreementSchemeStaticConfiguration:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyAgreementSchemeStaticConfiguration":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return KeyAgreementSchemeStaticConfiguration(
-            _static_configurations_from_dict(d["StaticConfiguration"])
-        )
+        return KeyAgreementSchemeStaticConfiguration(_static_configurations_from_dict(d["StaticConfiguration"]))
 
     def __repr__(self) -> str:
         return f"KeyAgreementSchemeStaticConfiguration(value=repr(self.value))"
@@ -5870,12 +5631,11 @@ class KeyAgreementSchemeStaticConfiguration:
             return False
         return self.value == other.value
 
-
-class KeyAgreementSchemeUnknown:
+class KeyAgreementSchemeUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -5888,34 +5648,26 @@ class KeyAgreementSchemeUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyAgreementSchemeUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return KeyAgreementSchemeUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"KeyAgreementSchemeUnknown(tag={self.tag})"
 
-
 # Supported ECDH Key Agreement Schemes.
-KeyAgreementScheme = Union[
-    KeyAgreementSchemeStaticConfiguration, KeyAgreementSchemeUnknown
-]
-
-
+KeyAgreementScheme = Union[KeyAgreementSchemeStaticConfiguration, KeyAgreementSchemeUnknown]
 def _key_agreement_scheme_from_dict(d: Dict[str, Any]) -> KeyAgreementScheme:
     if "StaticConfiguration" in d:
         return KeyAgreementSchemeStaticConfiguration.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 def _encrypted_data_key_list_as_dict(given: list[EncryptedDataKey]) -> List[Any]:
     return [v.as_dict() for v in given]
 
-
 def _encrypted_data_key_list_from_dict(given: List[Any]) -> list[EncryptedDataKey]:
     return [EncryptedDataKey.from_dict(v) for v in given]
-
 
 class Unit:
     pass

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/plugin.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/plugin.py
@@ -2,47 +2,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 
-from .config import (
-    Config,
-    Plugin,
-    smithy_config_to_dafny_config,
-    MaterialProvidersConfig,
-)
+from .config import Config, Plugin, smithy_config_to_dafny_config, MaterialProvidersConfig
 from smithy_python.interfaces.retries import RetryStrategy
 from smithy_python.exceptions import SmithyRetryException
 from .dafnyImplInterface import DafnyImplInterface
 
-
 def set_config_impl(config: Config):
-    """Set the Dafny-compiled implementation in the Smithy-Python client Config
-    and load our custom NoRetriesStrategy."""
+    """
+    Set the Dafny-compiled implementation in the Smithy-Python client Config
+    and load our custom NoRetriesStrategy.
+    """
     config.dafnyImplInterface = DafnyImplInterface()
     if isinstance(config, MaterialProvidersConfig):
-        from aws_cryptographic_material_providers.internaldafny.generated.MaterialProviders import (
-            default__,
-        )
-
-        config.dafnyImplInterface.impl = default__.MaterialProviders(
-            smithy_config_to_dafny_config(config)
-        ).value
+        from aws_cryptographic_material_providers.internaldafny.generated.MaterialProviders import default__
+        config.dafnyImplInterface.impl = default__.MaterialProviders(smithy_config_to_dafny_config(config)).value
     config.retry_strategy = NoRetriesStrategy()
 
-
 class ZeroRetryDelayToken:
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not wait to retry.
     """
-
     retry_delay = 0
 
-
 class NoRetriesStrategy(RetryStrategy):
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not retry calling Dafny code.
     """
-
     def acquire_initial_retry_token(self):
         return ZeroRetryDelayToken()
 

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/references.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/references.py
@@ -34,36 +34,31 @@ from smithy_dafny_standard_library.internaldafny.generated import Wrappers
 from typing import Any, Dict
 
 
+
 class IBranchKeyIdSupplier(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return hasattr(subclass, "GetBranchKeyId") and callable(subclass.GetBranchKeyId)
+        return (
+            hasattr(subclass, "GetBranchKeyId") and callable(subclass.GetBranchKeyId)
+        )
 
     @abc.abstractmethod
-    def get_branch_key_id(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdOutput":
-        """Given the Encryption Context associated with this encryption or
-        decryption, returns the branch key that should be responsible for
-        unwrapping or wrapping the data key.
-
-        :param param: Inputs for determining the Branch Key which should
-            be used to wrap or unwrap the data key for this encryption
-            or decryption
-        :returns: Outputs for the Branch Key responsible for wrapping or
-            unwrapping the data key in this encryption or decryption.
+    def get_branch_key_id(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdOutput':
+        """Given the Encryption Context associated with this encryption or decryption,
+        returns the branch key that should be responsible for unwrapping or wrapping the
+        data key.
+        :param param: Inputs for determining the Branch Key which should be used to wrap
+        or unwrap the data key for this encryption or decryption
+        :returns: Outputs for the Branch Key responsible for wrapping or unwrapping the
+        data key in this encryption or decryption.
         """
         raise NotImplementedError
 
-    def GetBranchKeyId(
-        self, dafny_input: "DafnyGetBranchKeyIdInput"
-    ) -> "DafnyGetBranchKeyIdOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def GetBranchKeyId(self, dafny_input: 'DafnyGetBranchKeyIdInput') -> 'DafnyGetBranchKeyIdOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetBranchKeyIdInput(
             dafny_input
@@ -78,82 +73,56 @@ class IBranchKeyIdSupplier(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-
 class BranchKeyIdSupplier(IBranchKeyIdSupplier):
 
-    _impl: (
-        aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IBranchKeyIdSupplier
-    )
+    _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IBranchKeyIdSupplier
 
-    def __init__(
-        self,
-        _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IBranchKeyIdSupplier,
-    ):
+    def __init__(self, _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IBranchKeyIdSupplier):
         self._impl = _impl
 
-    def get_branch_key_id(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdOutput":
-        """Given the Encryption Context associated with this encryption or
-        decryption, returns the branch key that should be responsible for
-        unwrapping or wrapping the data key.
-
-        :param param: Inputs for determining the Branch Key which should
-            be used to wrap or unwrap the data key for this encryption
-            or decryption
-        :returns: Outputs for the Branch Key responsible for wrapping or
-            unwrapping the data key in this encryption or decryption.
+    def get_branch_key_id(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetBranchKeyIdOutput':
+        """Given the Encryption Context associated with this encryption or decryption,
+        returns the branch key that should be responsible for unwrapping or wrapping the
+        data key.
+        :param param: Inputs for determining the Branch Key which should be used to wrap
+        or unwrap the data key for this encryption or decryption
+        :returns: Outputs for the Branch Key responsible for wrapping or unwrapping the
+        data key in this encryption or decryption.
         """
-        dafny_output = self._impl.GetBranchKeyId(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetBranchKeyIdInput(
-                param
-            )
-        )
+        dafny_output = self._impl.GetBranchKeyId(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetBranchKeyIdInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetBranchKeyIdOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetBranchKeyIdOutput(dafny_output.value)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "BranchKeyIdSupplier":
-        return BranchKeyIdSupplier(d["_impl"])
+    def from_dict(d: Dict[str, Any]) -> 'BranchKeyIdSupplier':
+        return BranchKeyIdSupplier(d['_impl'])
 
     def as_dict(self) -> Dict[str, Any]:
-        return {"_impl": self._impl}
-
+        return {'_impl': self._impl}
 
 class IClientSupplier(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return hasattr(subclass, "GetClient") and callable(subclass.GetClient)
+        return (
+            hasattr(subclass, "GetClient") and callable(subclass.GetClient)
+        )
 
     @abc.abstractmethod
-    def get_client(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetClientInput",
-    ) -> "botocore.client.BaseClient":
+    def get_client(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetClientInput') -> 'botocore.client.BaseClient':
         """Returns an AWS KMS Client.
-
         :param param: Inputs for getting a AWS KMS Client.
         """
         raise NotImplementedError
 
-    def GetClient(self, dafny_input: "DafnyGetClientInput") -> "DafnyGetClientOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def GetClient(self, dafny_input: 'DafnyGetClientInput') -> 'DafnyGetClientOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetClientInput(
             dafny_input
@@ -168,102 +137,63 @@ class IClientSupplier(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-
 class ClientSupplier(IClientSupplier):
 
-    _impl: (
-        aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IClientSupplier
-    )
+    _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IClientSupplier
 
-    def __init__(
-        self,
-        _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IClientSupplier,
-    ):
+    def __init__(self, _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IClientSupplier):
         self._impl = _impl
 
-    def get_client(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetClientInput",
-    ) -> "botocore.client.BaseClient":
+    def get_client(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetClientInput') -> 'botocore.client.BaseClient':
         """Returns an AWS KMS Client.
-
         :param param: Inputs for getting a AWS KMS Client.
         """
-        dafny_output = self._impl.GetClient(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetClientInput(
-                param
-            )
-        )
+        dafny_output = self._impl.GetClient(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetClientInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetClientOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetClientOutput(dafny_output.value)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "ClientSupplier":
-        return ClientSupplier(d["_impl"])
+    def from_dict(d: Dict[str, Any]) -> 'ClientSupplier':
+        return ClientSupplier(d['_impl'])
 
     def as_dict(self) -> Dict[str, Any]:
-        return {"_impl": self._impl}
-
+        return {'_impl': self._impl}
 
 class ICryptographicMaterialsCache(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
         return (
-            hasattr(subclass, "PutCacheEntry")
-            and callable(subclass.PutCacheEntry)
-            and hasattr(subclass, "GetCacheEntry")
-            and callable(subclass.GetCacheEntry)
-            and hasattr(subclass, "UpdateUsageMetadata")
-            and callable(subclass.UpdateUsageMetadata)
-            and hasattr(subclass, "DeleteCacheEntry")
-            and callable(subclass.DeleteCacheEntry)
+            hasattr(subclass, "PutCacheEntry") and callable(subclass.PutCacheEntry) and
+            hasattr(subclass, "GetCacheEntry") and callable(subclass.GetCacheEntry) and
+            hasattr(subclass, "UpdateUsageMetadata") and callable(subclass.UpdateUsageMetadata) and
+            hasattr(subclass, "DeleteCacheEntry") and callable(subclass.DeleteCacheEntry)
         )
 
     @abc.abstractmethod
-    def put_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PutCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
+    def put_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PutCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryOutput":
+    def get_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryOutput':
         raise NotImplementedError
 
     @abc.abstractmethod
-    def update_usage_metadata(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.UpdateUsageMetadataInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
+    def update_usage_metadata(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.UpdateUsageMetadataInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
         raise NotImplementedError
 
     @abc.abstractmethod
-    def delete_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DeleteCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
+    def delete_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DeleteCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
         raise NotImplementedError
 
-    def PutCacheEntry(self, dafny_input: "DafnyPutCacheEntryInput") -> "None":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def PutCacheEntry(self, dafny_input: 'DafnyPutCacheEntryInput') -> 'None':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PutCacheEntryInput(
             dafny_input
@@ -278,13 +208,10 @@ class ICryptographicMaterialsCache(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-    def GetCacheEntry(
-        self, dafny_input: "DafnyGetCacheEntryInput"
-    ) -> "DafnyGetCacheEntryOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def GetCacheEntry(self, dafny_input: 'DafnyGetCacheEntryInput') -> 'DafnyGetCacheEntryOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetCacheEntryInput(
             dafny_input
@@ -299,13 +226,10 @@ class ICryptographicMaterialsCache(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-    def UpdateUsageMetadata(
-        self, dafny_input: "DafnyUpdateUsageMetadataInput"
-    ) -> "None":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def UpdateUsageMetadata(self, dafny_input: 'DafnyUpdateUsageMetadataInput') -> 'None':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_UpdateUsageMetadataInput(
             dafny_input
@@ -320,11 +244,10 @@ class ICryptographicMaterialsCache(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-    def DeleteCacheEntry(self, dafny_input: "DafnyDeleteCacheEntryInput") -> "None":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def DeleteCacheEntry(self, dafny_input: 'DafnyDeleteCacheEntryInput') -> 'None':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DeleteCacheEntryInput(
             dafny_input
@@ -339,145 +262,77 @@ class ICryptographicMaterialsCache(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-
 class CryptographicMaterialsCache(ICryptographicMaterialsCache):
 
-    _impl: (
-        aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsCache
-    )
+    _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsCache
 
-    def __init__(
-        self,
-        _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsCache,
-    ):
+    def __init__(self, _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsCache):
         self._impl = _impl
 
-    def put_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PutCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
-        dafny_output = self._impl.PutCacheEntry(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PutCacheEntryInput(
-                param
-            )
-        )
+    def put_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.PutCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
+        dafny_output = self._impl.PutCacheEntry(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PutCacheEntryInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as smithy_api_deserialize_error,
-            )
-
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as smithy_api_deserialize_error
             raise smithy_api_deserialize_error(dafny_output.error)
 
         else:
-            return (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
 
-    def get_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryOutput":
-        dafny_output = self._impl.GetCacheEntry(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetCacheEntryInput(
-                param
-            )
-        )
+    def get_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheEntryOutput':
+        dafny_output = self._impl.GetCacheEntry(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetCacheEntryInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetCacheEntryOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetCacheEntryOutput(dafny_output.value)
 
-    def update_usage_metadata(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.UpdateUsageMetadataInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
-        dafny_output = self._impl.UpdateUsageMetadata(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_UpdateUsageMetadataInput(
-                param
-            )
-        )
+    def update_usage_metadata(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.UpdateUsageMetadataInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
+        dafny_output = self._impl.UpdateUsageMetadata(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_UpdateUsageMetadataInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as smithy_api_deserialize_error,
-            )
-
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as smithy_api_deserialize_error
             raise smithy_api_deserialize_error(dafny_output.error)
 
         else:
-            return (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
 
-    def delete_cache_entry(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DeleteCacheEntryInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit":
-        dafny_output = self._impl.DeleteCacheEntry(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DeleteCacheEntryInput(
-                param
-            )
-        )
+    def delete_cache_entry(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DeleteCacheEntryInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.Unit':
+        dafny_output = self._impl.DeleteCacheEntry(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DeleteCacheEntryInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as smithy_api_deserialize_error,
-            )
-
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as smithy_api_deserialize_error
             raise smithy_api_deserialize_error(dafny_output.error)
 
         else:
-            return (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.smithy_api_Unit()
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "CryptographicMaterialsCache":
-        return CryptographicMaterialsCache(d["_impl"])
+    def from_dict(d: Dict[str, Any]) -> 'CryptographicMaterialsCache':
+        return CryptographicMaterialsCache(d['_impl'])
 
     def as_dict(self) -> Dict[str, Any]:
-        return {"_impl": self._impl}
-
+        return {'_impl': self._impl}
 
 class ICryptographicMaterialsManager(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
         return (
-            hasattr(subclass, "GetEncryptionMaterials")
-            and callable(subclass.GetEncryptionMaterials)
-            and hasattr(subclass, "DecryptMaterials")
-            and callable(subclass.DecryptMaterials)
+            hasattr(subclass, "GetEncryptionMaterials") and callable(subclass.GetEncryptionMaterials) and
+            hasattr(subclass, "DecryptMaterials") and callable(subclass.DecryptMaterials)
         )
 
     @abc.abstractmethod
-    def get_encryption_materials(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsOutput":
+    def get_encryption_materials(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsOutput':
         raise NotImplementedError
 
     @abc.abstractmethod
-    def decrypt_materials(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsOutput":
+    def decrypt_materials(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsOutput':
         raise NotImplementedError
 
-    def GetEncryptionMaterials(
-        self, dafny_input: "DafnyGetEncryptionMaterialsInput"
-    ) -> "DafnyGetEncryptionMaterialsOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def GetEncryptionMaterials(self, dafny_input: 'DafnyGetEncryptionMaterialsInput') -> 'DafnyGetEncryptionMaterialsOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetEncryptionMaterialsInput(
             dafny_input
@@ -492,13 +347,10 @@ class ICryptographicMaterialsManager(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-    def DecryptMaterials(
-        self, dafny_input: "DafnyDecryptMaterialsInput"
-    ) -> "DafnyDecryptMaterialsOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def DecryptMaterials(self, dafny_input: 'DafnyDecryptMaterialsInput') -> 'DafnyDecryptMaterialsOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptMaterialsInput(
             dafny_input
@@ -513,103 +365,59 @@ class ICryptographicMaterialsManager(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-
 class CryptographicMaterialsManager(ICryptographicMaterialsManager):
 
-    _impl: (
-        aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsManager
-    )
+    _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsManager
 
-    def __init__(
-        self,
-        _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsManager,
-    ):
+    def __init__(self, _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.ICryptographicMaterialsManager):
         self._impl = _impl
 
-    def get_encryption_materials(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsOutput":
-        dafny_output = self._impl.GetEncryptionMaterials(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetEncryptionMaterialsInput(
-                param
-            )
-        )
+    def get_encryption_materials(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetEncryptionMaterialsOutput':
+        dafny_output = self._impl.GetEncryptionMaterials(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetEncryptionMaterialsInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetEncryptionMaterialsOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetEncryptionMaterialsOutput(dafny_output.value)
 
-    def decrypt_materials(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsOutput":
-        dafny_output = self._impl.DecryptMaterials(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptMaterialsInput(
-                param
-            )
-        )
+    def decrypt_materials(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptMaterialsOutput':
+        dafny_output = self._impl.DecryptMaterials(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptMaterialsInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptMaterialsOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptMaterialsOutput(dafny_output.value)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "CryptographicMaterialsManager":
-        return CryptographicMaterialsManager(d["_impl"])
+    def from_dict(d: Dict[str, Any]) -> 'CryptographicMaterialsManager':
+        return CryptographicMaterialsManager(d['_impl'])
 
     def as_dict(self) -> Dict[str, Any]:
-        return {"_impl": self._impl}
-
+        return {'_impl': self._impl}
 
 class IKeyring(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
         return (
-            hasattr(subclass, "OnEncrypt")
-            and callable(subclass.OnEncrypt)
-            and hasattr(subclass, "OnDecrypt")
-            and callable(subclass.OnDecrypt)
+            hasattr(subclass, "OnEncrypt") and callable(subclass.OnEncrypt) and
+            hasattr(subclass, "OnDecrypt") and callable(subclass.OnDecrypt)
         )
 
     @abc.abstractmethod
-    def on_encrypt(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptOutput":
+    def on_encrypt(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptOutput':
         raise NotImplementedError
 
     @abc.abstractmethod
-    def on_decrypt(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptOutput":
+    def on_decrypt(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptOutput':
         raise NotImplementedError
 
-    def OnEncrypt(self, dafny_input: "DafnyOnEncryptInput") -> "DafnyOnEncryptOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def OnEncrypt(self, dafny_input: 'DafnyOnEncryptInput') -> 'DafnyOnEncryptOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnEncryptInput(
             dafny_input
@@ -624,11 +432,10 @@ class IKeyring(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-    def OnDecrypt(self, dafny_input: "DafnyOnDecryptInput") -> "DafnyOnDecryptOutput":
-        """Do not use.
-
-        This method allows custom implementations of this interface to
-        interact with generated code.
+    def OnDecrypt(self, dafny_input: 'DafnyOnDecryptInput') -> 'DafnyOnDecryptOutput':
+        """
+        Do not use.
+        This method allows custom implementations of this interface to interact with generated code.
         """
         native_input = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnDecryptInput(
             dafny_input
@@ -643,68 +450,34 @@ class IKeyring(metaclass=abc.ABCMeta):
             error = _smithy_error_to_dafny_error(e)
             return Wrappers.Result_Failure(error)
 
-
 class Keyring(IKeyring):
 
-    _impl: (
-        aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IKeyring
-    )
+    _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IKeyring
 
-    def __init__(
-        self,
-        _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IKeyring,
-    ):
+    def __init__(self, _impl: aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IKeyring):
         self._impl = _impl
 
-    def on_encrypt(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptOutput":
-        dafny_output = self._impl.OnEncrypt(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_OnEncryptInput(
-                param
-            )
-        )
+    def on_encrypt(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnEncryptOutput':
+        dafny_output = self._impl.OnEncrypt(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_OnEncryptInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnEncryptOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnEncryptOutput(dafny_output.value)
 
-    def on_decrypt(
-        self,
-        param: "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptInput",
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptOutput":
-        dafny_output = self._impl.OnDecrypt(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_OnDecryptInput(
-                param
-            )
-        )
+    def on_decrypt(self, param: 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptInput') -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.OnDecryptOutput':
+        dafny_output = self._impl.OnDecrypt(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_OnDecryptInput(param))
         if dafny_output.IsFailure():
-            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import (
-                _deserialize_error as aws_cryptography_materialproviders_deserialize_error,
-            )
-
-            raise aws_cryptography_materialproviders_deserialize_error(
-                dafny_output.error
-            )
+            from aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.deserialize import _deserialize_error as aws_cryptography_materialproviders_deserialize_error
+            raise aws_cryptography_materialproviders_deserialize_error(dafny_output.error)
 
         else:
-            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnDecryptOutput(
-                dafny_output.value
-            )
+            return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_OnDecryptOutput(dafny_output.value)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Keyring":
-        return Keyring(d["_impl"])
+    def from_dict(d: Dict[str, Any]) -> 'Keyring':
+        return Keyring(d['_impl'])
 
     def as_dict(self) -> Dict[str, Any]:
-        return {"_impl": self._impl}
+        return {'_impl': self._impl}

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/serialize.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/serialize.py
@@ -10,287 +10,91 @@ from .config import Config
 
 
 def _serialize_create_aws_kms_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateAwsKmsKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(input))
 
 def _serialize_create_aws_kms_discovery_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsDiscoveryKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateAwsKmsDiscoveryKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(input))
 
 def _serialize_create_aws_kms_multi_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsMultiKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="CreateAwsKmsMultiKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(input))
 
-
-def _serialize_create_aws_kms_discovery_multi_keyring(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsDiscoveryMultiKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(
-            input
-        ),
-    )
-
+def _serialize_create_aws_kms_discovery_multi_keyring(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateAwsKmsDiscoveryMultiKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(input))
 
 def _serialize_create_aws_kms_mrk_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsMrkKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateAwsKmsMrkKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(input))
 
 def _serialize_create_aws_kms_mrk_multi_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsMrkMultiKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="CreateAwsKmsMrkMultiKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(input))
 
+def _serialize_create_aws_kms_mrk_discovery_keyring(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateAwsKmsMrkDiscoveryKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(input))
 
-def _serialize_create_aws_kms_mrk_discovery_keyring(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsMrkDiscoveryKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(
-            input
-        ),
-    )
+def _serialize_create_aws_kms_mrk_discovery_multi_keyring(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateAwsKmsMrkDiscoveryMultiKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(input))
 
-
-def _serialize_create_aws_kms_mrk_discovery_multi_keyring(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsMrkDiscoveryMultiKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-            input
-        ),
-    )
-
-
-def _serialize_create_aws_kms_hierarchical_keyring(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsHierarchicalKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(
-            input
-        ),
-    )
-
+def _serialize_create_aws_kms_hierarchical_keyring(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateAwsKmsHierarchicalKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(input))
 
 def _serialize_create_aws_kms_rsa_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsRsaKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateAwsKmsRsaKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(input))
 
 def _serialize_create_aws_kms_ecdh_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateAwsKmsEcdhKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateAwsKmsEcdhKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(input))
 
 def _serialize_create_multi_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateMultiKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateMultiKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateMultiKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateMultiKeyringInput(input))
 
 def _serialize_create_raw_aes_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateRawAesKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawAesKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateRawAesKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawAesKeyringInput(input))
 
 def _serialize_create_raw_rsa_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateRawRsaKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawRsaKeyringInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateRawRsaKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawRsaKeyringInput(input))
 
 def _serialize_create_raw_ecdh_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateRawEcdhKeyring",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="CreateRawEcdhKeyring", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(input))
 
+def _serialize_create_default_cryptographic_materials_manager(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateDefaultCryptographicMaterialsManager", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(input))
 
-def _serialize_create_default_cryptographic_materials_manager(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateDefaultCryptographicMaterialsManager",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(
-            input
-        ),
-    )
+def _serialize_create_required_encryption_context_cmm(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateRequiredEncryptionContextCMM", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(input))
 
-
-def _serialize_create_required_encryption_context_cmm(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateRequiredEncryptionContextCMM",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(
-            input
-        ),
-    )
-
-
-def _serialize_create_cryptographic_materials_cache(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateCryptographicMaterialsCache",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(
-            input
-        ),
-    )
-
+def _serialize_create_cryptographic_materials_cache(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateCryptographicMaterialsCache", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(input))
 
 def _serialize_create_default_client_supplier(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateDefaultClientSupplier",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateDefaultClientSupplier", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(input))
 
 def _serialize_initialize_encryption_materials(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="InitializeEncryptionMaterials",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="InitializeEncryptionMaterials", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(input))
 
 def _serialize_initialize_decryption_materials(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="InitializeDecryptionMaterials",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="InitializeDecryptionMaterials", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(input))
 
+def _serialize_valid_encryption_materials_transition(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="ValidEncryptionMaterialsTransition", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(input))
 
-def _serialize_valid_encryption_materials_transition(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="ValidEncryptionMaterialsTransition",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(
-            input
-        ),
-    )
+def _serialize_valid_decryption_materials_transition(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="ValidDecryptionMaterialsTransition", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(input))
 
+def _serialize_encryption_materials_has_plaintext_data_key(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="EncryptionMaterialsHasPlaintextDataKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(input))
 
-def _serialize_valid_decryption_materials_transition(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="ValidDecryptionMaterialsTransition",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(
-            input
-        ),
-    )
-
-
-def _serialize_encryption_materials_has_plaintext_data_key(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="EncryptionMaterialsHasPlaintextDataKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            input
-        ),
-    )
-
-
-def _serialize_decryption_materials_with_plaintext_data_key(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="DecryptionMaterialsWithPlaintextDataKey",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            input
-        ),
-    )
-
+def _serialize_decryption_materials_with_plaintext_data_key(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="DecryptionMaterialsWithPlaintextDataKey", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(input))
 
 def _serialize_get_algorithm_suite_info(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="GetAlgorithmSuiteInfo",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="GetAlgorithmSuiteInfo", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(input))
 
 def _serialize_valid_algorithm_suite_info(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="ValidAlgorithmSuiteInfo",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="ValidAlgorithmSuiteInfo", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(input))
 
+def _serialize_validate_commitment_policy_on_encrypt(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="ValidateCommitmentPolicyOnEncrypt", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(input))
 
-def _serialize_validate_commitment_policy_on_encrypt(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="ValidateCommitmentPolicyOnEncrypt",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(
-            input
-        ),
-    )
+def _serialize_validate_commitment_policy_on_decrypt(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="ValidateCommitmentPolicyOnDecrypt", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(input))
 
-
-def _serialize_validate_commitment_policy_on_decrypt(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="ValidateCommitmentPolicyOnDecrypt",
-        dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(
-            input
-        ),
-    )
+def _serialize_get_cache_identifier(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="GetCacheIdentifier", dafny_operation_input=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetCacheIdentifierInput(input))

--- a/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/smithy_to_dafny.py
+++ b/AwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptographic_material_providers/smithygenerated/aws_cryptography_materialproviders/smithy_to_dafny.py
@@ -75,6 +75,8 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     GetBranchKeyIdOutput_GetBranchKeyIdOutput as DafnyGetBranchKeyIdOutput,
     GetCacheEntryInput_GetCacheEntryInput as DafnyGetCacheEntryInput,
     GetCacheEntryOutput_GetCacheEntryOutput as DafnyGetCacheEntryOutput,
+    GetCacheIdentifierInput_GetCacheIdentifierInput as DafnyGetCacheIdentifierInput,
+    GetCacheIdentifierOutput_GetCacheIdentifierOutput as DafnyGetCacheIdentifierOutput,
     GetClientInput_GetClientInput as DafnyGetClientInput,
     GetEncryptionMaterialsInput_GetEncryptionMaterialsInput as DafnyGetEncryptionMaterialsInput,
     GetEncryptionMaterialsOutput_GetEncryptionMaterialsOutput as DafnyGetEncryptionMaterialsOutput,
@@ -149,544 +151,249 @@ from smithy_dafny_standard_library.internaldafny.generated.Wrappers import (
 
 def aws_cryptography_materialproviders_GetBranchKeyIdInput(native_input):
     return DafnyGetBranchKeyIdInput(
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
     )
-
 
 def aws_cryptography_materialproviders_GetBranchKeyIdOutput(native_input):
     return DafnyGetBranchKeyIdOutput(
-        branchKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.branch_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        branchKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviders_GetClientInput(native_input):
     return DafnyGetClientInput(
-        region=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.region.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        region=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.region.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviders_GetClientOutput(native_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-        native_input
-    )
-
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input)
 
 def aws_cryptography_materialproviders_KmsClientReference(native_input):
     import aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms
-
-    client = aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.KMSClient(
-        boto_client=native_input
-    )
+    client = aws_cryptography_internal_kms.internaldafny.generated.Com_Amazonaws_Kms.default__.KMSClient(boto_client = native_input)
     client.value.impl = native_input
     return client.value
-
 
 def aws_cryptography_materialproviders_PutCacheEntryInput(native_input):
     return DafnyPutCacheEntryInput(
         identifier=Seq(native_input.identifier),
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Materials(
-            native_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Materials(native_input.materials),
         creationTime=native_input.creation_time,
         expiryTime=native_input.expiry_time,
-        messagesUsed=(
-            (Option_Some(native_input.messages_used))
-            if (native_input.messages_used is not None)
-            else (Option_None())
-        ),
-        bytesUsed=(
-            (Option_Some(native_input.bytes_used))
-            if (native_input.bytes_used is not None)
-            else (Option_None())
-        ),
+        messagesUsed=((Option_Some(native_input.messages_used)) if (native_input.messages_used is not None) else (Option_None())),
+        bytesUsed=((Option_Some(native_input.bytes_used)) if (native_input.bytes_used is not None) else (Option_None())),
     )
 
-
 def aws_cryptography_materialproviders_Materials(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsEncryption,
-    ):
-        Materials_union_value = Materials_Encryption(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsDecryption,
-    ):
-        Materials_union_value = Materials_Decryption(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBranchKey,
-    ):
-        Materials_union_value = Materials_BranchKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBeaconKey,
-    ):
-        Materials_union_value = Materials_BeaconKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BeaconKeyMaterials(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsEncryption):
+        Materials_union_value = Materials_Encryption(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsDecryption):
+        Materials_union_value = Materials_Decryption(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBranchKey):
+        Materials_union_value = Materials_BranchKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BranchKeyMaterials(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.MaterialsBeaconKey):
+        Materials_union_value = Materials_BeaconKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_keystore.smithy_to_dafny.aws_cryptography_keystore_BeaconKeyMaterials(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return Materials_union_value
 
-
 def aws_cryptography_materialproviders_EncryptionMaterials(native_input):
     return DafnyEncryptionMaterials(
-        algorithmSuite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-            native_input.algorithm_suite
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        encryptedDataKeys=Seq(
-            [
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(
-                    list_element
-                )
-                for list_element in native_input.encrypted_data_keys
-            ]
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
-        plaintextDataKey=(
-            (Option_Some(Seq(native_input.plaintext_data_key)))
-            if (native_input.plaintext_data_key is not None)
-            else (Option_None())
-        ),
-        signingKey=(
-            (Option_Some(Seq(native_input.signing_key)))
-            if (native_input.signing_key is not None)
-            else (Option_None())
-        ),
-        symmetricSigningKeys=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(list_element)
-                            for list_element in native_input.symmetric_signing_keys
-                        ]
-                    )
-                )
-            )
-            if (native_input.symmetric_signing_keys is not None)
-            else (Option_None())
-        ),
+        algorithmSuite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(native_input.algorithm_suite),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        encryptedDataKeys=Seq([aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in native_input.encrypted_data_keys]),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
+        plaintextDataKey=((Option_Some(Seq(native_input.plaintext_data_key))) if (native_input.plaintext_data_key is not None) else (Option_None())),
+        signingKey=((Option_Some(Seq(native_input.signing_key))) if (native_input.signing_key is not None) else (Option_None())),
+        symmetricSigningKeys=((Option_Some(Seq([Seq(list_element) for list_element in native_input.symmetric_signing_keys]))) if (native_input.symmetric_signing_keys is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_DecryptionMaterials(native_input):
     return DafnyDecryptionMaterials(
-        algorithmSuite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-            native_input.algorithm_suite
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
-        plaintextDataKey=(
-            (Option_Some(Seq(native_input.plaintext_data_key)))
-            if (native_input.plaintext_data_key is not None)
-            else (Option_None())
-        ),
-        verificationKey=(
-            (Option_Some(Seq(native_input.verification_key)))
-            if (native_input.verification_key is not None)
-            else (Option_None())
-        ),
-        symmetricSigningKey=(
-            (Option_Some(Seq(native_input.symmetric_signing_key)))
-            if (native_input.symmetric_signing_key is not None)
-            else (Option_None())
-        ),
+        algorithmSuite=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(native_input.algorithm_suite),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
+        plaintextDataKey=((Option_Some(Seq(native_input.plaintext_data_key))) if (native_input.plaintext_data_key is not None) else (Option_None())),
+        verificationKey=((Option_Some(Seq(native_input.verification_key))) if (native_input.verification_key is not None) else (Option_None())),
+        symmetricSigningKey=((Option_Some(Seq(native_input.symmetric_signing_key))) if (native_input.symmetric_signing_key is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_AlgorithmSuiteInfo(native_input):
     return DafnyAlgorithmSuiteInfo(
-        id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.id
-        ),
+        id=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.id),
         binaryId=Seq(native_input.binary_id),
         messageVersion=native_input.message_version,
-        encrypt=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Encrypt(
-            native_input.encrypt
-        ),
-        kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(
-            native_input.kdf
-        ),
-        commitment=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(
-            native_input.commitment
-        ),
-        signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SignatureAlgorithm(
-            native_input.signature
-        ),
-        symmetricSignature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(
-            native_input.symmetric_signature
-        ),
-        edkWrapping=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EdkWrappingAlgorithm(
-            native_input.edk_wrapping
-        ),
+        encrypt=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Encrypt(native_input.encrypt),
+        kdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(native_input.kdf),
+        commitment=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(native_input.commitment),
+        signature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SignatureAlgorithm(native_input.signature),
+        symmetricSignature=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(native_input.symmetric_signature),
+        edkWrapping=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EdkWrappingAlgorithm(native_input.edk_wrapping),
     )
-
 
 def aws_cryptography_materialproviders_EncryptedDataKey(native_input):
     return DafnyEncryptedDataKey(
-        keyProviderId=Seq(native_input.key_provider_id.encode("utf-8")),
+        keyProviderId=Seq(native_input.key_provider_id.encode('utf-8')),
         keyProviderInfo=Seq(native_input.key_provider_info),
         ciphertext=Seq(native_input.ciphertext),
     )
 
-
 def aws_cryptography_materialproviders_AlgorithmSuiteId(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdESDK,
-    ):
-        AlgorithmSuiteId_union_value = AlgorithmSuiteId_ESDK(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdDBE,
-    ):
-        AlgorithmSuiteId_union_value = AlgorithmSuiteId_DBE(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DBEAlgorithmSuiteId(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdESDK):
+        AlgorithmSuiteId_union_value = AlgorithmSuiteId_ESDK(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteIdDBE):
+        AlgorithmSuiteId_union_value = AlgorithmSuiteId_DBE(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DBEAlgorithmSuiteId(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return AlgorithmSuiteId_union_value
 
-
 def aws_cryptography_materialproviders_Encrypt(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptAES_GCM,
-    ):
-        Encrypt_union_value = Encrypt_AES__GCM(
-            aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_AES_GCM(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptAES_GCM):
+        Encrypt_union_value = Encrypt_AES__GCM(aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_AES_GCM(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return Encrypt_union_value
 
-
 def aws_cryptography_materialproviders_DerivationAlgorithm(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmHKDF,
-    ):
-        DerivationAlgorithm_union_value = DerivationAlgorithm_HKDF(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_HKDF(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmIDENTITY,
-    ):
-        DerivationAlgorithm_union_value = DerivationAlgorithm_IDENTITY(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_IDENTITY(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmNone,
-    ):
-        DerivationAlgorithm_union_value = DerivationAlgorithm_None(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmHKDF):
+        DerivationAlgorithm_union_value = DerivationAlgorithm_HKDF(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_HKDF(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmIDENTITY):
+        DerivationAlgorithm_union_value = DerivationAlgorithm_IDENTITY(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_IDENTITY(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DerivationAlgorithmNone):
+        DerivationAlgorithm_union_value = DerivationAlgorithm_None(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return DerivationAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_SignatureAlgorithm(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmECDSA,
-    ):
-        SignatureAlgorithm_union_value = SignatureAlgorithm_ECDSA(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ECDSA(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmNone,
-    ):
-        SignatureAlgorithm_union_value = SignatureAlgorithm_None(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmECDSA):
+        SignatureAlgorithm_union_value = SignatureAlgorithm_ECDSA(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ECDSA(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SignatureAlgorithmNone):
+        SignatureAlgorithm_union_value = SignatureAlgorithm_None(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return SignatureAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_SymmetricSignatureAlgorithm(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmHMAC,
-    ):
-        SymmetricSignatureAlgorithm_union_value = SymmetricSignatureAlgorithm_HMAC(
-            aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_DigestAlgorithm(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmNone,
-    ):
-        SymmetricSignatureAlgorithm_union_value = SymmetricSignatureAlgorithm_None(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmHMAC):
+        SymmetricSignatureAlgorithm_union_value = SymmetricSignatureAlgorithm_HMAC(aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_DigestAlgorithm(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.SymmetricSignatureAlgorithmNone):
+        SymmetricSignatureAlgorithm_union_value = SymmetricSignatureAlgorithm_None(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_None(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return SymmetricSignatureAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_EdkWrappingAlgorithm(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmDIRECT_KEY_WRAPPING,
-    ):
-        EdkWrappingAlgorithm_union_value = EdkWrappingAlgorithm_DIRECT__KEY__WRAPPING(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmIntermediateKeyWrapping,
-    ):
-        EdkWrappingAlgorithm_union_value = EdkWrappingAlgorithm_IntermediateKeyWrapping(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_IntermediateKeyWrapping(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmDIRECT_KEY_WRAPPING):
+        EdkWrappingAlgorithm_union_value = EdkWrappingAlgorithm_DIRECT__KEY__WRAPPING(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EdkWrappingAlgorithmIntermediateKeyWrapping):
+        EdkWrappingAlgorithm_union_value = EdkWrappingAlgorithm_IntermediateKeyWrapping(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_IntermediateKeyWrapping(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return EdkWrappingAlgorithm_union_value
 
-
 def aws_cryptography_materialproviders_ESDKAlgorithmSuiteId(native_input):
-    if native_input == "0x0014":
+    if native_input == '0x0014':
         return ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__NO__KDF()
 
-    elif native_input == "0x0046":
+    elif native_input == '0x0046':
         return ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__NO__KDF()
 
-    elif native_input == "0x0078":
+    elif native_input == '0x0078':
         return ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__NO__KDF()
 
-    elif native_input == "0x0114":
+    elif native_input == '0x0114':
         return ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256()
 
-    elif native_input == "0x0146":
+    elif native_input == '0x0146':
         return ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA256()
 
-    elif native_input == "0x0178":
+    elif native_input == '0x0178':
         return ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA256()
 
-    elif native_input == "0x0214":
-        return (
-            ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256__ECDSA__P256()
-        )
+    elif native_input == '0x0214':
+        return ESDKAlgorithmSuiteId_ALG__AES__128__GCM__IV12__TAG16__HKDF__SHA256__ECDSA__P256()
 
-    elif native_input == "0x0346":
-        return (
-            ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384()
-        )
+    elif native_input == '0x0346':
+        return ESDKAlgorithmSuiteId_ALG__AES__192__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384()
 
-    elif native_input == "0x0378":
-        return (
-            ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384()
-        )
+    elif native_input == '0x0378':
+        return ESDKAlgorithmSuiteId_ALG__AES__256__GCM__IV12__TAG16__HKDF__SHA384__ECDSA__P384()
 
-    elif native_input == "0x0478":
+    elif native_input == '0x0478':
         return ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY()
 
-    elif native_input == "0x0578":
-        return (
-            ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384()
-        )
+    elif native_input == '0x0578':
+        return ESDKAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_DBEAlgorithmSuiteId(native_input):
-    if native_input == "0x6700":
-        return (
-            DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__SYMSIG__HMAC__SHA384()
-        )
+    if native_input == '0x6700':
+        return DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__SYMSIG__HMAC__SHA384()
 
-    elif native_input == "0x6701":
-        return (
-            DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384__SYMSIG__HMAC__SHA384()
-        )
+    elif native_input == '0x6701':
+        return DBEAlgorithmSuiteId_ALG__AES__256__GCM__HKDF__SHA512__COMMIT__KEY__ECDSA__P384__SYMSIG__HMAC__SHA384()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_HKDF(native_input):
     return DafnyHKDF(
-        hmac=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_DigestAlgorithm(
-            native_input.hmac
-        ),
+        hmac=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_DigestAlgorithm(native_input.hmac),
         saltLength=native_input.salt_length,
         inputKeyLength=native_input.input_key_length,
         outputKeyLength=native_input.output_key_length,
     )
 
-
 def aws_cryptography_materialproviders_IDENTITY(native_input):
-    return DafnyIDENTITY()
-
+    return DafnyIDENTITY(
+    )
 
 def aws_cryptography_materialproviders_None(native_input):
-    return DafnyNone()
-
+    return DafnyNone(
+    )
 
 def aws_cryptography_materialproviders_ECDSA(native_input):
     return DafnyECDSA(
-        curve=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDSASignatureAlgorithm(
-            native_input.curve
-        ),
+        curve=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDSASignatureAlgorithm(native_input.curve),
     )
 
-
 def aws_cryptography_materialproviders_DIRECT_KEY_WRAPPING(native_input):
-    return DafnyDIRECT_KEY_WRAPPING()
-
+    return DafnyDIRECT_KEY_WRAPPING(
+    )
 
 def aws_cryptography_materialproviders_IntermediateKeyWrapping(native_input):
     return DafnyIntermediateKeyWrapping(
-        keyEncryptionKeyKdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(
-            native_input.key_encryption_key_kdf
-        ),
-        macKeyKdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(
-            native_input.mac_key_kdf
-        ),
-        pdkEncryptAlgorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Encrypt(
-            native_input.pdk_encrypt_algorithm
-        ),
+        keyEncryptionKeyKdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(native_input.key_encryption_key_kdf),
+        macKeyKdf=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DerivationAlgorithm(native_input.mac_key_kdf),
+        pdkEncryptAlgorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Encrypt(native_input.pdk_encrypt_algorithm),
     )
-
 
 def smithy_api_Unit(native_input):
     return None
 
-
 def aws_cryptography_materialproviders_GetCacheEntryInput(native_input):
     return DafnyGetCacheEntryInput(
         identifier=Seq(native_input.identifier),
-        bytesUsed=(
-            (Option_Some(native_input.bytes_used))
-            if (native_input.bytes_used is not None)
-            else (Option_None())
-        ),
+        bytesUsed=((Option_Some(native_input.bytes_used)) if (native_input.bytes_used is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_GetCacheEntryOutput(native_input):
     return DafnyGetCacheEntryOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Materials(
-            native_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_Materials(native_input.materials),
         creationTime=native_input.creation_time,
         expiryTime=native_input.expiry_time,
         messagesUsed=native_input.messages_used,
         bytesUsed=native_input.bytes_used,
     )
-
 
 def aws_cryptography_materialproviders_UpdateUsageMetadataInput(native_input):
     return DafnyUpdateUsageMetadataInput(
@@ -694,1673 +401,509 @@ def aws_cryptography_materialproviders_UpdateUsageMetadataInput(native_input):
         bytesUsed=native_input.bytes_used,
     )
 
-
 def aws_cryptography_materialproviders_DeleteCacheEntryInput(native_input):
     return DafnyDeleteCacheEntryInput(
         identifier=Seq(native_input.identifier),
     )
 
-
 def aws_cryptography_materialproviders_GetEncryptionMaterialsInput(native_input):
     return DafnyGetEncryptionMaterialsInput(
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(
-            native_input.commitment_policy
-        ),
-        algorithmSuiteId=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-                        native_input.algorithm_suite_id
-                    )
-                )
-            )
-            if (native_input.algorithm_suite_id is not None)
-            else (Option_None())
-        ),
-        maxPlaintextLength=(
-            (Option_Some(native_input.max_plaintext_length))
-            if (native_input.max_plaintext_length is not None)
-            else (Option_None())
-        ),
-        requiredEncryptionContextKeys=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(list_element.encode("utf-8"))
-                            for list_element in native_input.required_encryption_context_keys
-                        ]
-                    )
-                )
-            )
-            if (native_input.required_encryption_context_keys is not None)
-            else (Option_None())
-        ),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(native_input.commitment_policy),
+        algorithmSuiteId=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm_suite_id))) if (native_input.algorithm_suite_id is not None) else (Option_None())),
+        maxPlaintextLength=((Option_Some(native_input.max_plaintext_length)) if (native_input.max_plaintext_length is not None) else (Option_None())),
+        requiredEncryptionContextKeys=((Option_Some(Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]))) if (native_input.required_encryption_context_keys is not None) else (Option_None())),
     )
 
-
 def aws_cryptography_materialproviders_CommitmentPolicy(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyESDK,
-    ):
-        CommitmentPolicy_union_value = CommitmentPolicy_ESDK(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ESDKCommitmentPolicy(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyDBE,
-    ):
-        CommitmentPolicy_union_value = CommitmentPolicy_DBE(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DBECommitmentPolicy(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyESDK):
+        CommitmentPolicy_union_value = CommitmentPolicy_ESDK(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ESDKCommitmentPolicy(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CommitmentPolicyDBE):
+        CommitmentPolicy_union_value = CommitmentPolicy_DBE(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DBECommitmentPolicy(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return CommitmentPolicy_union_value
 
-
 def aws_cryptography_materialproviders_ESDKCommitmentPolicy(native_input):
-    if native_input == "FORBID_ENCRYPT_ALLOW_DECRYPT":
+    if native_input == 'FORBID_ENCRYPT_ALLOW_DECRYPT':
         return ESDKCommitmentPolicy_FORBID__ENCRYPT__ALLOW__DECRYPT()
 
-    elif native_input == "REQUIRE_ENCRYPT_ALLOW_DECRYPT":
+    elif native_input == 'REQUIRE_ENCRYPT_ALLOW_DECRYPT':
         return ESDKCommitmentPolicy_REQUIRE__ENCRYPT__ALLOW__DECRYPT()
 
-    elif native_input == "REQUIRE_ENCRYPT_REQUIRE_DECRYPT":
+    elif native_input == 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT':
         return ESDKCommitmentPolicy_REQUIRE__ENCRYPT__REQUIRE__DECRYPT()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_DBECommitmentPolicy(native_input):
-    if native_input == "REQUIRE_ENCRYPT_REQUIRE_DECRYPT":
+    if native_input == 'REQUIRE_ENCRYPT_REQUIRE_DECRYPT':
         return DBECommitmentPolicy_REQUIRE__ENCRYPT__REQUIRE__DECRYPT()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_GetEncryptionMaterialsOutput(native_input):
     return DafnyGetEncryptionMaterialsOutput(
-        encryptionMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            native_input.encryption_materials
-        ),
+        encryptionMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.encryption_materials),
     )
-
 
 def aws_cryptography_materialproviders_DecryptMaterialsInput(native_input):
     return DafnyDecryptMaterialsInput(
-        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.algorithm_suite_id
-        ),
-        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(
-            native_input.commitment_policy
-        ),
-        encryptedDataKeys=Seq(
-            [
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(
-                    list_element
-                )
-                for list_element in native_input.encrypted_data_keys
-            ]
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        reproducedEncryptionContext=(
-            (
-                Option_Some(
-                    Map(
-                        {
-                            Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                            for (
-                                key,
-                                value,
-                            ) in native_input.reproduced_encryption_context.items()
-                        }
-                    )
-                )
-            )
-            if (native_input.reproduced_encryption_context is not None)
-            else (Option_None())
-        ),
+        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm_suite_id),
+        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(native_input.commitment_policy),
+        encryptedDataKeys=Seq([aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in native_input.encrypted_data_keys]),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        reproducedEncryptionContext=((Option_Some(Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.reproduced_encryption_context.items() }))) if (native_input.reproduced_encryption_context is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_DecryptMaterialsOutput(native_input):
     return DafnyDecryptMaterialsOutput(
-        decryptionMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            native_input.decryption_materials
-        ),
+        decryptionMaterials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.decryption_materials),
     )
-
 
 def aws_cryptography_materialproviders_OnEncryptInput(native_input):
     return DafnyOnEncryptInput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            native_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_OnEncryptOutput(native_input):
     return DafnyOnEncryptOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            native_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_OnDecryptInput(native_input):
     return DafnyOnDecryptInput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            native_input.materials
-        ),
-        encryptedDataKeys=Seq(
-            [
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(
-                    list_element
-                )
-                for list_element in native_input.encrypted_data_keys
-            ]
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.materials),
+        encryptedDataKeys=Seq([aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptedDataKey(list_element) for list_element in native_input.encrypted_data_keys]),
     )
-
 
 def aws_cryptography_materialproviders_OnDecryptOutput(native_input):
     return DafnyOnDecryptOutput(
-        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            native_input.materials
-        ),
+        materials=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.materials),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(native_input):
     return DafnyCreateAwsKmsKeyringInput(
-        kmsKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.kms_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-            native_input.kms_client
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        kmsKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.kms_key_id.encode('utf-16-be'))]*2)])),
+        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(native_input):
     return DafnyCreateAwsKmsDiscoveryKeyringInput(
-        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-            native_input.kms_client
-        ),
-        discoveryFilter=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(
-                        native_input.discovery_filter
-                    )
-                )
-            )
-            if (native_input.discovery_filter is not None)
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client),
+        discoveryFilter=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(native_input.discovery_filter))) if (native_input.discovery_filter is not None) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_DiscoveryFilter(native_input):
     return DafnyDiscoveryFilter(
-        accountIds=Seq(
-            [
-                Seq(
-                    "".join(
-                        [
-                            chr(int.from_bytes(pair, "big"))
-                            for pair in zip(
-                                *[iter(list_element.encode("utf-16-be"))] * 2
-                            )
-                        ]
-                    )
-                )
-                for list_element in native_input.account_ids
-            ]
-        ),
-        partition=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.partition.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        accountIds=Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.account_ids]),
+        partition=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.partition.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(native_input):
     return DafnyCreateAwsKmsMultiKeyringInput(
-        generator=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[iter(native_input.generator.encode("utf-16-be"))]
-                                    * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.generator is not None)
-            else (Option_None())
-        ),
-        kmsKeyIds=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.kms_key_ids
-                        ]
-                    )
-                )
-            )
-            if (native_input.kms_key_ids is not None)
-            else (Option_None())
-        ),
-        clientSupplier=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                )
-            )
-            if (
-                (native_input.client_supplier is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        generator=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.generator.encode('utf-16-be'))]*2)])))) if (native_input.generator is not None) else (Option_None())),
+        kmsKeyIds=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.kms_key_ids]))) if (native_input.kms_key_ids is not None) else (Option_None())),
+        clientSupplier=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier))) if ((native_input.client_supplier is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier) is not None)) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
 
-
 def aws_cryptography_materialproviders_ClientSupplierReference(native_input):
-    if hasattr(native_input, "_impl"):
+    if hasattr(native_input, '_impl'):
         return native_input._impl
 
     else:
         return native_input
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(native_input):
     return DafnyCreateAwsKmsDiscoveryMultiKeyringInput(
-        regions=Seq(
-            [
-                Seq(
-                    "".join(
-                        [
-                            chr(int.from_bytes(pair, "big"))
-                            for pair in zip(
-                                *[iter(list_element.encode("utf-16-be"))] * 2
-                            )
-                        ]
-                    )
-                )
-                for list_element in native_input.regions
-            ]
-        ),
-        discoveryFilter=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(
-                        native_input.discovery_filter
-                    )
-                )
-            )
-            if (native_input.discovery_filter is not None)
-            else (Option_None())
-        ),
-        clientSupplier=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                )
-            )
-            if (
-                (native_input.client_supplier is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        regions=Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.regions]),
+        discoveryFilter=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(native_input.discovery_filter))) if (native_input.discovery_filter is not None) else (Option_None())),
+        clientSupplier=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier))) if ((native_input.client_supplier is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier) is not None)) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(native_input):
     return DafnyCreateAwsKmsMrkKeyringInput(
-        kmsKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.kms_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-            native_input.kms_client
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        kmsKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.kms_key_id.encode('utf-16-be'))]*2)])),
+        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(native_input):
     return DafnyCreateAwsKmsMrkMultiKeyringInput(
-        generator=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[iter(native_input.generator.encode("utf-16-be"))]
-                                    * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.generator is not None)
-            else (Option_None())
-        ),
-        kmsKeyIds=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.kms_key_ids
-                        ]
-                    )
-                )
-            )
-            if (native_input.kms_key_ids is not None)
-            else (Option_None())
-        ),
-        clientSupplier=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                )
-            )
-            if (
-                (native_input.client_supplier is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        generator=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.generator.encode('utf-16-be'))]*2)])))) if (native_input.generator is not None) else (Option_None())),
+        kmsKeyIds=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.kms_key_ids]))) if (native_input.kms_key_ids is not None) else (Option_None())),
+        clientSupplier=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier))) if ((native_input.client_supplier is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier) is not None)) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(native_input):
     return DafnyCreateAwsKmsMrkDiscoveryKeyringInput(
-        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-            native_input.kms_client
-        ),
-        discoveryFilter=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(
-                        native_input.discovery_filter
-                    )
-                )
-            )
-            if (native_input.discovery_filter is not None)
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
-        region=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.region.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client),
+        discoveryFilter=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(native_input.discovery_filter))) if (native_input.discovery_filter is not None) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
+        region=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.region.encode('utf-16-be'))]*2)])),
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(native_input):
     return DafnyCreateAwsKmsMrkDiscoveryMultiKeyringInput(
-        regions=Seq(
-            [
-                Seq(
-                    "".join(
-                        [
-                            chr(int.from_bytes(pair, "big"))
-                            for pair in zip(
-                                *[iter(list_element.encode("utf-16-be"))] * 2
-                            )
-                        ]
-                    )
-                )
-                for list_element in native_input.regions
-            ]
-        ),
-        discoveryFilter=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(
-                        native_input.discovery_filter
-                    )
-                )
-            )
-            if (native_input.discovery_filter is not None)
-            else (Option_None())
-        ),
-        clientSupplier=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                )
-            )
-            if (
-                (native_input.client_supplier is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-                        native_input.client_supplier
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        regions=Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.regions]),
+        discoveryFilter=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(native_input.discovery_filter))) if (native_input.discovery_filter is not None) else (Option_None())),
+        clientSupplier=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier))) if ((native_input.client_supplier is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input.client_supplier) is not None)) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
 
-
-def aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(native_input):
     return DafnyCreateAwsKmsHierarchicalKeyringInput(
-        branchKeyId=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[
-                                        iter(
-                                            native_input.branch_key_id.encode(
-                                                "utf-16-be"
-                                            )
-                                        )
-                                    ]
-                                    * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.branch_key_id is not None)
-            else (Option_None())
-        ),
-        branchKeyIdSupplier=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(
-                        native_input.branch_key_id_supplier
-                    )
-                )
-            )
-            if (
-                (native_input.branch_key_id_supplier is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(
-                        native_input.branch_key_id_supplier
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        keyStore=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyStoreReference(
-            native_input.key_store
-        ),
+        branchKeyId=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_id.encode('utf-16-be'))]*2)])))) if (native_input.branch_key_id is not None) else (Option_None())),
+        branchKeyIdSupplier=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(native_input.branch_key_id_supplier))) if ((native_input.branch_key_id_supplier is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_BranchKeyIdSupplierReference(native_input.branch_key_id_supplier) is not None)) else (Option_None())),
+        keyStore=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyStoreReference(native_input.key_store),
         ttlSeconds=native_input.ttl_seconds,
-        cache=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CacheType(
-                        native_input.cache
-                    )
-                )
-            )
-            if (native_input.cache is not None)
-            else (Option_None())
-        ),
-        partitionId=(
-            (
-                Option_Some(
-                    Seq(
-                        "".join(
-                            [
-                                chr(int.from_bytes(pair, "big"))
-                                for pair in zip(
-                                    *[
-                                        iter(
-                                            native_input.partition_id.encode(
-                                                "utf-16-be"
-                                            )
-                                        )
-                                    ]
-                                    * 2
-                                )
-                            ]
-                        )
-                    )
-                )
-            )
-            if (native_input.partition_id is not None)
-            else (Option_None())
-        ),
+        cache=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CacheType(native_input.cache))) if (native_input.cache is not None) else (Option_None())),
+        partitionId=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.partition_id.encode('utf-16-be'))]*2)])))) if (native_input.partition_id is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_BranchKeyIdSupplierReference(native_input):
-    if hasattr(native_input, "_impl"):
+    if hasattr(native_input, '_impl'):
         return native_input._impl
 
     else:
         return native_input
-
 
 def aws_cryptography_materialproviders_KeyStoreReference(native_input):
     return native_input._config.dafnyImplInterface.impl
 
-
 def aws_cryptography_materialproviders_CacheType(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeDefault,
-    ):
-        CacheType_union_value = CacheType_Default(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DefaultCache(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeNo,
-    ):
-        CacheType_union_value = CacheType_No(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_NoCache(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeSingleThreaded,
-    ):
-        CacheType_union_value = CacheType_SingleThreaded(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SingleThreadedCache(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeMultiThreaded,
-    ):
-        CacheType_union_value = CacheType_MultiThreaded(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_MultiThreadedCache(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeStormTracking,
-    ):
-        CacheType_union_value = CacheType_StormTracking(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_StormTrackingCache(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeShared,
-    ):
-        CacheType_union_value = CacheType_Shared(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeDefault):
+        CacheType_union_value = CacheType_Default(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DefaultCache(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeNo):
+        CacheType_union_value = CacheType_No(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_NoCache(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeSingleThreaded):
+        CacheType_union_value = CacheType_SingleThreaded(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_SingleThreadedCache(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeMultiThreaded):
+        CacheType_union_value = CacheType_MultiThreaded(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_MultiThreadedCache(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeStormTracking):
+        CacheType_union_value = CacheType_StormTracking(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_StormTrackingCache(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CacheTypeShared):
+        CacheType_union_value = CacheType_Shared(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return CacheType_union_value
-
 
 def aws_cryptography_materialproviders_DefaultCache(native_input):
     return DafnyDefaultCache(
         entryCapacity=native_input.entry_capacity,
     )
 
-
 def aws_cryptography_materialproviders_NoCache(native_input):
-    return DafnyNoCache()
-
+    return DafnyNoCache(
+    )
 
 def aws_cryptography_materialproviders_SingleThreadedCache(native_input):
     return DafnySingleThreadedCache(
         entryCapacity=native_input.entry_capacity,
-        entryPruningTailSize=(
-            (Option_Some(native_input.entry_pruning_tail_size))
-            if (native_input.entry_pruning_tail_size is not None)
-            else (Option_None())
-        ),
+        entryPruningTailSize=((Option_Some(native_input.entry_pruning_tail_size)) if (native_input.entry_pruning_tail_size is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_MultiThreadedCache(native_input):
     return DafnyMultiThreadedCache(
         entryCapacity=native_input.entry_capacity,
-        entryPruningTailSize=(
-            (Option_Some(native_input.entry_pruning_tail_size))
-            if (native_input.entry_pruning_tail_size is not None)
-            else (Option_None())
-        ),
+        entryPruningTailSize=((Option_Some(native_input.entry_pruning_tail_size)) if (native_input.entry_pruning_tail_size is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_StormTrackingCache(native_input):
     return DafnyStormTrackingCache(
         entryCapacity=native_input.entry_capacity,
-        entryPruningTailSize=(
-            (Option_Some(native_input.entry_pruning_tail_size))
-            if (native_input.entry_pruning_tail_size is not None)
-            else (Option_None())
-        ),
+        entryPruningTailSize=((Option_Some(native_input.entry_pruning_tail_size)) if (native_input.entry_pruning_tail_size is not None) else (Option_None())),
         gracePeriod=native_input.grace_period,
         graceInterval=native_input.grace_interval,
         fanOut=native_input.fan_out,
         inFlightTTL=native_input.in_flight_ttl,
         sleepMilli=native_input.sleep_milli,
-        timeUnits=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_TimeUnits(
-                        native_input.time_units
-                    )
-                )
-            )
-            if (native_input.time_units is not None)
-            else (Option_None())
-        ),
+        timeUnits=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_TimeUnits(native_input.time_units))) if (native_input.time_units is not None) else (Option_None())),
     )
 
-
-def aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-    native_input,
-):
-    if hasattr(native_input, "_impl"):
+def aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(native_input):
+    if hasattr(native_input, '_impl'):
         return native_input._impl
 
     else:
         return native_input
 
-
 def aws_cryptography_materialproviders_TimeUnits(native_input):
-    if native_input == "Seconds":
+    if native_input == 'Seconds':
         return TimeUnits_Seconds()
 
-    elif native_input == "Milliseconds":
+    elif native_input == 'Milliseconds':
         return TimeUnits_Milliseconds()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(native_input):
     return DafnyCreateAwsKmsRsaKeyringInput(
-        publicKey=(
-            (Option_Some(Seq(native_input.public_key)))
-            if (native_input.public_key is not None)
-            else (Option_None())
-        ),
-        kmsKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.kms_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        encryptionAlgorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.aws_sdk_to_dafny.com_amazonaws_kms_EncryptionAlgorithmSpec(
-            native_input.encryption_algorithm
-        ),
-        kmsClient=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-                        native_input.kms_client
-                    )
-                )
-            )
-            if (
-                (native_input.kms_client is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-                        native_input.kms_client
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        publicKey=((Option_Some(Seq(native_input.public_key))) if (native_input.public_key is not None) else (Option_None())),
+        kmsKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.kms_key_id.encode('utf-16-be'))]*2)])),
+        encryptionAlgorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.aws_sdk_to_dafny.com_amazonaws_kms_EncryptionAlgorithmSpec(native_input.encryption_algorithm),
+        kmsClient=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client))) if ((native_input.kms_client is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client) is not None)) else (Option_None())),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(native_input):
     return DafnyCreateAwsKmsEcdhKeyringInput(
-        KeyAgreementScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(
-            native_input.key_agreement_scheme
-        ),
-        curveSpec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDHCurveSpec(
-            native_input.curve_spec
-        ),
-        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(
-            native_input.kms_client
-        ),
-        grantTokens=(
-            (
-                Option_Some(
-                    Seq(
-                        [
-                            Seq(
-                                "".join(
-                                    [
-                                        chr(int.from_bytes(pair, "big"))
-                                        for pair in zip(
-                                            *[iter(list_element.encode("utf-16-be"))]
-                                            * 2
-                                        )
-                                    ]
-                                )
-                            )
-                            for list_element in native_input.grant_tokens
-                        ]
-                    )
-                )
-            )
-            if (native_input.grant_tokens is not None)
-            else (Option_None())
-        ),
+        KeyAgreementScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(native_input.key_agreement_scheme),
+        curveSpec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDHCurveSpec(native_input.curve_spec),
+        kmsClient=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsClientReference(native_input.kms_client),
+        grantTokens=((Option_Some(Seq([Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(list_element.encode('utf-16-be'))]*2)])) for list_element in native_input.grant_tokens]))) if (native_input.grant_tokens is not None) else (Option_None())),
     )
 
-
 def aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery,
-    ):
-        KmsEcdhStaticConfigurations_union_value = KmsEcdhStaticConfigurations_KmsPublicKeyDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey,
-    ):
-        KmsEcdhStaticConfigurations_union_value = KmsEcdhStaticConfigurations_KmsPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPublicKeyDiscovery):
+        KmsEcdhStaticConfigurations_union_value = KmsEcdhStaticConfigurations_KmsPublicKeyDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KmsEcdhStaticConfigurationsKmsPrivateKeyToStaticPublicKey):
+        KmsEcdhStaticConfigurations_union_value = KmsEcdhStaticConfigurations_KmsPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return KmsEcdhStaticConfigurations_union_value
 
-
 def aws_cryptography_materialproviders_KmsPublicKeyDiscoveryInput(native_input):
     return DafnyKmsPublicKeyDiscoveryInput(
-        recipientKmsIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[
-                            iter(
-                                native_input.recipient_kms_identifier.encode(
-                                    "utf-16-be"
-                                )
-                            )
-                        ]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        recipientKmsIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.recipient_kms_identifier.encode('utf-16-be'))]*2)])),
     )
 
-
-def aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_KmsPrivateKeyToStaticPublicKeyInput(native_input):
     return DafnyKmsPrivateKeyToStaticPublicKeyInput(
-        senderKmsIdentifier=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.sender_kms_identifier.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        senderPublicKey=(
-            (Option_Some(Seq(native_input.sender_public_key)))
-            if (native_input.sender_public_key is not None)
-            else (Option_None())
-        ),
+        senderKmsIdentifier=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.sender_kms_identifier.encode('utf-16-be'))]*2)])),
+        senderPublicKey=((Option_Some(Seq(native_input.sender_public_key))) if (native_input.sender_public_key is not None) else (Option_None())),
         recipientPublicKey=Seq(native_input.recipient_public_key),
     )
 
-
 def aws_cryptography_materialproviders_CreateMultiKeyringInput(native_input):
     return DafnyCreateMultiKeyringInput(
-        generator=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-                        native_input.generator
-                    )
-                )
-            )
-            if (
-                (native_input.generator is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-                        native_input.generator
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        childKeyrings=Seq(
-            [
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-                    list_element
-                )
-                for list_element in native_input.child_keyrings
-            ]
-        ),
+        generator=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.generator))) if ((native_input.generator is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.generator) is not None)) else (Option_None())),
+        childKeyrings=Seq([aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(list_element) for list_element in native_input.child_keyrings]),
     )
 
-
 def aws_cryptography_materialproviders_KeyringReference(native_input):
-    if hasattr(native_input, "_impl"):
+    if hasattr(native_input, '_impl'):
         return native_input._impl
 
     else:
         return native_input
 
-
 def aws_cryptography_materialproviders_CreateRawAesKeyringInput(native_input):
     return DafnyCreateRawAesKeyringInput(
-        keyNamespace=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_namespace.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        keyName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_name.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyNamespace=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_namespace.encode('utf-16-be'))]*2)])),
+        keyName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_name.encode('utf-16-be'))]*2)])),
         wrappingKey=Seq(native_input.wrapping_key),
-        wrappingAlg=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AesWrappingAlg(
-            native_input.wrapping_alg
-        ),
+        wrappingAlg=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AesWrappingAlg(native_input.wrapping_alg),
     )
 
-
 def aws_cryptography_materialproviders_AesWrappingAlg(native_input):
-    if native_input == "ALG_AES128_GCM_IV12_TAG16":
+    if native_input == 'ALG_AES128_GCM_IV12_TAG16':
         return AesWrappingAlg_ALG__AES128__GCM__IV12__TAG16()
 
-    elif native_input == "ALG_AES192_GCM_IV12_TAG16":
+    elif native_input == 'ALG_AES192_GCM_IV12_TAG16':
         return AesWrappingAlg_ALG__AES192__GCM__IV12__TAG16()
 
-    elif native_input == "ALG_AES256_GCM_IV12_TAG16":
+    elif native_input == 'ALG_AES256_GCM_IV12_TAG16':
         return AesWrappingAlg_ALG__AES256__GCM__IV12__TAG16()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_CreateRawRsaKeyringInput(native_input):
     return DafnyCreateRawRsaKeyringInput(
-        keyNamespace=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_namespace.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        keyName=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_name.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        paddingScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PaddingScheme(
-            native_input.padding_scheme
-        ),
-        publicKey=(
-            (Option_Some(Seq(native_input.public_key)))
-            if (native_input.public_key is not None)
-            else (Option_None())
-        ),
-        privateKey=(
-            (Option_Some(Seq(native_input.private_key)))
-            if (native_input.private_key is not None)
-            else (Option_None())
-        ),
+        keyNamespace=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_namespace.encode('utf-16-be'))]*2)])),
+        keyName=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_name.encode('utf-16-be'))]*2)])),
+        paddingScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PaddingScheme(native_input.padding_scheme),
+        publicKey=((Option_Some(Seq(native_input.public_key))) if (native_input.public_key is not None) else (Option_None())),
+        privateKey=((Option_Some(Seq(native_input.private_key))) if (native_input.private_key is not None) else (Option_None())),
     )
 
-
 def aws_cryptography_materialproviders_PaddingScheme(native_input):
-    if native_input == "PKCS1":
+    if native_input == 'PKCS1':
         return PaddingScheme_PKCS1()
 
-    elif native_input == "OAEP_SHA1_MGF1":
+    elif native_input == 'OAEP_SHA1_MGF1':
         return PaddingScheme_OAEP__SHA1__MGF1()
 
-    elif native_input == "OAEP_SHA256_MGF1":
+    elif native_input == 'OAEP_SHA256_MGF1':
         return PaddingScheme_OAEP__SHA256__MGF1()
 
-    elif native_input == "OAEP_SHA384_MGF1":
+    elif native_input == 'OAEP_SHA384_MGF1':
         return PaddingScheme_OAEP__SHA384__MGF1()
 
-    elif native_input == "OAEP_SHA512_MGF1":
+    elif native_input == 'OAEP_SHA512_MGF1':
         return PaddingScheme_OAEP__SHA512__MGF1()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
 def aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(native_input):
     return DafnyCreateRawEcdhKeyringInput(
-        KeyAgreementScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(
-            native_input.key_agreement_scheme
-        ),
-        curveSpec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDHCurveSpec(
-            native_input.curve_spec
-        ),
+        KeyAgreementScheme=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(native_input.key_agreement_scheme),
+        curveSpec=aws_cryptography_primitives.smithygenerated.aws_cryptography_primitives.smithy_to_dafny.aws_cryptography_primitives_ECDHCurveSpec(native_input.curve_spec),
     )
 
-
 def aws_cryptography_materialproviders_RawEcdhStaticConfigurations(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsPublicKeyDiscovery,
-    ):
-        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_PublicKeyDiscovery(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PublicKeyDiscoveryInput(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey,
-    ):
-        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_RawPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey,
-    ):
-        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_EphemeralPrivateKeyToStaticPublicKey(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsPublicKeyDiscovery):
+        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_PublicKeyDiscovery(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PublicKeyDiscoveryInput(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsRawPrivateKeyToStaticPublicKey):
+        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_RawPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.RawEcdhStaticConfigurationsEphemeralPrivateKeyToStaticPublicKey):
+        RawEcdhStaticConfigurations_union_value = RawEcdhStaticConfigurations_EphemeralPrivateKeyToStaticPublicKey(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return RawEcdhStaticConfigurations_union_value
-
 
 def aws_cryptography_materialproviders_PublicKeyDiscoveryInput(native_input):
     return DafnyPublicKeyDiscoveryInput(
         recipientStaticPrivateKey=Seq(native_input.recipient_static_private_key),
     )
 
-
-def aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_RawPrivateKeyToStaticPublicKeyInput(native_input):
     return DafnyRawPrivateKeyToStaticPublicKeyInput(
         senderStaticPrivateKey=Seq(native_input.sender_static_private_key),
         recipientPublicKey=Seq(native_input.recipient_public_key),
     )
 
-
-def aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_EphemeralPrivateKeyToStaticPublicKeyInput(native_input):
     return DafnyEphemeralPrivateKeyToStaticPublicKeyInput(
         recipientPublicKey=Seq(native_input.recipient_public_key),
     )
 
-
-def aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(native_input):
     return DafnyCreateDefaultCryptographicMaterialsManagerInput(
-        keyring=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-            native_input.keyring
-        ),
+        keyring=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.keyring),
     )
 
-
-def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(native_input):
     return DafnyCreateRequiredEncryptionContextCMMInput(
-        underlyingCMM=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-                        native_input.underlying_cmm
-                    )
-                )
-            )
-            if (
-                (native_input.underlying_cmm is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-                        native_input.underlying_cmm
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        keyring=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-                        native_input.keyring
-                    )
-                )
-            )
-            if (
-                (native_input.keyring is not None)
-                and (
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-                        native_input.keyring
-                    )
-                    is not None
-                )
-            )
-            else (Option_None())
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
+        underlyingCMM=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input.underlying_cmm))) if ((native_input.underlying_cmm is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input.underlying_cmm) is not None)) else (Option_None())),
+        keyring=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.keyring))) if ((native_input.keyring is not None) and (aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.keyring) is not None)) else (Option_None())),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
     )
 
-
-def aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-    native_input,
-):
-    if hasattr(native_input, "_impl"):
+def aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input):
+    if hasattr(native_input, '_impl'):
         return native_input._impl
 
     else:
         return native_input
 
-
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(native_input):
     return DafnyCreateCryptographicMaterialsCacheInput(
-        cache=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CacheType(
-            native_input.cache
-        ),
+        cache=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CacheType(native_input.cache),
     )
 
-
 def aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(native_input):
-    return DafnyCreateDefaultClientSupplierInput()
-
+    return DafnyCreateDefaultClientSupplierInput(
+    )
 
 def aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(native_input):
     return DafnyInitializeEncryptionMaterialsInput(
-        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.algorithm_suite_id
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
-        signingKey=(
-            (Option_Some(Seq(native_input.signing_key)))
-            if (native_input.signing_key is not None)
-            else (Option_None())
-        ),
-        verificationKey=(
-            (Option_Some(Seq(native_input.verification_key)))
-            if (native_input.verification_key is not None)
-            else (Option_None())
-        ),
+        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm_suite_id),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
+        signingKey=((Option_Some(Seq(native_input.signing_key))) if (native_input.signing_key is not None) else (Option_None())),
+        verificationKey=((Option_Some(Seq(native_input.verification_key))) if (native_input.verification_key is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(native_input):
     return DafnyInitializeDecryptionMaterialsInput(
-        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.algorithm_suite_id
-        ),
-        encryptionContext=Map(
-            {
-                Seq(key.encode("utf-8")): Seq(value.encode("utf-8"))
-                for (key, value) in native_input.encryption_context.items()
-            }
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
+        algorithmSuiteId=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm_suite_id),
+        encryptionContext=Map({Seq(key.encode('utf-8')): Seq(value.encode('utf-8')) for (key, value) in native_input.encryption_context.items() }),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
     )
 
-
-def aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(native_input):
     return DafnyValidEncryptionMaterialsTransitionInput(
-        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            native_input.start
-        ),
-        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-            native_input.stop
-        ),
+        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.start),
+        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(native_input.stop),
     )
 
-
-def aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(native_input):
     return DafnyValidDecryptionMaterialsTransitionInput(
-        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            native_input.start
-        ),
-        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-            native_input.stop
-        ),
+        start=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.start),
+        stop=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(native_input.stop),
     )
-
 
 def aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(native_input):
     return Seq(native_input)
 
-
-def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(native_input):
     return DafnyValidateCommitmentPolicyOnEncryptInput(
-        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.algorithm
-        ),
-        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(
-            native_input.commitment_policy
-        ),
+        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm),
+        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(native_input.commitment_policy),
     )
 
-
-def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(
-    native_input,
-):
+def aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(native_input):
     return DafnyValidateCommitmentPolicyOnDecryptInput(
-        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(
-            native_input.algorithm
-        ),
-        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(
-            native_input.commitment_policy
-        ),
+        algorithm=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteId(native_input.algorithm),
+        commitmentPolicy=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CommitmentPolicy(native_input.commitment_policy),
     )
 
+def aws_cryptography_materialproviders_GetCacheIdentifierInput(native_input):
+    return DafnyGetCacheIdentifierInput(
+        keyring=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input.keyring),
+        branchKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_id.encode('utf-16-be'))]*2)])),
+        branchKeyVersion=((Option_Some(Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.branch_key_version.encode('utf-16-be'))]*2)])))) if (native_input.branch_key_version is not None) else (Option_None())),
+    )
 
 def aws_cryptography_materialproviders_CreateKeyringOutput(native_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(
-        native_input
-    )
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KeyringReference(native_input)
 
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(native_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input)
 
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(
-    native_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        native_input
-    )
+def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(native_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input)
 
-
-def aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(
-    native_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        native_input
-    )
-
-
-def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(
-    native_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(
-        native_input
-    )
-
+def aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(native_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsCacheReference(native_input)
 
 def aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(native_input):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(
-        native_input
-    )
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_ClientSupplierReference(native_input)
 
+def aws_cryptography_materialproviders_GetCacheIdentifierOutput(native_input):
+    return DafnyGetCacheIdentifierOutput(
+        identifier=Seq(native_input.identifier),
+    )
 
 def aws_cryptography_materialproviders_DdbClientReference(native_input):
     import aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb
-
-    client = aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb.default__.DynamoDBClient(
-        boto_client=native_input
-    )
+    client = aws_cryptography_internal_dynamodb.internaldafny.generated.Com_Amazonaws_Dynamodb.default__.DynamoDBClient(boto_client = native_input)
     client.value.impl = native_input
     return client.value
 
-
 def aws_cryptography_materialproviders_StaticConfigurations(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsAWS_KMS_ECDH,
-    ):
-        StaticConfigurations_union_value = StaticConfigurations_AWS__KMS__ECDH(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsRAW_ECDH,
-    ):
-        StaticConfigurations_union_value = StaticConfigurations_RAW__ECDH(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsAWS_KMS_ECDH):
+        StaticConfigurations_union_value = StaticConfigurations_AWS__KMS__ECDH(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_KmsEcdhStaticConfigurations(native_input.value))
+    elif isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.StaticConfigurationsRAW_ECDH):
+        StaticConfigurations_union_value = StaticConfigurations_RAW__ECDH(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_RawEcdhStaticConfigurations(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return StaticConfigurations_union_value
 
-
 def aws_cryptography_materialproviders_KeyAgreementScheme(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KeyAgreementSchemeStaticConfiguration,
-    ):
-        KeyAgreementScheme_union_value = KeyAgreementScheme_StaticConfiguration(
-            aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_StaticConfigurations(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.KeyAgreementSchemeStaticConfiguration):
+        KeyAgreementScheme_union_value = KeyAgreementScheme_StaticConfiguration(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_StaticConfigurations(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return KeyAgreementScheme_union_value
 
-
 def aws_cryptography_materialproviders_MaterialProvidersConfig(native_input):
-    return DafnyMaterialProvidersConfig()
+    return DafnyMaterialProvidersConfig(
+    )

--- a/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/CreateStaticKeyStores.dfy
+++ b/TestVectorsAwsCryptographicMaterialProviders/dafny/KeyVectors/src/CreateStaticKeyStores.dfy
@@ -225,5 +225,24 @@ module {:options "-functionSyntax:4"} CreateStaticKeyStores {
       History.VersionKey := History.VersionKey + [DafnyCallEvent(input, output)];
     }
 
+    ghost predicate GetBranchKeyVersionsEnsuresPublicly(input: GetBranchKeyVersionsInput, output: Result<GetBranchKeyVersionsOutput, Error>)
+    {true}
+
+    method GetBranchKeyVersions ( input: GetBranchKeyVersionsInput )
+      returns (output: Result<GetBranchKeyVersionsOutput, Error>)
+      requires
+        && ValidState()
+      modifies Modifies - {History} ,
+               History`GetBranchKeyVersions
+      decreases Modifies - {History}
+      ensures
+        && ValidState()
+      ensures GetBranchKeyVersionsEnsuresPublicly(input, output)
+      ensures History.GetBranchKeyVersions == old(History.GetBranchKeyVersions) + [DafnyCallEvent(input, output)]
+    {
+      output := Failure(KeyStoreException( message := "Not Supported"));
+      History.GetBranchKeyVersions := History.GetBranchKeyVersions + [DafnyCallEvent(input, output)];
+    }
+
   }
 }

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/wrapped/TestMaterialProviders.java
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/java/src/main/smithy-generated/software/amazon/cryptography/materialproviders/wrapped/TestMaterialProviders.java
@@ -38,6 +38,8 @@ import software.amazon.cryptography.materialproviders.internaldafny.types.Create
 import software.amazon.cryptography.materialproviders.internaldafny.types.DecryptionMaterials;
 import software.amazon.cryptography.materialproviders.internaldafny.types.EncryptionMaterials;
 import software.amazon.cryptography.materialproviders.internaldafny.types.Error;
+import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput;
+import software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput;
 import software.amazon.cryptography.materialproviders.internaldafny.types.IAwsCryptographicMaterialProvidersClient;
 import software.amazon.cryptography.materialproviders.internaldafny.types.IClientSupplier;
 import software.amazon.cryptography.materialproviders.internaldafny.types.ICryptographicMaterialsCache;
@@ -573,6 +575,31 @@ public class TestMaterialProviders
     } catch (RuntimeException ex) {
       return Result.create_Failure(
         AlgorithmSuiteInfo._typeDescriptor(),
+        Error._typeDescriptor(),
+        ToDafny.Error(ex)
+      );
+    }
+  }
+
+  public Result<GetCacheIdentifierOutput, Error> GetCacheIdentifier(
+    GetCacheIdentifierInput dafnyInput
+  ) {
+    try {
+      software.amazon.cryptography.materialproviders.model.GetCacheIdentifierInput nativeInput =
+        ToNative.GetCacheIdentifierInput(dafnyInput);
+      software.amazon.cryptography.materialproviders.model.GetCacheIdentifierOutput nativeOutput =
+        this._impl.GetCacheIdentifier(nativeInput);
+      GetCacheIdentifierOutput dafnyOutput = ToDafny.GetCacheIdentifierOutput(
+        nativeOutput
+      );
+      return Result.create_Success(
+        GetCacheIdentifierOutput._typeDescriptor(),
+        Error._typeDescriptor(),
+        dafnyOutput
+      );
+    } catch (RuntimeException ex) {
+      return Result.create_Failure(
+        GetCacheIdentifierOutput._typeDescriptor(),
         Error._typeDescriptor(),
         ToDafny.Error(ex)
       );

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/TestVectorsAwsCryptographicMaterialProviders/AwsCryptographicMaterialProvidersShim.cs
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/TestVectorsAwsCryptographicMaterialProviders/AwsCryptographicMaterialProvidersShim.cs
@@ -449,6 +449,21 @@ namespace AWS.Cryptography.MaterialProviders.Wrapped
       }
 
     }
+    public Wrappers_Compile._IResult<software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput, software.amazon.cryptography.materialproviders.internaldafny.types._IError> GetCacheIdentifier(software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput request)
+    {
+      try
+      {
+        AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput unWrappedRequest = TypeConversion.FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(request);
+        AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput wrappedResponse =
+        this._impl.GetCacheIdentifier(unWrappedRequest);
+        return Wrappers_Compile.Result<software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput, software.amazon.cryptography.materialproviders.internaldafny.types._IError>.create_Success(TypeConversion.ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(wrappedResponse));
+      }
+      catch (System.Exception ex)
+      {
+        return Wrappers_Compile.Result<software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput, software.amazon.cryptography.materialproviders.internaldafny.types._IError>.create_Failure(this.ConvertError(ex));
+      }
+
+    }
     private software.amazon.cryptography.materialproviders.internaldafny.types._IError ConvertError(System.Exception error)
     {
 

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/TestVectorsAwsCryptographicMaterialProviders/TypeConversion.cs
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/net/Generated/TestVectorsAwsCryptographicMaterialProviders/TypeConversion.cs
@@ -2212,6 +2212,60 @@ namespace AWS.Cryptography.MaterialProviders.Wrapped
     {
       return ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S15_PositiveInteger(value);
     }
+    public static AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput value)
+    {
+      software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput)value; AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput converted = new AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput(); converted.Keyring = (AWS.Cryptography.MaterialProviders.IKeyring)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(concrete._keyring);
+      converted.BranchKeyId = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(concrete._branchKeyId);
+      if (concrete._branchKeyVersion.is_Some) converted.BranchKeyVersion = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(concrete._branchKeyVersion); return converted;
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierInput ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput(AWS.Cryptography.MaterialProviders.GetCacheIdentifierInput value)
+    {
+      value.Validate();
+      string var_branchKeyVersion = value.IsSetBranchKeyVersion() ? value.BranchKeyVersion : (string)null;
+      return new software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierInput(ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(value.Keyring), ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(value.BranchKeyId), ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(var_branchKeyVersion));
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(Dafny.ISequence<char> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static Dafny.ISequence<char> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M11_branchKeyId(string value)
+    {
+      return ToDafny_N6_smithy__N3_api__S6_String(value);
+    }
+    public static string FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(Wrappers_Compile._IOption<Dafny.ISequence<char>> value)
+    {
+      return value.is_None ? (string)null : FromDafny_N6_smithy__N3_api__S6_String(value.Extract());
+    }
+    public static Wrappers_Compile._IOption<Dafny.ISequence<char>> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M16_branchKeyVersion(string value)
+    {
+      return value == null ? Wrappers_Compile.Option<Dafny.ISequence<char>>.create_None() : Wrappers_Compile.Option<Dafny.ISequence<char>>.create_Some(ToDafny_N6_smithy__N3_api__S6_String((string)value));
+    }
+    public static AWS.Cryptography.MaterialProviders.IKeyring FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(software.amazon.cryptography.materialproviders.internaldafny.types.IKeyring value)
+    {
+      return FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S16_KeyringReference(value);
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types.IKeyring ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S23_GetCacheIdentifierInput__M7_keyring(AWS.Cryptography.MaterialProviders.IKeyring value)
+    {
+      return ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S16_KeyringReference(value);
+    }
+    public static AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput value)
+    {
+      software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput)value; AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput converted = new AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput(); converted.Identifier = (System.IO.MemoryStream)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(concrete._identifier); return converted;
+    }
+    public static software.amazon.cryptography.materialproviders.internaldafny.types._IGetCacheIdentifierOutput ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput(AWS.Cryptography.MaterialProviders.GetCacheIdentifierOutput value)
+    {
+      value.Validate();
+
+      return new software.amazon.cryptography.materialproviders.internaldafny.types.GetCacheIdentifierOutput(ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(value.Identifier));
+    }
+    public static System.IO.MemoryStream FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(Dafny.ISequence<byte> value)
+    {
+      return FromDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
+    public static Dafny.ISequence<byte> ToDafny_N3_aws__N12_cryptography__N17_materialProviders__S24_GetCacheIdentifierOutput__M10_identifier(System.IO.MemoryStream value)
+    {
+      return ToDafny_N6_smithy__N3_api__S4_Blob(value);
+    }
     public static AWS.Cryptography.MaterialProviders.GetClientInput FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S14_GetClientInput(software.amazon.cryptography.materialproviders.internaldafny.types._IGetClientInput value)
     {
       software.amazon.cryptography.materialproviders.internaldafny.types.GetClientInput concrete = (software.amazon.cryptography.materialproviders.internaldafny.types.GetClientInput)value; AWS.Cryptography.MaterialProviders.GetClientInput converted = new AWS.Cryptography.MaterialProviders.GetClientInput(); converted.Region = (string)FromDafny_N3_aws__N12_cryptography__N17_materialProviders__S14_GetClientInput__M6_region(concrete._region); return converted;

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviders/__init__.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviders/__init__.py
@@ -1,3 +1,4 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviders/shim.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviders/shim.py
@@ -25,6 +25,8 @@ from aws_cryptographic_material_providers.internaldafny.generated.AwsCryptograph
     CreateRequiredEncryptionContextCMMInput_CreateRequiredEncryptionContextCMMInput as DafnyCreateRequiredEncryptionContextCMMInput,
     DecryptionMaterials_DecryptionMaterials as DafnyDecryptionMaterials,
     EncryptionMaterials_EncryptionMaterials as DafnyEncryptionMaterials,
+    GetCacheIdentifierInput_GetCacheIdentifierInput as DafnyGetCacheIdentifierInput,
+    GetCacheIdentifierOutput_GetCacheIdentifierOutput as DafnyGetCacheIdentifierOutput,
     InitializeDecryptionMaterialsInput_InitializeDecryptionMaterialsInput as DafnyInitializeDecryptionMaterialsInput,
     InitializeEncryptionMaterialsInput_InitializeEncryptionMaterialsInput as DafnyInitializeEncryptionMaterialsInput,
     ValidDecryptionMaterialsTransitionInput_ValidDecryptionMaterialsTransitionInput as DafnyValidDecryptionMaterialsTransitionInput,
@@ -50,511 +52,246 @@ import smithy_dafny_standard_library.internaldafny.generated.Wrappers as Wrapper
 import aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes
 import aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.client as client_impl
 
-
-class MaterialProvidersShim(
-    aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IAwsCryptographicMaterialProvidersClient
-):
-    def __init__(self, _impl: client_impl):
+class MaterialProvidersShim(aws_cryptographic_material_providers.internaldafny.generated.AwsCryptographyMaterialProvidersTypes.IAwsCryptographicMaterialProvidersClient):
+    def __init__(self, _impl: client_impl) :
         self._impl = _impl
 
     def CreateAwsKmsKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsDiscoveryKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_discovery_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_discovery_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsMultiKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMultiKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_multi_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMultiKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMultiKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_multi_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsDiscoveryMultiKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryMultiKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_discovery_multi_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsDiscoveryMultiKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsDiscoveryMultiKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_discovery_multi_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsMrkKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_mrk_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_mrk_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsMrkMultiKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkMultiKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_mrk_multi_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkMultiKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkMultiKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_mrk_multi_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsMrkDiscoveryKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_mrk_discovery_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_mrk_discovery_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsMrkDiscoveryMultiKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryMultiKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(
-                input
-            )
-            smithy_client_response = (
-                self._impl.create_aws_kms_mrk_discovery_multi_keyring(
-                    smithy_client_request
-                )
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsMrkDiscoveryMultiKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsMrkDiscoveryMultiKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_mrk_discovery_multi_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsHierarchicalKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsHierarchicalKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_hierarchical_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsHierarchicalKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsHierarchicalKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_hierarchical_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsRsaKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsRsaKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_rsa_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsRsaKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsRsaKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_rsa_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateAwsKmsEcdhKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsEcdhKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_aws_kms_ecdh_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateAwsKmsEcdhKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateAwsKmsEcdhKeyringInput(input)
+            smithy_client_response = self._impl.create_aws_kms_ecdh_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateMultiKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateMultiKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateMultiKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_multi_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateMultiKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateMultiKeyringInput(input)
+            smithy_client_response = self._impl.create_multi_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateRawAesKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawAesKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawAesKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_raw_aes_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawAesKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawAesKeyringInput(input)
+            smithy_client_response = self._impl.create_raw_aes_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateRawRsaKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawRsaKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawRsaKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_raw_rsa_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawRsaKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawRsaKeyringInput(input)
+            smithy_client_response = self._impl.create_raw_rsa_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateRawEcdhKeyring(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawEcdhKeyringInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(
-                input
-            )
-            smithy_client_response = self._impl.create_raw_ecdh_keyring(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRawEcdhKeyringInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRawEcdhKeyringInput(input)
+            smithy_client_response = self._impl.create_raw_ecdh_keyring(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateKeyringOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateDefaultCryptographicMaterialsManager(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultCryptographicMaterialsManagerInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(
-                input
-            )
-            smithy_client_response = (
-                self._impl.create_default_cryptographic_materials_manager(
-                    smithy_client_request
-                )
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultCryptographicMaterialsManagerInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultCryptographicMaterialsManagerInput(input)
+            smithy_client_response = self._impl.create_default_cryptographic_materials_manager(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsManagerOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateRequiredEncryptionContextCMM(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRequiredEncryptionContextCMMInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(
-                input
-            )
-            smithy_client_response = self._impl.create_required_encryption_context_cmm(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateRequiredEncryptionContextCMMInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMInput(input)
+            smithy_client_response = self._impl.create_required_encryption_context_cmm(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateRequiredEncryptionContextCMMOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateCryptographicMaterialsCache(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateCryptographicMaterialsCacheInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(
-                input
-            )
-            smithy_client_response = self._impl.create_cryptographic_materials_cache(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateCryptographicMaterialsCacheInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheInput(input)
+            smithy_client_response = self._impl.create_cryptographic_materials_cache(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateCryptographicMaterialsCacheOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def CreateDefaultClientSupplier(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultClientSupplierInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(
-                input
-            )
-            smithy_client_response = self._impl.create_default_client_supplier(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.CreateDefaultClientSupplierInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateDefaultClientSupplierInput(input)
+            smithy_client_response = self._impl.create_default_client_supplier(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CreateDefaultClientSupplierOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def InitializeEncryptionMaterials(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeEncryptionMaterialsInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(
-                input
-            )
-            smithy_client_response = self._impl.initialize_encryption_materials(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeEncryptionMaterialsInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_InitializeEncryptionMaterialsInput(input)
+            smithy_client_response = self._impl.initialize_encryption_materials(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_EncryptionMaterials(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def InitializeDecryptionMaterials(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeDecryptionMaterialsInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(
-                input
-            )
-            smithy_client_response = self._impl.initialize_decryption_materials(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.InitializeDecryptionMaterialsInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_InitializeDecryptionMaterialsInput(input)
+            smithy_client_response = self._impl.initialize_decryption_materials(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DecryptionMaterials(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def ValidEncryptionMaterialsTransition(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidEncryptionMaterialsTransitionInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(
-                input
-            )
-            smithy_client_response = self._impl.valid_encryption_materials_transition(
-                smithy_client_request
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidEncryptionMaterialsTransitionInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidEncryptionMaterialsTransitionInput(input)
+            smithy_client_response = self._impl.valid_encryption_materials_transition(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def ValidDecryptionMaterialsTransition(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidDecryptionMaterialsTransitionInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(
-                input
-            )
-            smithy_client_response = self._impl.valid_decryption_materials_transition(
-                smithy_client_request
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidDecryptionMaterialsTransitionInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidDecryptionMaterialsTransitionInput(input)
+            smithy_client_response = self._impl.valid_decryption_materials_transition(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def EncryptionMaterialsHasPlaintextDataKey(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptionMaterials
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(
-                input
-            )
-            smithy_client_response = (
-                self._impl.encryption_materials_has_plaintext_data_key(
-                    smithy_client_request
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.EncryptionMaterials = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_EncryptionMaterials(input)
+            smithy_client_response = self._impl.encryption_materials_has_plaintext_data_key(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def DecryptionMaterialsWithPlaintextDataKey(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptionMaterials
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(
-                input
-            )
-            smithy_client_response = (
-                self._impl.decryption_materials_with_plaintext_data_key(
-                    smithy_client_request
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.DecryptionMaterials = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DecryptionMaterials(input)
+            smithy_client_response = self._impl.decryption_materials_with_plaintext_data_key(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def GetAlgorithmSuiteInfo(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetAlgorithmSuiteInfoInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(
-                input
-            )
-            smithy_client_response = self._impl.get_algorithm_suite_info(
-                smithy_client_request
-            )
-            return Wrappers.Result_Success(
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-                    smithy_client_response
-                )
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetAlgorithmSuiteInfoInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetAlgorithmSuiteInfoInput(input)
+            smithy_client_response = self._impl.get_algorithm_suite_info(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_AlgorithmSuiteInfo(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def ValidAlgorithmSuiteInfo(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteInfo
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(
-                input
-            )
-            smithy_client_response = self._impl.valid_algorithm_suite_info(
-                smithy_client_request
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.AlgorithmSuiteInfo = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_AlgorithmSuiteInfo(input)
+            smithy_client_response = self._impl.valid_algorithm_suite_info(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def ValidateCommitmentPolicyOnEncrypt(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnEncryptInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(
-                input
-            )
-            smithy_client_response = self._impl.validate_commitment_policy_on_encrypt(
-                smithy_client_request
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnEncryptInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnEncryptInput(input)
+            smithy_client_response = self._impl.validate_commitment_policy_on_encrypt(smithy_client_request)
             return Wrappers.Result_Success(None)
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
 
     def ValidateCommitmentPolicyOnDecrypt(self, input):
         try:
-            smithy_client_request: (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnDecryptInput
-            ) = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(
-                input
-            )
-            smithy_client_response = self._impl.validate_commitment_policy_on_decrypt(
-                smithy_client_request
-            )
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.ValidateCommitmentPolicyOnDecryptInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_ValidateCommitmentPolicyOnDecryptInput(input)
+            smithy_client_response = self._impl.validate_commitment_policy_on_decrypt(smithy_client_request)
             return Wrappers.Result_Success(None)
+        except Exception as e:
+            return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))
+
+    def GetCacheIdentifier(self, input):
+        try:
+            smithy_client_request: aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.models.GetCacheIdentifierInput = aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_GetCacheIdentifierInput(input)
+            smithy_client_response = self._impl.get_cache_identifier(smithy_client_request)
+            return Wrappers.Result_Success(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_GetCacheIdentifierOutput(smithy_client_response))
         except Exception as e:
             return Wrappers.Result_Failure(_smithy_error_to_dafny_error(e))

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/__init__.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/__init__.py
@@ -1,3 +1,4 @@
 # Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
+

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/client.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/client.py
@@ -44,17 +44,15 @@ from .serialize import (
 Input = TypeVar("Input")
 Output = TypeVar("Output")
 
-
 class KeyVectors:
-    """Client for KeyVectors.
+    """Client for KeyVectors
 
     :param config: Configuration for the client.
     """
-
     def __init__(
         self,
         config: KeyVectorsConfig | None = None,
-        dafny_client: IKeyVectorsClient | None = None,
+        dafny_client: IKeyVectorsClient | None = None
     ):
         if config is None:
             self._config = Config()
@@ -71,9 +69,7 @@ class KeyVectors:
         if dafny_client is not None:
             self._config.dafnyImplInterface.impl = dafny_client
 
-    def create_test_vector_keyring(
-        self, input: TestVectorKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
+    def create_test_vector_keyring(self, input: TestVectorKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
         """Invokes the CreateTestVectorKeyring operation.
 
         :param input: The operation's input.
@@ -87,9 +83,7 @@ class KeyVectors:
             operation_name="CreateTestVectorKeyring",
         )
 
-    def create_wrapped_test_vector_keyring(
-        self, input: TestVectorKeyringInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring":
+    def create_wrapped_test_vector_keyring(self, input: TestVectorKeyringInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.Keyring':
         """Invokes the CreateWrappedTestVectorKeyring operation.
 
         :param input: The operation's input.
@@ -103,9 +97,7 @@ class KeyVectors:
             operation_name="CreateWrappedTestVectorKeyring",
         )
 
-    def create_wrapped_test_vector_cmm(
-        self, input: TestVectorCmmInput
-    ) -> "aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager":
+    def create_wrapped_test_vector_cmm(self, input: TestVectorCmmInput) -> 'aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.references.CryptographicMaterialsManager':
         """Invokes the CreateWrappedTestVectorCmm operation.
 
         :param input: The operation's input.
@@ -119,9 +111,7 @@ class KeyVectors:
             operation_name="CreateWrappedTestVectorCmm",
         )
 
-    def get_key_description(
-        self, input: GetKeyDescriptionInput
-    ) -> GetKeyDescriptionOutput:
+    def get_key_description(self, input: GetKeyDescriptionInput) -> GetKeyDescriptionOutput:
         """Invokes the GetKeyDescription operation.
 
         :param input: The operation's input.
@@ -135,9 +125,7 @@ class KeyVectors:
             operation_name="GetKeyDescription",
         )
 
-    def serialize_key_description(
-        self, input: SerializeKeyDescriptionInput
-    ) -> SerializeKeyDescriptionOutput:
+    def serialize_key_description(self, input: SerializeKeyDescriptionInput) -> SerializeKeyDescriptionOutput:
         """Invokes the SerializeKeyDescription operation.
 
         :param input: The operation's input.
@@ -187,13 +175,12 @@ class KeyVectors:
             transport_response=None,
         )
         try:
-            _client_interceptors = config.interceptors
+          _client_interceptors = config.interceptors
         except AttributeError:
-            config.interceptors = []
-            _client_interceptors = config.interceptors
+          config.interceptors = []
+          _client_interceptors = config.interceptors
         client_interceptors = cast(
-            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-            _client_interceptors,
+            list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]], _client_interceptors
         )
         interceptors = client_interceptors
 
@@ -276,7 +263,7 @@ class KeyVectors:
                             error_info=RetryErrorInfo(
                                 # TODO: Determine the error type.
                                 error_type=RetryErrorType.CLIENT_ERROR,
-                            ),
+                            )
                         )
                     except SmithyRetryException:
                         raise context_with_response.response
@@ -291,10 +278,7 @@ class KeyVectors:
         # The response will be set either with the modeled output or an exception. The
         # transport_request and transport_response may be set or None.
         execution_context = cast(
-            InterceptorContext[
-                Input, Output, DafnyRequest | None, DafnyResponse | None
-            ],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None], context
         )
         return self._finalize_execution(interceptors, execution_context)
 
@@ -319,10 +303,8 @@ class KeyVectors:
                 InterceptorContext[Input, None, DafnyRequest, DafnyResponse], context
             )
 
-            context_with_response._transport_response = (
-                config.dafnyImplInterface.handle_request(
-                    input=context_with_response.transport_request
-                )
+            context_with_response._transport_response = config.dafnyImplInterface.handle_request(
+                input=context_with_response.transport_request
             )
 
             # Step 7n: Invoke read_after_transmit
@@ -359,8 +341,7 @@ class KeyVectors:
         # None. This will also be true after _finalize_attempt because there is no opportunity
         # there to set the transport_response.
         attempt_context = cast(
-            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None],
-            context,
+            InterceptorContext[Input, Output, DafnyRequest, DafnyResponse | None], context
         )
         return self._finalize_attempt(interceptors, attempt_context)
 
@@ -390,9 +371,7 @@ class KeyVectors:
     def _finalize_execution(
         self,
         interceptors: list[Interceptor[Input, Output, DafnyRequest, DafnyResponse]],
-        context: InterceptorContext[
-            Input, Output, DafnyRequest | None, DafnyResponse | None
-        ],
+        context: InterceptorContext[Input, Output, DafnyRequest | None, DafnyResponse | None],
     ) -> Output:
         try:
             # Step 9: Invoke modify_before_completion

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/config.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/config.py
@@ -17,8 +17,6 @@ from smithy_python.interfaces.retries import RetryStrategy
 
 
 _ServiceInterceptor = Any
-
-
 @dataclass(init=False)
 class Config:
     """Configuration for KeyVectors."""
@@ -36,42 +34,47 @@ class Config:
     ):
         """Constructor.
 
-        :param interceptors: The list of interceptors, which are hooks
-            that are called during the execution of a request.
-        :param retry_strategy: The retry strategy for issuing retry
-            tokens and computing retry delays.
+        :param interceptors: The list of interceptors, which are hooks that are called
+        during the execution of a request.
+
+        :param retry_strategy: The retry strategy for issuing retry tokens and computing
+        retry delays.
+
         :param dafnyImplInterface:
         """
         self.interceptors = interceptors or []
         self.retry_strategy = retry_strategy or SimpleRetryStrategy()
         self.dafnyImplInterface = dafnyImplInterface
 
-
 # A callable that allows customizing the config object on each request.
 Plugin: TypeAlias = Callable[[Config], None]
 
-
 class KeyVectorsConfig(Config):
     key_manifest_path: str
-
     def __init__(
         self,
         *,
         key_manifest_path: str,
     ):
-        """Constructor for KeyVectorsConfig."""
+        """Constructor for KeyVectorsConfig
+
+        """
         super().__init__()
         self.key_manifest_path = key_manifest_path
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KeyVectorsConfig to a dictionary."""
+        """Converts the KeyVectorsConfig to a dictionary.
+
+        """
         return {
             "key_manifest_path": self.key_manifest_path,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyVectorsConfig":
-        """Creates a KeyVectorsConfig from a dictionary."""
+        """Creates a KeyVectorsConfig from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_manifest_path": d["key_manifest_path"],
         }
@@ -88,23 +91,22 @@ class KeyVectorsConfig(Config):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KeyVectorsConfig):
             return False
-        attributes: list[str] = [
-            "key_manifest_path",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_manifest_path',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def dafny_config_to_smithy_config(dafny_config) -> KeyVectorsConfig:
-    """Converts the provided Dafny shape for this localService's config into
-    the corresponding Smithy-modelled shape."""
-    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(
-        dafny_config
-    )
-
+    """
+    Converts the provided Dafny shape for this localService's config
+    into the corresponding Smithy-modelled shape.
+    """
+    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(dafny_config)
 
 def smithy_config_to_dafny_config(smithy_config) -> DafnyKeyVectorsConfig:
-    """Converts the provided Smithy-modelled shape for this localService's
-    config into the corresponding Dafny shape."""
-    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(
-        smithy_config
-    )
+    """
+    Converts the provided Smithy-modelled shape for this localService's config
+    into the corresponding Dafny shape.
+    """
+    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(smithy_config)

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafnyImplInterface.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafnyImplInterface.py
@@ -2,11 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Do not modify this file. This file is machine generated, and any changes to it will be overwritten.
 
-from aws_cryptography_materialproviders_test_vectors.internaldafny.generated.KeyVectors import (
-    KeyVectorsClient,
-)
+from aws_cryptography_materialproviders_test_vectors.internaldafny.generated.KeyVectors import KeyVectorsClient
 from .dafny_protocol import DafnyRequest
-
 
 class DafnyImplInterface:
     impl: KeyVectorsClient | None = None
@@ -28,9 +25,9 @@ class DafnyImplInterface:
                 "SerializeKeyDescription": self.impl.SerializeKeyDescription,
             }
 
-        # This logic is where a typical Smithy client would expect the "server" to be.
-        # This code can be thought of as logic our Dafny "server" uses
-        #   to route incoming client requests to the correct request handler code.
+         # This logic is where a typical Smithy client would expect the "server" to be.
+         # This code can be thought of as logic our Dafny "server" uses
+         #   to route incoming client requests to the correct request handler code.
         if input.dafny_operation_input is None:
             return self.operation_map[input.operation_name]()
         else:

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafny_protocol.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafny_protocol.py
@@ -14,7 +14,6 @@ import aws_cryptography_materialproviders_test_vectors.internaldafny.generated.m
 import smithy_dafny_standard_library.internaldafny.generated.Wrappers as Wrappers
 from typing import Union
 
-
 class DafnyRequest:
     operation_name: str
 
@@ -30,7 +29,6 @@ class DafnyRequest:
     def __init__(self, operation_name, dafny_operation_input):
         self.operation_name = operation_name
         self.dafny_operation_input = dafny_operation_input
-
 
 class DafnyResponse(Wrappers.Result):
     def __init__(self):

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafny_to_smithy.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/dafny_to_smithy.py
@@ -28,336 +28,160 @@ import aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_crypt
 def aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input):
     # Convert KeyDescription
     if isinstance(dafny_input, KeyDescription_Kms):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKms(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KMSInfo(
-                dafny_input.Kms
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKms(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KMSInfo(dafny_input.Kms))
     elif isinstance(dafny_input, KeyDescription_KmsMrk):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrk(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(
-                dafny_input.KmsMrk
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrk(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(dafny_input.KmsMrk))
     elif isinstance(dafny_input, KeyDescription_KmsMrkDiscovery):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrkDiscovery(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(
-                dafny_input.KmsMrkDiscovery
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrkDiscovery(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(dafny_input.KmsMrkDiscovery))
     elif isinstance(dafny_input, KeyDescription_RSA):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRSA(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawRSA(
-                dafny_input.RSA
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRSA(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawRSA(dafny_input.RSA))
     elif isinstance(dafny_input, KeyDescription_AES):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionAES(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawAES(
-                dafny_input.AES
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionAES(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawAES(dafny_input.AES))
     elif isinstance(dafny_input, KeyDescription_ECDH):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionECDH(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawEcdh(
-                dafny_input.ECDH
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionECDH(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RawEcdh(dafny_input.ECDH))
     elif isinstance(dafny_input, KeyDescription_Static):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionStatic(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(
-                dafny_input.Static
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionStatic(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(dafny_input.Static))
     elif isinstance(dafny_input, KeyDescription_KmsRsa):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsRsa(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(
-                dafny_input.KmsRsa
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsRsa(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(dafny_input.KmsRsa))
     elif isinstance(dafny_input, KeyDescription_KmsECDH):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsECDH(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(
-                dafny_input.KmsECDH
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsECDH(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(dafny_input.KmsECDH))
     elif isinstance(dafny_input, KeyDescription_Hierarchy):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionHierarchy(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(
-                dafny_input.Hierarchy
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionHierarchy(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(dafny_input.Hierarchy))
     elif isinstance(dafny_input, KeyDescription_Multi):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionMulti(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(
-                dafny_input.Multi
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionMulti(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(dafny_input.Multi))
     elif isinstance(dafny_input, KeyDescription_RequiredEncryptionContext):
-        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRequiredEncryptionContext(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(
-                dafny_input.RequiredEncryptionContext
-            )
-        )
+        KeyDescription_union_value = aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRequiredEncryptionContext(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(dafny_input.RequiredEncryptionContext))
     else:
         raise ValueError("No recognized union value in union type: " + str(dafny_input))
 
     return KeyDescription_union_value
 
-
 def aws_cryptography_materialproviderstestvectorkeys_KMSInfo(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KMSInfo(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KmsMrkAware(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KmsMrkAwareDiscovery(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
-        default_mrk_region=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.defaultMrkRegion
-        ).decode("utf-16-be"),
-        aws_kms_discovery_filter=(
-            (
-                aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(
-                    dafny_input.awsKmsDiscoveryFilter.value
-                )
-            )
-            if (dafny_input.awsKmsDiscoveryFilter.is_Some)
-            else None
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
+        default_mrk_region=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.defaultMrkRegion).decode('utf-16-be'),
+        aws_kms_discovery_filter=(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_DiscoveryFilter(dafny_input.awsKmsDiscoveryFilter.value)) if (dafny_input.awsKmsDiscoveryFilter.is_Some) else None,
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawRSA(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.RawRSA(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
-        provider_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.providerId
-        ).decode("utf-16-be"),
-        padding=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PaddingScheme(
-            dafny_input.padding
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
+        provider_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.providerId).decode('utf-16-be'),
+        padding=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_PaddingScheme(dafny_input.padding),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawAES(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.RawAES(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
-        provider_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.providerId
-        ).decode("utf-16-be"),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
+        provider_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.providerId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawEcdh(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.RawEcdh(
-        sender_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.senderKeyId
-        ).decode("utf-16-be"),
-        recipient_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.recipientKeyId
-        ).decode("utf-16-be"),
-        sender_public_key=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.senderPublicKey
-        ).decode("utf-16-be"),
-        recipient_public_key=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.recipientPublicKey
-        ).decode("utf-16-be"),
-        provider_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.providerId
-        ).decode("utf-16-be"),
-        curve_spec=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.curveSpec
-        ).decode("utf-16-be"),
-        key_agreement_scheme=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyAgreementScheme
-        ).decode("utf-16-be"),
+        sender_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.senderKeyId).decode('utf-16-be'),
+        recipient_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.recipientKeyId).decode('utf-16-be'),
+        sender_public_key=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.senderPublicKey).decode('utf-16-be'),
+        recipient_public_key=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.recipientPublicKey).decode('utf-16-be'),
+        provider_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.providerId).decode('utf-16-be'),
+        curve_spec=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.curveSpec).decode('utf-16-be'),
+        key_agreement_scheme=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyAgreementScheme).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.StaticKeyring(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KmsRsaKeyring(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
-        encryption_algorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.dafny_to_aws_sdk.com_amazonaws_kms_EncryptionAlgorithmSpec(
-            dafny_input.encryptionAlgorithm
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
+        encryption_algorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.dafny_to_aws_sdk.com_amazonaws_kms_EncryptionAlgorithmSpec(dafny_input.encryptionAlgorithm),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KmsEcdhKeyring(
-        sender_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.senderKeyId
-        ).decode("utf-16-be"),
-        recipient_key_id=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.recipientKeyId
-        ).decode("utf-16-be"),
-        sender_public_key=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.senderPublicKey
-        ).decode("utf-16-be"),
-        recipient_public_key=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.recipientPublicKey
-        ).decode("utf-16-be"),
-        curve_spec=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.curveSpec
-        ).decode("utf-16-be"),
-        key_agreement_scheme=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyAgreementScheme
-        ).decode("utf-16-be"),
+        sender_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.senderKeyId).decode('utf-16-be'),
+        recipient_key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.recipientKeyId).decode('utf-16-be'),
+        sender_public_key=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.senderPublicKey).decode('utf-16-be'),
+        recipient_public_key=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.recipientPublicKey).decode('utf-16-be'),
+        curve_spec=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.curveSpec).decode('utf-16-be'),
+        key_agreement_scheme=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyAgreementScheme).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.HierarchyKeyring(
-        key_id=b"".join(ord(c).to_bytes(2, "big") for c in dafny_input.keyId).decode(
-            "utf-16-be"
-        ),
+        key_id=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyId).decode('utf-16-be'),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.MultiKeyring(
-        generator=(
-            (
-                aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-                    dafny_input.generator.value
-                )
-            )
-            if (dafny_input.generator.is_Some)
-            else None
-        ),
-        child_keyrings=[
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-                list_element
-            )
-            for list_element in dafny_input.childKeyrings
-        ],
+        generator=(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.generator.value)) if (dafny_input.generator.is_Some) else None,
+        child_keyrings=[aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(list_element) for list_element in dafny_input.childKeyrings],
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.RequiredEncryptionContextCMM(
-        underlying=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            dafny_input.underlying
-        ),
-        required_encryption_context_keys=[
-            bytes(list_element.Elements).decode("utf-8")
-            for list_element in dafny_input.requiredEncryptionContextKeys
-        ],
+        underlying=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.underlying),
+        required_encryption_context_keys=[bytes(list_element.Elements).decode('utf-8') for list_element in dafny_input.requiredEncryptionContextKeys],
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.TestVectorKeyringInput(
-        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            dafny_input.keyDescription
-        ),
+        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.keyDescription),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_CmmOperation(dafny_input):
     if isinstance(dafny_input, CmmOperation_ENCRYPT):
-        return "ENCRYPT"
+        return 'ENCRYPT'
 
     elif isinstance(dafny_input, CmmOperation_DECRYPT):
-        return "DECRYPT"
+        return 'DECRYPT'
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {dafny_input=}")
-
+        raise ValueError(f'No recognized enum value in enum type: {dafny_input=}')
 
 def aws_cryptography_materialproviderstestvectorkeys_TestVectorCmmInput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.TestVectorCmmInput(
-        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            dafny_input.keyDescription
-        ),
-        for_operation=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_CmmOperation(
-            dafny_input.forOperation
-        ),
+        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.keyDescription),
+        for_operation=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_CmmOperation(dafny_input.forOperation),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.GetKeyDescriptionInput(
         json=bytes(dafny_input.json),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.SerializeKeyDescriptionInput(
-        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            dafny_input.keyDescription
-        ),
+        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.keyDescription),
     )
 
+def aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(dafny_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(dafny_input)
 
-def aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(
-    dafny_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        dafny_input
-    )
-
-
-def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.GetKeyDescriptionOutput(
-        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            dafny_input.keyDescription
-        ),
+        key_description=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(dafny_input.keyDescription),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(
-    dafny_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(dafny_input):
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.SerializeKeyDescriptionOutput(
         json=bytes(dafny_input.json),
     )
 
-
 def aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(dafny_input):
     # Deferred import of .config to avoid circular dependency
     import aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.config
-
     return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.config.KeyVectorsConfig(
-        key_manifest_path=b"".join(
-            ord(c).to_bytes(2, "big") for c in dafny_input.keyManifestPath
-        ).decode("utf-16-be"),
+        key_manifest_path=b''.join(ord(c).to_bytes(2, 'big') for c in dafny_input.keyManifestPath).decode('utf-16-be'),
     )

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/deserialize.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/deserialize.py
@@ -28,64 +28,45 @@ from .config import Config
 
 def _deserialize_create_test_vector_keyring(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
+def _deserialize_create_wrapped_test_vector_keyring(input: DafnyResponse, config: Config):
 
-def _deserialize_create_wrapped_test_vector_keyring(
-    input: DafnyResponse, config: Config
-):
-
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.dafny_to_smithy.aws_cryptography_materialproviders_CreateKeyringOutput(input.value)
 
 def _deserialize_create_wrapped_test_vector_cmm(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(input.value)
 
 def _deserialize_get_key_description(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(input.value)
 
 def _deserialize_serialize_key_description(input: DafnyResponse, config: Config):
 
-    if input.IsFailure():
-        return _deserialize_error(input.error)
-    return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(
-        input.value
-    )
-
+  if input.IsFailure():
+      return _deserialize_error(input.error)
+  return aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.dafny_to_smithy.aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(input.value)
 
 def _deserialize_error(error: Error) -> ServiceError:
     if error.is_Opaque:
         return OpaqueError(obj=error.obj)
     elif error.is_OpaqueWithText:
-        return OpaqueWithTextError(
-            obj=error.obj, obj_message=_dafny.string_of(error.objMessage)
-        )
+        return OpaqueWithTextError(obj=error.obj, obj_message=_dafny.string_of(error.objMessage))
     elif error.is_CollectionOfErrors:
         return CollectionOfErrors(
             message=_dafny.string_of(error.message),
             list=[_deserialize_error(dafny_e) for dafny_e in error.list],
         )
     elif error.is_KeyVectorException:
-        return KeyVectorException(message=_dafny.string_of(error.message))
+      return KeyVectorException(message=_dafny.string_of(error.message))
     else:
         return OpaqueError(obj=error)

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/errors.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/errors.py
@@ -10,34 +10,27 @@ from typing import Any, Dict, Generic, List, Literal, TypeVar
 
 
 class ServiceError(Exception):
-    """Base error for all errors in the service."""
-
+    """Base error for all errors in the service.
+    """
     pass
 
-
-T = TypeVar("T")
-
-
+T = TypeVar('T')
 class ApiError(ServiceError, Generic[T]):
-    """Base error for all api errors in the service."""
-
+    """Base error for all api errors in the service.
+    """
     code: T
-
     def __init__(self, message: str):
         super().__init__(message)
         self.message = message
 
-
-class UnknownApiError(ApiError[Literal["Unknown"]]):
-    """Error representing any unknown api errors."""
-
-    code: Literal["Unknown"] = "Unknown"
-
+class UnknownApiError(ApiError[Literal['Unknown']]):
+    """Error representing any unknown api errors
+    """
+    code: Literal['Unknown'] = 'Unknown'
 
 class KeyVectorException(ApiError[Literal["KeyVectorException"]]):
     code: Literal["KeyVectorException"] = "KeyVectorException"
     message: str
-
     def __init__(
         self,
         *,
@@ -46,17 +39,21 @@ class KeyVectorException(ApiError[Literal["KeyVectorException"]]):
         super().__init__(message)
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KeyVectorException to a dictionary."""
+        """Converts the KeyVectorException to a dictionary.
+
+        """
         return {
-            "message": self.message,
-            "code": self.code,
+            'message': self.message,
+            'code': self.code,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyVectorException":
-        """Creates a KeyVectorException from a dictionary."""
+        """Creates a KeyVectorException from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
+            'message': d['message'],
         }
 
         return KeyVectorException(**kwargs)
@@ -71,57 +68,62 @@ class KeyVectorException(ApiError[Literal["KeyVectorException"]]):
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KeyVectorException):
             return False
-        attributes: list[str] = [
-            "message",
-            "message",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KeyVectorException(ApiError[Literal["KeyVectorException"]]):
     code: Literal["KeyVectorException"] = "KeyVectorException"
     message: str
-
 
 class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
     code: Literal["CollectionOfErrors"] = "CollectionOfErrors"
     message: str
     list: List[ServiceError]
 
-    def __init__(self, *, message: str, list):
+    def __init__(
+        self,
+        *,
+        message: str,
+        list
+    ):
         super().__init__(message)
         self.list = list
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the CollectionOfErrors to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "list": self.list,
+            'message': self.message,
+            'code': self.code,
+            'list': self.list,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "CollectionOfErrors":
         """Creates a CollectionOfErrors from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "list": d["list"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'list': d['list']
+        }
 
         return CollectionOfErrors(**kwargs)
 
     def __repr__(self) -> str:
         result = "CollectionOfErrors("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"list={self.list}"
+        result += f'list={self.list}'
         result += ")"
         return result
 
@@ -130,48 +132,56 @@ class CollectionOfErrors(ApiError[Literal["CollectionOfErrors"]]):
             return False
         if not (self.list == other.list):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueError(ApiError[Literal["OpaqueError"]]):
     code: Literal["OpaqueError"] = "OpaqueError"
     obj: Any  # As an OpaqueError, type of obj is unknown
 
-    def __init__(self, *, obj):
+    def __init__(
+        self,
+        *,
+        obj
+    ):
         super().__init__("")
         self.obj = obj
 
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueError":
         """Creates a OpaqueError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
-        kwargs: Dict[str, Any] = {"message": d["message"], "obj": d["obj"]}
+        kwargs: Dict[str, Any] = {
+            'message': d['message'],
+            'obj': d['obj']
+        }
 
         return OpaqueError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
+        result += f'obj={self.obj}'
         result += ")"
         return result
 
@@ -180,16 +190,23 @@ class OpaqueError(ApiError[Literal["OpaqueError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     code: Literal["OpaqueWithTextError"] = "OpaqueWithTextError"
     obj: Any  # As an OpaqueWithTextError, type of obj is unknown
-    obj_message: str  # obj_message is a message representing the details of obj
+    obj_message: str # obj_message is a message representing the details of obj
 
-    def __init__(self, *, obj, obj_message):
+    def __init__(
+        self,
+        *,
+        obj,
+        obj_message
+    ):
         super().__init__("")
         self.obj = obj
         self.obj_message = obj_message
@@ -197,39 +214,38 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
     def as_dict(self) -> Dict[str, Any]:
         """Converts the OpaqueWithTextError to a dictionary.
 
-        The dictionary uses the modeled shape names rather than the
-        parameter names as keys to be mostly compatible with boto3.
+        The dictionary uses the modeled shape names rather than the parameter names as
+        keys to be mostly compatible with boto3.
         """
         return {
-            "message": self.message,
-            "code": self.code,
-            "obj": self.obj,
-            "obj_message": self.obj_message,
+            'message': self.message,
+            'code': self.code,
+            'obj': self.obj,
+            'obj_message': self.obj_message,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "OpaqueWithTextError":
         """Creates a OpaqueWithTextError from a dictionary.
 
-        The dictionary is expected to use the modeled shape names rather
-        than the parameter names as keys to be mostly compatible with
-        boto3.
+        The dictionary is expected to use the modeled shape names rather than the
+        parameter names as keys to be mostly compatible with boto3.
         """
         kwargs: Dict[str, Any] = {
-            "message": d["message"],
-            "obj": d["obj"],
-            "obj_message": d["obj_message"],
+            'message': d['message'],
+            'obj': d['obj'],
+            'obj_message': d['obj_message']
         }
 
         return OpaqueWithTextError(**kwargs)
 
     def __repr__(self) -> str:
         result = "OpaqueWithTextError("
-        result += f"message={self.message},"
+        result += f'message={self.message},'
         if self.message is not None:
             result += f"message={repr(self.message)}"
-        result += f"obj={self.obj}"
-        result += f"obj_message={self.obj_message}"
+        result += f'obj={self.obj}'
+        result += f'obj_message={self.obj_message}'
         result += ")"
         return result
 
@@ -238,40 +254,30 @@ class OpaqueWithTextError(ApiError[Literal["OpaqueWithTextError"]]):
             return False
         if not (self.obj == other.obj):
             return False
-        attributes: list[str] = ["message", "message"]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['message','message']
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def _smithy_error_to_dafny_error(e: ServiceError):
-    """Converts the provided native Smithy-modeled error into the corresponding
-    Dafny error."""
-    if isinstance(
-        e,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.errors.KeyVectorException,
-    ):
-        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_KeyVectorException(
-            message=_dafny.Seq(e.message)
-        )
+    """
+    Converts the provided native Smithy-modeled error
+    into the corresponding Dafny error.
+    """
+    if isinstance(e, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.errors.KeyVectorException):
+        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_KeyVectorException(message=_dafny.Seq(e.message))
 
     if isinstance(e, CollectionOfErrors):
-        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_CollectionOfErrors(
-            message=_dafny.Seq(e.message),
-            list=_dafny.Seq(
-                _smithy_error_to_dafny_error(native_err) for native_err in e.list
-            ),
-        )
+        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_CollectionOfErrors(message=_dafny.Seq(e.message), list=_dafny.Seq(
+            _smithy_error_to_dafny_error(native_err) for native_err in e.list
+        ))
 
     if isinstance(e, OpaqueError):
-        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_Opaque(
-            obj=e.obj
-        )
+        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_Opaque(obj=e.obj)
 
     if isinstance(e, OpaqueWithTextError):
-        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_OpaqueWithText(
-            obj=e.obj, objMessage=e.obj_message
-        )
+        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_OpaqueWithText(obj=e.obj, objMessage=e.obj_message)
 
     else:
-        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_Opaque(
-            obj=e
-        )
+        return aws_cryptography_materialproviders_test_vectors.internaldafny.generated.AwsCryptographyMaterialProvidersTestVectorKeysTypes.Error_Opaque(obj=e)

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/models.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/models.py
@@ -18,11 +18,9 @@ class CmmOperation:
     # values may be added in the future.
     values = frozenset({"ENCRYPT", "DECRYPT"})
 
-
 class RawAES:
     key_id: str
     provider_id: str
-
     def __init__(
         self,
         *,
@@ -33,7 +31,9 @@ class RawAES:
         self.provider_id = provider_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the RawAES to a dictionary."""
+        """Converts the RawAES to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
             "provider_id": self.provider_id,
@@ -41,7 +41,9 @@ class RawAES:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawAES":
-        """Creates a RawAES from a dictionary."""
+        """Creates a RawAES from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
             "provider_id": d["provider_id"],
@@ -62,12 +64,11 @@ class RawAES:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RawAES):
             return False
-        attributes: list[str] = [
-            "key_id",
-            "provider_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id','provider_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class RawEcdh:
     sender_key_id: str
@@ -77,7 +78,6 @@ class RawEcdh:
     provider_id: str
     curve_spec: str
     key_agreement_scheme: str
-
     def __init__(
         self,
         *,
@@ -98,7 +98,9 @@ class RawEcdh:
         self.key_agreement_scheme = key_agreement_scheme
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the RawEcdh to a dictionary."""
+        """Converts the RawEcdh to a dictionary.
+
+        """
         return {
             "sender_key_id": self.sender_key_id,
             "recipient_key_id": self.recipient_key_id,
@@ -111,7 +113,9 @@ class RawEcdh:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawEcdh":
-        """Creates a RawEcdh from a dictionary."""
+        """Creates a RawEcdh from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "sender_key_id": d["sender_key_id"],
             "recipient_key_id": d["recipient_key_id"],
@@ -152,21 +156,14 @@ class RawEcdh:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RawEcdh):
             return False
-        attributes: list[str] = [
-            "sender_key_id",
-            "recipient_key_id",
-            "sender_public_key",
-            "recipient_public_key",
-            "provider_id",
-            "curve_spec",
-            "key_agreement_scheme",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['sender_key_id','recipient_key_id','sender_public_key','recipient_public_key','provider_id','curve_spec','key_agreement_scheme',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class HierarchyKeyring:
     key_id: str
-
     def __init__(
         self,
         *,
@@ -175,14 +172,18 @@ class HierarchyKeyring:
         self.key_id = key_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the HierarchyKeyring to a dictionary."""
+        """Converts the HierarchyKeyring to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "HierarchyKeyring":
-        """Creates a HierarchyKeyring from a dictionary."""
+        """Creates a HierarchyKeyring from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
         }
@@ -199,15 +200,14 @@ class HierarchyKeyring:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, HierarchyKeyring):
             return False
-        attributes: list[str] = [
-            "key_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KMSInfo:
     key_id: str
-
     def __init__(
         self,
         *,
@@ -216,14 +216,18 @@ class KMSInfo:
         self.key_id = key_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KMSInfo to a dictionary."""
+        """Converts the KMSInfo to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KMSInfo":
-        """Creates a KMSInfo from a dictionary."""
+        """Creates a KMSInfo from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
         }
@@ -240,11 +244,11 @@ class KMSInfo:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KMSInfo):
             return False
-        attributes: list[str] = [
-            "key_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsEcdhKeyring:
     sender_key_id: str
@@ -253,7 +257,6 @@ class KmsEcdhKeyring:
     recipient_public_key: str
     curve_spec: str
     key_agreement_scheme: str
-
     def __init__(
         self,
         *,
@@ -272,7 +275,9 @@ class KmsEcdhKeyring:
         self.key_agreement_scheme = key_agreement_scheme
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsEcdhKeyring to a dictionary."""
+        """Converts the KmsEcdhKeyring to a dictionary.
+
+        """
         return {
             "sender_key_id": self.sender_key_id,
             "recipient_key_id": self.recipient_key_id,
@@ -284,7 +289,9 @@ class KmsEcdhKeyring:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsEcdhKeyring":
-        """Creates a KmsEcdhKeyring from a dictionary."""
+        """Creates a KmsEcdhKeyring from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "sender_key_id": d["sender_key_id"],
             "recipient_key_id": d["recipient_key_id"],
@@ -321,20 +328,14 @@ class KmsEcdhKeyring:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsEcdhKeyring):
             return False
-        attributes: list[str] = [
-            "sender_key_id",
-            "recipient_key_id",
-            "sender_public_key",
-            "recipient_public_key",
-            "curve_spec",
-            "key_agreement_scheme",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['sender_key_id','recipient_key_id','sender_public_key','recipient_public_key','curve_spec','key_agreement_scheme',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsMrkAware:
     key_id: str
-
     def __init__(
         self,
         *,
@@ -343,14 +344,18 @@ class KmsMrkAware:
         self.key_id = key_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsMrkAware to a dictionary."""
+        """Converts the KmsMrkAware to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsMrkAware":
-        """Creates a KmsMrkAware from a dictionary."""
+        """Creates a KmsMrkAware from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
         }
@@ -367,17 +372,16 @@ class KmsMrkAware:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsMrkAware):
             return False
-        attributes: list[str] = [
-            "key_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsMrkAwareDiscovery:
     key_id: str
     default_mrk_region: str
     aws_kms_discovery_filter: Optional[DiscoveryFilter]
-
     def __init__(
         self,
         *,
@@ -395,7 +399,9 @@ class KmsMrkAwareDiscovery:
         self.aws_kms_discovery_filter = aws_kms_discovery_filter
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsMrkAwareDiscovery to a dictionary."""
+        """Converts the KmsMrkAwareDiscovery to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "key_id": self.key_id,
             "default_mrk_region": self.default_mrk_region,
@@ -408,16 +414,16 @@ class KmsMrkAwareDiscovery:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsMrkAwareDiscovery":
-        """Creates a KmsMrkAwareDiscovery from a dictionary."""
+        """Creates a KmsMrkAwareDiscovery from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
             "default_mrk_region": d["default_mrk_region"],
         }
 
         if "aws_kms_discovery_filter" in d:
-            kwargs["aws_kms_discovery_filter"] = DiscoveryFilter.from_dict(
-                d["aws_kms_discovery_filter"]
-            )
+            kwargs["aws_kms_discovery_filter"] = DiscoveryFilter.from_dict(d["aws_kms_discovery_filter"])
 
         return KmsMrkAwareDiscovery(**kwargs)
 
@@ -437,18 +443,15 @@ class KmsMrkAwareDiscovery:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsMrkAwareDiscovery):
             return False
-        attributes: list[str] = [
-            "key_id",
-            "default_mrk_region",
-            "aws_kms_discovery_filter",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id','default_mrk_region','aws_kms_discovery_filter',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class KmsRsaKeyring:
     key_id: str
     encryption_algorithm: str
-
     def __init__(
         self,
         *,
@@ -459,7 +462,9 @@ class KmsRsaKeyring:
         self.encryption_algorithm = encryption_algorithm
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the KmsRsaKeyring to a dictionary."""
+        """Converts the KmsRsaKeyring to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
             "encryption_algorithm": self.encryption_algorithm,
@@ -467,7 +472,9 @@ class KmsRsaKeyring:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KmsRsaKeyring":
-        """Creates a KmsRsaKeyring from a dictionary."""
+        """Creates a KmsRsaKeyring from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
             "encryption_algorithm": d["encryption_algorithm"],
@@ -488,18 +495,16 @@ class KmsRsaKeyring:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, KmsRsaKeyring):
             return False
-        attributes: list[str] = [
-            "key_id",
-            "encryption_algorithm",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id','encryption_algorithm',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class RawRSA:
     key_id: str
     provider_id: str
     padding: str
-
     def __init__(
         self,
         *,
@@ -512,7 +517,9 @@ class RawRSA:
         self.padding = padding
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the RawRSA to a dictionary."""
+        """Converts the RawRSA to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
             "provider_id": self.provider_id,
@@ -521,7 +528,9 @@ class RawRSA:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RawRSA":
-        """Creates a RawRSA from a dictionary."""
+        """Creates a RawRSA from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
             "provider_id": d["provider_id"],
@@ -546,17 +555,14 @@ class RawRSA:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RawRSA):
             return False
-        attributes: list[str] = [
-            "key_id",
-            "provider_id",
-            "padding",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id','provider_id','padding',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class StaticKeyring:
     key_id: str
-
     def __init__(
         self,
         *,
@@ -565,14 +571,18 @@ class StaticKeyring:
         self.key_id = key_id
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the StaticKeyring to a dictionary."""
+        """Converts the StaticKeyring to a dictionary.
+
+        """
         return {
             "key_id": self.key_id,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "StaticKeyring":
-        """Creates a StaticKeyring from a dictionary."""
+        """Creates a StaticKeyring from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_id": d["key_id"],
         }
@@ -589,15 +599,14 @@ class StaticKeyring:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, StaticKeyring):
             return False
-        attributes: list[str] = [
-            "key_id",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_id',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetKeyDescriptionInput:
     json: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -606,14 +615,18 @@ class GetKeyDescriptionInput:
         self.json = json
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetKeyDescriptionInput to a dictionary."""
+        """Converts the GetKeyDescriptionInput to a dictionary.
+
+        """
         return {
             "json": self.json,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetKeyDescriptionInput":
-        """Creates a GetKeyDescriptionInput from a dictionary."""
+        """Creates a GetKeyDescriptionInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "json": d["json"],
         }
@@ -630,15 +643,14 @@ class GetKeyDescriptionInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetKeyDescriptionInput):
             return False
-        attributes: list[str] = [
-            "json",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['json',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class SerializeKeyDescriptionOutput:
     json: bytes | bytearray
-
     def __init__(
         self,
         *,
@@ -647,14 +659,18 @@ class SerializeKeyDescriptionOutput:
         self.json = json
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the SerializeKeyDescriptionOutput to a dictionary."""
+        """Converts the SerializeKeyDescriptionOutput to a dictionary.
+
+        """
         return {
             "json": self.json,
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SerializeKeyDescriptionOutput":
-        """Creates a SerializeKeyDescriptionOutput from a dictionary."""
+        """Creates a SerializeKeyDescriptionOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "json": d["json"],
         }
@@ -671,13 +687,13 @@ class SerializeKeyDescriptionOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SerializeKeyDescriptionOutput):
             return False
-        attributes: list[str] = [
-            "json",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
+        attributes: list[str] = ['json',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
-
-class KeyDescriptionKms:
+class KeyDescriptionKms():
     def __init__(self, value: KMSInfo):
         self.value = value
 
@@ -686,7 +702,7 @@ class KeyDescriptionKms:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionKms":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionKms(KMSInfo.from_dict(d["Kms"]))
@@ -699,8 +715,7 @@ class KeyDescriptionKms:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionKmsMrk:
+class KeyDescriptionKmsMrk():
     def __init__(self, value: KmsMrkAware):
         self.value = value
 
@@ -709,7 +724,7 @@ class KeyDescriptionKmsMrk:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionKmsMrk":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionKmsMrk(KmsMrkAware.from_dict(d["KmsMrk"]))
@@ -722,8 +737,7 @@ class KeyDescriptionKmsMrk:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionKmsMrkDiscovery:
+class KeyDescriptionKmsMrkDiscovery():
     def __init__(self, value: KmsMrkAwareDiscovery):
         self.value = value
 
@@ -732,12 +746,10 @@ class KeyDescriptionKmsMrkDiscovery:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionKmsMrkDiscovery":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return KeyDescriptionKmsMrkDiscovery(
-            KmsMrkAwareDiscovery.from_dict(d["KmsMrkDiscovery"])
-        )
+        return KeyDescriptionKmsMrkDiscovery(KmsMrkAwareDiscovery.from_dict(d["KmsMrkDiscovery"]))
 
     def __repr__(self) -> str:
         return f"KeyDescriptionKmsMrkDiscovery(value=repr(self.value))"
@@ -747,8 +759,7 @@ class KeyDescriptionKmsMrkDiscovery:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionRSA:
+class KeyDescriptionRSA():
     def __init__(self, value: RawRSA):
         self.value = value
 
@@ -757,7 +768,7 @@ class KeyDescriptionRSA:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionRSA":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionRSA(RawRSA.from_dict(d["RSA"]))
@@ -770,8 +781,7 @@ class KeyDescriptionRSA:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionAES:
+class KeyDescriptionAES():
     def __init__(self, value: RawAES):
         self.value = value
 
@@ -780,7 +790,7 @@ class KeyDescriptionAES:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionAES":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionAES(RawAES.from_dict(d["AES"]))
@@ -793,8 +803,7 @@ class KeyDescriptionAES:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionECDH:
+class KeyDescriptionECDH():
     def __init__(self, value: RawEcdh):
         self.value = value
 
@@ -803,7 +812,7 @@ class KeyDescriptionECDH:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionECDH":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionECDH(RawEcdh.from_dict(d["ECDH"]))
@@ -816,8 +825,7 @@ class KeyDescriptionECDH:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionStatic:
+class KeyDescriptionStatic():
     def __init__(self, value: StaticKeyring):
         self.value = value
 
@@ -826,7 +834,7 @@ class KeyDescriptionStatic:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionStatic":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionStatic(StaticKeyring.from_dict(d["Static"]))
@@ -839,8 +847,7 @@ class KeyDescriptionStatic:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionKmsRsa:
+class KeyDescriptionKmsRsa():
     def __init__(self, value: KmsRsaKeyring):
         self.value = value
 
@@ -849,7 +856,7 @@ class KeyDescriptionKmsRsa:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionKmsRsa":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionKmsRsa(KmsRsaKeyring.from_dict(d["KmsRsa"]))
@@ -862,8 +869,7 @@ class KeyDescriptionKmsRsa:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionKmsECDH:
+class KeyDescriptionKmsECDH():
     def __init__(self, value: KmsEcdhKeyring):
         self.value = value
 
@@ -872,7 +878,7 @@ class KeyDescriptionKmsECDH:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionKmsECDH":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionKmsECDH(KmsEcdhKeyring.from_dict(d["KmsECDH"]))
@@ -885,8 +891,7 @@ class KeyDescriptionKmsECDH:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionHierarchy:
+class KeyDescriptionHierarchy():
     def __init__(self, value: HierarchyKeyring):
         self.value = value
 
@@ -895,7 +900,7 @@ class KeyDescriptionHierarchy:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionHierarchy":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionHierarchy(HierarchyKeyring.from_dict(d["Hierarchy"]))
@@ -908,9 +913,8 @@ class KeyDescriptionHierarchy:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionMulti:
-    def __init__(self, value: "MultiKeyring"):
+class KeyDescriptionMulti():
+    def __init__(self, value: 'MultiKeyring'):
         self.value = value
 
     def as_dict(self) -> Dict[str, Any]:
@@ -918,7 +922,7 @@ class KeyDescriptionMulti:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionMulti":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
         return KeyDescriptionMulti(MultiKeyring.from_dict(d["Multi"]))
@@ -931,9 +935,8 @@ class KeyDescriptionMulti:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionRequiredEncryptionContext:
-    def __init__(self, value: "RequiredEncryptionContextCMM"):
+class KeyDescriptionRequiredEncryptionContext():
+    def __init__(self, value: 'RequiredEncryptionContextCMM'):
         self.value = value
 
     def as_dict(self) -> Dict[str, Any]:
@@ -941,12 +944,10 @@ class KeyDescriptionRequiredEncryptionContext:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionRequiredEncryptionContext":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
 
-        return KeyDescriptionRequiredEncryptionContext(
-            RequiredEncryptionContextCMM.from_dict(d["RequiredEncryptionContext"])
-        )
+        return KeyDescriptionRequiredEncryptionContext(RequiredEncryptionContextCMM.from_dict(d["RequiredEncryptionContext"]))
 
     def __repr__(self) -> str:
         return f"KeyDescriptionRequiredEncryptionContext(value=repr(self.value))"
@@ -956,12 +957,11 @@ class KeyDescriptionRequiredEncryptionContext:
             return False
         return self.value == other.value
 
-
-class KeyDescriptionUnknown:
+class KeyDescriptionUnknown():
     """Represents an unknown variant.
 
-    If you receive this value, you will need to update your library to
-    receive the parsed value.
+    If you receive this value, you will need to update your library to receive the
+    parsed value.
 
     This value may not be deliberately sent.
     """
@@ -974,31 +974,14 @@ class KeyDescriptionUnknown:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "KeyDescriptionUnknown":
-        if len(d) != 1:
+        if (len(d) != 1):
             raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
         return KeyDescriptionUnknown(d["SDK_UNKNOWN_MEMBER"]["name"])
 
     def __repr__(self) -> str:
         return f"KeyDescriptionUnknown(tag={self.tag})"
 
-
-KeyDescription = Union[
-    KeyDescriptionKms,
-    KeyDescriptionKmsMrk,
-    KeyDescriptionKmsMrkDiscovery,
-    KeyDescriptionRSA,
-    KeyDescriptionAES,
-    KeyDescriptionECDH,
-    KeyDescriptionStatic,
-    KeyDescriptionKmsRsa,
-    KeyDescriptionKmsECDH,
-    KeyDescriptionHierarchy,
-    KeyDescriptionMulti,
-    KeyDescriptionRequiredEncryptionContext,
-    KeyDescriptionUnknown,
-]
-
-
+KeyDescription = Union[KeyDescriptionKms, KeyDescriptionKmsMrk, KeyDescriptionKmsMrkDiscovery, KeyDescriptionRSA, KeyDescriptionAES, KeyDescriptionECDH, KeyDescriptionStatic, KeyDescriptionKmsRsa, KeyDescriptionKmsECDH, KeyDescriptionHierarchy, KeyDescriptionMulti, KeyDescriptionRequiredEncryptionContext, KeyDescriptionUnknown]
 def _key_description_from_dict(d: Dict[str, Any]) -> KeyDescription:
     if "Kms" in d:
         return KeyDescriptionKms.from_dict(d)
@@ -1036,24 +1019,24 @@ def _key_description_from_dict(d: Dict[str, Any]) -> KeyDescription:
     if "RequiredEncryptionContext" in d:
         return KeyDescriptionRequiredEncryptionContext.from_dict(d)
 
-    raise TypeError(f"Unions may have exactly 1 value, but found {len(d)}")
-
+    raise TypeError(f'Unions may have exactly 1 value, but found {len(d)}')
 
 class RequiredEncryptionContextCMM:
-    underlying: "KeyDescription"
+    underlying: 'KeyDescription'
     required_encryption_context_keys: list[str]
-
     def __init__(
         self,
         *,
-        underlying: "KeyDescription",
+        underlying: 'KeyDescription',
         required_encryption_context_keys: list[str],
     ):
         self.underlying = underlying
         self.required_encryption_context_keys = required_encryption_context_keys
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the RequiredEncryptionContextCMM to a dictionary."""
+        """Converts the RequiredEncryptionContextCMM to a dictionary.
+
+        """
         return {
             "underlying": self.underlying.as_dict(),
             "required_encryption_context_keys": self.required_encryption_context_keys,
@@ -1061,7 +1044,9 @@ class RequiredEncryptionContextCMM:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "RequiredEncryptionContextCMM":
-        """Creates a RequiredEncryptionContextCMM from a dictionary."""
+        """Creates a RequiredEncryptionContextCMM from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "underlying": _key_description_from_dict(d["underlying"]),
             "required_encryption_context_keys": d["required_encryption_context_keys"],
@@ -1082,32 +1067,34 @@ class RequiredEncryptionContextCMM:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, RequiredEncryptionContextCMM):
             return False
-        attributes: list[str] = [
-            "underlying",
-            "required_encryption_context_keys",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['underlying','required_encryption_context_keys',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class GetKeyDescriptionOutput:
-    key_description: "KeyDescription"
-
+    key_description: 'KeyDescription'
     def __init__(
         self,
         *,
-        key_description: "KeyDescription",
+        key_description: 'KeyDescription',
     ):
         self.key_description = key_description
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the GetKeyDescriptionOutput to a dictionary."""
+        """Converts the GetKeyDescriptionOutput to a dictionary.
+
+        """
         return {
             "key_description": self.key_description.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "GetKeyDescriptionOutput":
-        """Creates a GetKeyDescriptionOutput from a dictionary."""
+        """Creates a GetKeyDescriptionOutput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_description": _key_description_from_dict(d["key_description"]),
         }
@@ -1124,31 +1111,34 @@ class GetKeyDescriptionOutput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, GetKeyDescriptionOutput):
             return False
-        attributes: list[str] = [
-            "key_description",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_description',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class SerializeKeyDescriptionInput:
-    key_description: "KeyDescription"
-
+    key_description: 'KeyDescription'
     def __init__(
         self,
         *,
-        key_description: "KeyDescription",
+        key_description: 'KeyDescription',
     ):
         self.key_description = key_description
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the SerializeKeyDescriptionInput to a dictionary."""
+        """Converts the SerializeKeyDescriptionInput to a dictionary.
+
+        """
         return {
             "key_description": self.key_description.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SerializeKeyDescriptionInput":
-        """Creates a SerializeKeyDescriptionInput from a dictionary."""
+        """Creates a SerializeKeyDescriptionInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_description": _key_description_from_dict(d["key_description"]),
         }
@@ -1165,27 +1155,28 @@ class SerializeKeyDescriptionInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, SerializeKeyDescriptionInput):
             return False
-        attributes: list[str] = [
-            "key_description",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_description',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class TestVectorCmmInput:
-    key_description: "KeyDescription"
+    key_description: 'KeyDescription'
     for_operation: str
-
     def __init__(
         self,
         *,
-        key_description: "KeyDescription",
+        key_description: 'KeyDescription',
         for_operation: str,
     ):
         self.key_description = key_description
         self.for_operation = for_operation
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the TestVectorCmmInput to a dictionary."""
+        """Converts the TestVectorCmmInput to a dictionary.
+
+        """
         return {
             "key_description": self.key_description.as_dict(),
             "for_operation": self.for_operation,
@@ -1193,7 +1184,9 @@ class TestVectorCmmInput:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "TestVectorCmmInput":
-        """Creates a TestVectorCmmInput from a dictionary."""
+        """Creates a TestVectorCmmInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_description": _key_description_from_dict(d["key_description"]),
             "for_operation": d["for_operation"],
@@ -1214,32 +1207,34 @@ class TestVectorCmmInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, TestVectorCmmInput):
             return False
-        attributes: list[str] = [
-            "key_description",
-            "for_operation",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_description','for_operation',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class TestVectorKeyringInput:
-    key_description: "KeyDescription"
-
+    key_description: 'KeyDescription'
     def __init__(
         self,
         *,
-        key_description: "KeyDescription",
+        key_description: 'KeyDescription',
     ):
         self.key_description = key_description
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the TestVectorKeyringInput to a dictionary."""
+        """Converts the TestVectorKeyringInput to a dictionary.
+
+        """
         return {
             "key_description": self.key_description.as_dict(),
         }
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "TestVectorKeyringInput":
-        """Creates a TestVectorKeyringInput from a dictionary."""
+        """Creates a TestVectorKeyringInput from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "key_description": _key_description_from_dict(d["key_description"]),
         }
@@ -1256,27 +1251,28 @@ class TestVectorKeyringInput:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, TestVectorKeyringInput):
             return False
-        attributes: list[str] = [
-            "key_description",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['key_description',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 class MultiKeyring:
-    generator: Optional["KeyDescription"]
-    child_keyrings: "list[KeyDescription]"
-
+    generator: Optional['KeyDescription']
+    child_keyrings: 'list[KeyDescription]'
     def __init__(
         self,
         *,
-        child_keyrings: "list[KeyDescription]",
-        generator: Optional["KeyDescription"] = None,
+        child_keyrings: 'list[KeyDescription]',
+        generator: Optional['KeyDescription'] = None,
     ):
         self.child_keyrings = child_keyrings
         self.generator = generator
 
     def as_dict(self) -> Dict[str, Any]:
-        """Converts the MultiKeyring to a dictionary."""
+        """Converts the MultiKeyring to a dictionary.
+
+        """
         d: Dict[str, Any] = {
             "child_keyrings": _key_description_list_as_dict(self.child_keyrings),
         }
@@ -1288,13 +1284,15 @@ class MultiKeyring:
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "MultiKeyring":
-        """Creates a MultiKeyring from a dictionary."""
+        """Creates a MultiKeyring from a dictionary.
+
+        """
         kwargs: Dict[str, Any] = {
             "child_keyrings": _key_description_list_from_dict(d["child_keyrings"]),
         }
 
         if "generator" in d:
-            kwargs["generator"] = (_key_description_from_dict(d["generator"]),)
+            kwargs["generator"] = _key_description_from_dict(d["generator"]),
 
         return MultiKeyring(**kwargs)
 
@@ -1311,20 +1309,17 @@ class MultiKeyring:
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, MultiKeyring):
             return False
-        attributes: list[str] = [
-            "generator",
-            "child_keyrings",
-        ]
-        return all(getattr(self, a) == getattr(other, a) for a in attributes)
-
+        attributes: list[str] = ['generator','child_keyrings',]
+        return all(
+            getattr(self, a) == getattr(other, a)
+            for a in attributes
+        )
 
 def _key_description_list_as_dict(given: list[KeyDescription]) -> List[Any]:
     return [v.as_dict() for v in given]
 
-
 def _key_description_list_from_dict(given: List[Any]) -> list[KeyDescription]:
     return [KeyDescription.from_dict(v) for v in given]
-
 
 class Unit:
     pass

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/plugin.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/plugin.py
@@ -7,37 +7,29 @@ from smithy_python.interfaces.retries import RetryStrategy
 from smithy_python.exceptions import SmithyRetryException
 from .dafnyImplInterface import DafnyImplInterface
 
-
 def set_config_impl(config: Config):
-    """Set the Dafny-compiled implementation in the Smithy-Python client Config
-    and load our custom NoRetriesStrategy."""
+    """
+    Set the Dafny-compiled implementation in the Smithy-Python client Config
+    and load our custom NoRetriesStrategy.
+    """
     config.dafnyImplInterface = DafnyImplInterface()
     if isinstance(config, KeyVectorsConfig):
-        from aws_cryptography_materialproviders_test_vectors.internaldafny.generated.KeyVectors import (
-            default__,
-        )
-
-        config.dafnyImplInterface.impl = default__.KeyVectors(
-            smithy_config_to_dafny_config(config)
-        ).value
+        from aws_cryptography_materialproviders_test_vectors.internaldafny.generated.KeyVectors import default__
+        config.dafnyImplInterface.impl = default__.KeyVectors(smithy_config_to_dafny_config(config)).value
     config.retry_strategy = NoRetriesStrategy()
 
-
 class ZeroRetryDelayToken:
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not wait to retry.
     """
-
     retry_delay = 0
 
-
 class NoRetriesStrategy(RetryStrategy):
-    """Placeholder class required by Smithy-Python client implementation.
-
+    """
+    Placeholder class required by Smithy-Python client implementation.
     Do not retry calling Dafny code.
     """
-
     def acquire_initial_retry_token(self):
         return ZeroRetryDelayToken()
 

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/serialize.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/serialize.py
@@ -10,47 +10,16 @@ from .config import Config
 
 
 def _serialize_create_test_vector_keyring(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateTestVectorKeyring",
-        dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="CreateTestVectorKeyring", dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(input))
 
-
-def _serialize_create_wrapped_test_vector_keyring(
-    input, config: Config
-) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateWrappedTestVectorKeyring",
-        dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(
-            input
-        ),
-    )
-
+def _serialize_create_wrapped_test_vector_keyring(input, config: Config) -> DafnyRequest:
+    return DafnyRequest(operation_name="CreateWrappedTestVectorKeyring", dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(input))
 
 def _serialize_create_wrapped_test_vector_cmm(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="CreateWrappedTestVectorCmm",
-        dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorCmmInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="CreateWrappedTestVectorCmm", dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_TestVectorCmmInput(input))
 
 def _serialize_get_key_description(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="GetKeyDescription",
-        dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(
-            input
-        ),
-    )
-
+    return DafnyRequest(operation_name="GetKeyDescription", dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(input))
 
 def _serialize_serialize_key_description(input, config: Config) -> DafnyRequest:
-    return DafnyRequest(
-        operation_name="SerializeKeyDescription",
-        dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(
-            input
-        ),
-    )
+    return DafnyRequest(operation_name="SerializeKeyDescription", dafny_operation_input=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(input))

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/smithy_to_dafny.py
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/python/src/aws_cryptography_materialproviders_test_vectors/smithygenerated/aws_cryptography_materialproviderstestvectorkeys/smithy_to_dafny.py
@@ -49,560 +49,160 @@ from smithy_dafny_standard_library.internaldafny.generated.Wrappers import (
 )
 
 
-def aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_TestVectorKeyringInput(native_input):
     return DafnyTestVectorKeyringInput(
-        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            native_input.key_description
-        ),
+        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.key_description),
     )
 
-
 def aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input):
-    if isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKms,
-    ):
-        KeyDescription_union_value = KeyDescription_Kms(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KMSInfo(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrk,
-    ):
-        KeyDescription_union_value = KeyDescription_KmsMrk(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrkDiscovery,
-    ):
-        KeyDescription_union_value = KeyDescription_KmsMrkDiscovery(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRSA,
-    ):
-        KeyDescription_union_value = KeyDescription_RSA(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawRSA(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionAES,
-    ):
-        KeyDescription_union_value = KeyDescription_AES(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawAES(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionECDH,
-    ):
-        KeyDescription_union_value = KeyDescription_ECDH(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawEcdh(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionStatic,
-    ):
-        KeyDescription_union_value = KeyDescription_Static(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsRsa,
-    ):
-        KeyDescription_union_value = KeyDescription_KmsRsa(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsECDH,
-    ):
-        KeyDescription_union_value = KeyDescription_KmsECDH(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionHierarchy,
-    ):
-        KeyDescription_union_value = KeyDescription_Hierarchy(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionMulti,
-    ):
-        KeyDescription_union_value = KeyDescription_Multi(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(
-                native_input.value
-            )
-        )
-    elif isinstance(
-        native_input,
-        aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRequiredEncryptionContext,
-    ):
-        KeyDescription_union_value = KeyDescription_RequiredEncryptionContext(
-            aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(
-                native_input.value
-            )
-        )
+    if isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKms):
+        KeyDescription_union_value = KeyDescription_Kms(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KMSInfo(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrk):
+        KeyDescription_union_value = KeyDescription_KmsMrk(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsMrkDiscovery):
+        KeyDescription_union_value = KeyDescription_KmsMrkDiscovery(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRSA):
+        KeyDescription_union_value = KeyDescription_RSA(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawRSA(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionAES):
+        KeyDescription_union_value = KeyDescription_AES(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawAES(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionECDH):
+        KeyDescription_union_value = KeyDescription_ECDH(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RawEcdh(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionStatic):
+        KeyDescription_union_value = KeyDescription_Static(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsRsa):
+        KeyDescription_union_value = KeyDescription_KmsRsa(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionKmsECDH):
+        KeyDescription_union_value = KeyDescription_KmsECDH(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionHierarchy):
+        KeyDescription_union_value = KeyDescription_Hierarchy(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionMulti):
+        KeyDescription_union_value = KeyDescription_Multi(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(native_input.value))
+    elif isinstance(native_input, aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.models.KeyDescriptionRequiredEncryptionContext):
+        KeyDescription_union_value = KeyDescription_RequiredEncryptionContext(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(native_input.value))
     else:
-        raise ValueError(
-            "No recognized union value in union type: " + str(native_input)
-        )
+        raise ValueError("No recognized union value in union type: " + str(native_input))
 
     return KeyDescription_union_value
 
-
 def aws_cryptography_materialproviderstestvectorkeys_KMSInfo(native_input):
     return DafnyKMSInfo(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsMrkAware(native_input):
     return DafnyKmsMrkAware(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsMrkAwareDiscovery(native_input):
     return DafnyKmsMrkAwareDiscovery(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        defaultMrkRegion=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.default_mrk_region.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        awsKmsDiscoveryFilter=(
-            (
-                Option_Some(
-                    aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(
-                        native_input.aws_kms_discovery_filter
-                    )
-                )
-            )
-            if (native_input.aws_kms_discovery_filter is not None)
-            else (Option_None())
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
+        defaultMrkRegion=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.default_mrk_region.encode('utf-16-be'))]*2)])),
+        awsKmsDiscoveryFilter=((Option_Some(aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_DiscoveryFilter(native_input.aws_kms_discovery_filter))) if (native_input.aws_kms_discovery_filter is not None) else (Option_None())),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawRSA(native_input):
     return DafnyRawRSA(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        providerId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.provider_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        padding=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PaddingScheme(
-            native_input.padding
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
+        providerId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.provider_id.encode('utf-16-be'))]*2)])),
+        padding=aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_PaddingScheme(native_input.padding),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawAES(native_input):
     return DafnyRawAES(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        providerId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.provider_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
+        providerId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.provider_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_RawEcdh(native_input):
     return DafnyRawEcdh(
-        senderKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.sender_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        recipientKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.recipient_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        senderPublicKey=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.sender_public_key.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        recipientPublicKey=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.recipient_public_key.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        providerId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.provider_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        curveSpec=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.curve_spec.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        keyAgreementScheme=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_agreement_scheme.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        senderKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.sender_key_id.encode('utf-16-be'))]*2)])),
+        recipientKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.recipient_key_id.encode('utf-16-be'))]*2)])),
+        senderPublicKey=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.sender_public_key.encode('utf-16-be'))]*2)])),
+        recipientPublicKey=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.recipient_public_key.encode('utf-16-be'))]*2)])),
+        providerId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.provider_id.encode('utf-16-be'))]*2)])),
+        curveSpec=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.curve_spec.encode('utf-16-be'))]*2)])),
+        keyAgreementScheme=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_agreement_scheme.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_StaticKeyring(native_input):
     return DafnyStaticKeyring(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsRsaKeyring(native_input):
     return DafnyKmsRsaKeyring(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        encryptionAlgorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.aws_sdk_to_dafny.com_amazonaws_kms_EncryptionAlgorithmSpec(
-            native_input.encryption_algorithm
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
+        encryptionAlgorithm=aws_cryptography_internal_kms.smithygenerated.com_amazonaws_kms.aws_sdk_to_dafny.com_amazonaws_kms_EncryptionAlgorithmSpec(native_input.encryption_algorithm),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_KmsEcdhKeyring(native_input):
     return DafnyKmsEcdhKeyring(
-        senderKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.sender_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        recipientKeyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.recipient_key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        senderPublicKey=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.sender_public_key.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        recipientPublicKey=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.recipient_public_key.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
-        curveSpec=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.curve_spec.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
-        keyAgreementScheme=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_agreement_scheme.encode("utf-16-be"))]
-                        * 2
-                    )
-                ]
-            )
-        ),
+        senderKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.sender_key_id.encode('utf-16-be'))]*2)])),
+        recipientKeyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.recipient_key_id.encode('utf-16-be'))]*2)])),
+        senderPublicKey=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.sender_public_key.encode('utf-16-be'))]*2)])),
+        recipientPublicKey=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.recipient_public_key.encode('utf-16-be'))]*2)])),
+        curveSpec=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.curve_spec.encode('utf-16-be'))]*2)])),
+        keyAgreementScheme=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_agreement_scheme.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_HierarchyKeyring(native_input):
     return DafnyHierarchyKeyring(
-        keyId=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_id.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyId=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_id.encode('utf-16-be'))]*2)])),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_MultiKeyring(native_input):
     return DafnyMultiKeyring(
-        generator=(
-            (
-                Option_Some(
-                    aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-                        native_input.generator
-                    )
-                )
-            )
-            if (native_input.generator is not None)
-            else (Option_None())
-        ),
-        childKeyrings=Seq(
-            [
-                aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-                    list_element
-                )
-                for list_element in native_input.child_keyrings
-            ]
-        ),
+        generator=((Option_Some(aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.generator))) if (native_input.generator is not None) else (Option_None())),
+        childKeyrings=Seq([aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(list_element) for list_element in native_input.child_keyrings]),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_RequiredEncryptionContextCMM(native_input):
     return DafnyRequiredEncryptionContextCMM(
-        underlying=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            native_input.underlying
-        ),
-        requiredEncryptionContextKeys=Seq(
-            [
-                Seq(list_element.encode("utf-8"))
-                for list_element in native_input.required_encryption_context_keys
-            ]
-        ),
+        underlying=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.underlying),
+        requiredEncryptionContextKeys=Seq([Seq(list_element.encode('utf-8')) for list_element in native_input.required_encryption_context_keys]),
     )
-
 
 def aws_cryptography_materialproviderstestvectorkeys_TestVectorCmmInput(native_input):
     return DafnyTestVectorCmmInput(
-        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            native_input.key_description
-        ),
-        forOperation=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_CmmOperation(
-            native_input.for_operation
-        ),
+        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.key_description),
+        forOperation=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_CmmOperation(native_input.for_operation),
     )
 
-
 def aws_cryptography_materialproviderstestvectorkeys_CmmOperation(native_input):
-    if native_input == "ENCRYPT":
+    if native_input == 'ENCRYPT':
         return CmmOperation_ENCRYPT()
 
-    elif native_input == "DECRYPT":
+    elif native_input == 'DECRYPT':
         return CmmOperation_DECRYPT()
 
     else:
-        raise ValueError(f"No recognized enum value in enum type: {native_input=}")
+        raise ValueError(f'No recognized enum value in enum type: {native_input=}')
 
-
-def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionInput(native_input):
     return DafnyGetKeyDescriptionInput(
         json=Seq(native_input.json),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionInput(native_input):
     return DafnySerializeKeyDescriptionInput(
-        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            native_input.key_description
-        ),
+        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.key_description),
     )
 
+def aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(native_input):
+    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(native_input)
 
-def aws_cryptography_materialproviderstestvectorkeys_CreateWrappedTestVectorCmmOutput(
-    native_input,
-):
-    return aws_cryptographic_material_providers.smithygenerated.aws_cryptography_materialproviders.smithy_to_dafny.aws_cryptography_materialproviders_CryptographicMaterialsManagerReference(
-        native_input
-    )
-
-
-def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_GetKeyDescriptionOutput(native_input):
     return DafnyGetKeyDescriptionOutput(
-        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(
-            native_input.key_description
-        ),
+        keyDescription=aws_cryptography_materialproviders_test_vectors.smithygenerated.aws_cryptography_materialproviderstestvectorkeys.smithy_to_dafny.aws_cryptography_materialproviderstestvectorkeys_KeyDescription(native_input.key_description),
     )
 
-
-def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(
-    native_input,
-):
+def aws_cryptography_materialproviderstestvectorkeys_SerializeKeyDescriptionOutput(native_input):
     return DafnySerializeKeyDescriptionOutput(
         json=Seq(native_input.json),
     )
 
-
 def aws_cryptography_materialproviderstestvectorkeys_KeyVectorsConfig(native_input):
     return DafnyKeyVectorsConfig(
-        keyManifestPath=Seq(
-            "".join(
-                [
-                    chr(int.from_bytes(pair, "big"))
-                    for pair in zip(
-                        *[iter(native_input.key_manifest_path.encode("utf-16-be"))] * 2
-                    )
-                ]
-            )
-        ),
+        keyManifestPath=Seq(''.join([chr(int.from_bytes(pair, 'big')) for pair in zip(*[iter(native_input.key_manifest_path.encode('utf-16-be'))]*2)])),
     )


### PR DESCRIPTION


- GetBranchKeyVersions (KeyStore): queries DDB for N branch key versions, decrypts each via KMS
- GetCacheIdentifier (MPL): computes cache entry ID from a Hierarchical Keyring's internal state
- ComputeDecryptCacheId helper on HKR class
- StaticKeyStore stub for GetBranchKeyVersions

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
