### PR TITLE
chore: add special-characters-workaround to avoid sigv4 failure

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -37,7 +37,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoReleaseTest
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -37,6 +37,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoReleaseTest
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/library_go_build.yml
+++ b/.github/workflows/library_go_build.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_go_build.yml
+++ b/.github/workflows/library_go_build.yml
@@ -39,6 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -60,7 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -60,6 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: GoTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_interop_build.yml
+++ b/.github/workflows/library_interop_build.yml
@@ -38,7 +38,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InteropBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/library_interop_build.yml
+++ b/.github/workflows/library_interop_build.yml
@@ -38,6 +38,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InteropBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -49,6 +49,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6
@@ -174,6 +175,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -49,7 +49,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6
@@ -175,7 +175,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/library_java_build.yml
+++ b/.github/workflows/library_java_build.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: JavaBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_java_build.yml
+++ b/.github/workflows/library_java_build.yml
@@ -39,6 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: JavaBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -55,7 +55,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: JavaTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -55,6 +55,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: JavaTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_build.yml
+++ b/.github/workflows/library_net_build.yml
@@ -42,7 +42,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: NetBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_build.yml
+++ b/.github/workflows/library_net_build.yml
@@ -42,6 +42,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: NetBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -58,7 +58,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: NetTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -58,6 +58,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: NetTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_build.yml
+++ b/.github/workflows/library_python_build.yml
@@ -39,7 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: PythonBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_build.yml
+++ b/.github/workflows/library_python_build.yml
@@ -39,6 +39,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: PythonBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -60,7 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: PythonTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -60,6 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: PythonTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_rust_build.yml
+++ b/.github/workflows/library_rust_build.yml
@@ -44,7 +44,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: RustBuild
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/library_rust_build.yml
+++ b/.github/workflows/library_rust_build.yml
@@ -44,6 +44,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: RustBuild
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -60,7 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: RustTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -60,6 +60,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: RustTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -73,7 +73,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: Dafny_Issue_Blocker
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
       - name: Get CI Bot Creds Secret

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -73,6 +73,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: Dafny_Issue_Blocker
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
       - name: Get CI Bot Creds Secret

--- a/.github/workflows/sem_ver.yml
+++ b/.github/workflows/sem_ver.yml
@@ -25,6 +25,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: CI_Bot_Release
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/sem_ver.yml
+++ b/.github/workflows/sem_ver.yml
@@ -25,7 +25,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: CI_Bot_Release
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -34,7 +34,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: CI_Bot_Release
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -34,6 +34,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
           role-session-name: CI_Bot_Release
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/test-interop-metrics.yml
+++ b/.github/workflows/test-interop-metrics.yml
@@ -49,7 +49,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6
@@ -287,7 +287,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/test-interop-metrics.yml
+++ b/.github/workflows/test-interop-metrics.yml
@@ -49,6 +49,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6
@@ -286,6 +287,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
           role-session-name: InterOpTests
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
           role-duration-seconds: 7200
 
       - uses: actions/checkout@v6

--- a/.github/workflows/test_dbesdk_examples.yml
+++ b/.github/workflows/test_dbesdk_examples.yml
@@ -29,7 +29,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
           role-session-name: MPL-DBESDK-Examples-Test
-          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Checkout MPL
         uses: actions/checkout@v6

--- a/.github/workflows/test_dbesdk_examples.yml
+++ b/.github/workflows/test_dbesdk_examples.yml
@@ -29,6 +29,7 @@ jobs:
           aws-region: us-west-2
           role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
           role-session-name: MPL-DBESDK-Examples-Test
+          special-characters-workaround: 'true' # Some environments (example: windowsOS) cannot tolerate special characters in a secret key. 
 
       - name: Checkout MPL
         uses: actions/checkout@v6


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Similar to https://github.com/aws-actions/configure-aws-credentials/issues/599, we very often get sigv4 validation error because windows cannot handle special characters. special-characters-workaround will help us

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
