### PR TITLE
ci: add Java 21 to Java test matrix

### DIFF
--- a/.github/workflows/library_interop_build.yml
+++ b/.github/workflows/library_interop_build.yml
@@ -88,6 +88,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -110,7 +110,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
-
+          cache: false
       - name: Setup Go
         if: matrix.language == 'go'
         uses: actions/setup-go@v6
@@ -232,6 +232,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Setup Go
         if: matrix.decrypting_language == 'go'

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -35,7 +35,7 @@ jobs:
             StandardLibrary,
           ]
         os: [ubuntu-22.04, macos-latest]
-        java-versions: [8, 11, 17, 19]
+        java-versions: [8, 11, 17, 19, 21]
     runs-on: ${{ matrix.os }}
     permissions:
       id-token: write

--- a/.github/workflows/library_rust_build.yml
+++ b/.github/workflows/library_rust_build.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Setup Dafny
         uses: ./.github/actions/setup_dafny

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       # Go is needed for aws-lc-FIPS
       - name: Install Go

--- a/.github/workflows/test-interop-metrics.yml
+++ b/.github/workflows/test-interop-metrics.yml
@@ -102,6 +102,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Setup Go
         uses: actions/setup-go@v6
@@ -335,6 +336,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+          cache: false
 
       - name: Setup Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add Java 21 to the Java test matrix in `library_java_tests.yml`. Previously tested on Java 8, 11, 17, and 19. This aligns with what was done for DBESDK in aws/aws-database-encryption-sdk-dynamodb#2159. Also disables `rust-cache` in the interop test jobs, which was breaking `cargo`/`rustfmt` on macOS by restoring a stale cache when no `Cargo.toml` exists at the repo root.

*Squash/merge commit message, if applicable:*

ci: add Java 21 to Java test matrix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.