### PR TITLE
chore(ci): add retries to configure-aws-credentials with wretry.action

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -31,13 +31,17 @@ jobs:
 
       # KMS and MPL tests need to use credentials which can call KMS
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         if: github.event.inputs.project-name == 'ComAmazonawsKms' || github.event.inputs.project-name == 'ComAmazonawsDynamodb' || github.event.inputs.project-name == 'AwsCryptographicMaterialProviders'
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: GoReleaseTest
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: GoReleaseTest
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/library_go_build.yml
+++ b/.github/workflows/library_go_build.yml
@@ -34,12 +34,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: GoBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: GoBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_go_tests.yml
+++ b/.github/workflows/library_go_tests.yml
@@ -55,12 +55,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: GoTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: GoTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_interop_build.yml
+++ b/.github/workflows/library_interop_build.yml
@@ -38,13 +38,17 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: InteropBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          role-duration-seconds: 7200
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: InteropBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+            role-duration-seconds: 7200
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/library_interop_tests.yml
+++ b/.github/workflows/library_interop_tests.yml
@@ -45,13 +45,17 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: InterOpTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          role-duration-seconds: 7200
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: InterOpTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+            role-duration-seconds: 7200
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
         with:
@@ -173,13 +177,17 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: InterOpTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          role-duration-seconds: 7200
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: InterOpTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+            role-duration-seconds: 7200
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/library_java_build.yml
+++ b/.github/workflows/library_java_build.yml
@@ -34,12 +34,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: JavaBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: JavaBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_java_tests.yml
+++ b/.github/workflows/library_java_tests.yml
@@ -49,13 +49,17 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         if: matrix.library == 'ComAmazonawsKms' || matrix.library == 'ComAmazonawsDynamodb' || matrix.library == 'AwsCryptographicMaterialProviders' || matrix.library == 'TestVectorsAwsCryptographicMaterialProviders'
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: JavaTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: JavaTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_build.yml
+++ b/.github/workflows/library_net_build.yml
@@ -37,12 +37,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: NetBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: NetBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_net_tests.yml
+++ b/.github/workflows/library_net_tests.yml
@@ -53,12 +53,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: NetTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: NetTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_build.yml
+++ b/.github/workflows/library_python_build.yml
@@ -34,12 +34,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: PythonBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: PythonBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_python_tests.yml
+++ b/.github/workflows/library_python_tests.yml
@@ -55,12 +55,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: PythonTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: PythonTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
       - run: git submodule update --init libraries

--- a/.github/workflows/library_rust_build.yml
+++ b/.github/workflows/library_rust_build.yml
@@ -39,12 +39,16 @@ jobs:
           git submodule update --init --recursive smithy-dafny
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: RustBuild
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: RustBuild
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/library_rust_tests.yml
+++ b/.github/workflows/library_rust_tests.yml
@@ -55,12 +55,16 @@ jobs:
           git submodule update --init --recursive smithy-dafny
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: RustTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: RustTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Setup Rust Toolchain for GitHub CI
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/nightly_dafny.yml
+++ b/.github/workflows/nightly_dafny.yml
@@ -68,12 +68,16 @@ jobs:
     steps:
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-          role-session-name: Dafny_Issue_Blocker
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+            role-session-name: Dafny_Issue_Blocker
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       # Use AWS Secrets Manger GHA to retrieve CI Bot Creds
       - name: Get CI Bot Creds Secret

--- a/.github/workflows/sem_ver.yml
+++ b/.github/workflows/sem_ver.yml
@@ -20,12 +20,16 @@ jobs:
 
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-          role-session-name: CI_Bot_Release
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+            role-session-name: CI_Bot_Release
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/sem_ver.yml
+++ b/.github/workflows/sem_ver.yml
@@ -20,16 +20,12 @@ jobs:
 
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release
-        uses: Wandalen/wretry.action@v3.8.0
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          action: aws-actions/configure-aws-credentials@v6.1.2
-          with: |
-            aws-region: us-west-2
-            role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-            role-session-name: CI_Bot_Release
-            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          attempt_limit: 5
-          attempt_delay: 30000
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+          role-session-name: CI_Bot_Release
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -29,12 +29,16 @@ jobs:
 
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-          role-session-name: CI_Bot_Release
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+            role-session-name: CI_Bot_Release
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Upgrade Node
         uses: actions/setup-node@v6

--- a/.github/workflows/semantic_release.yml
+++ b/.github/workflows/semantic_release.yml
@@ -29,16 +29,12 @@ jobs:
 
       # We need access to the role that is able to get CI Bot Creds
       - name: Configure AWS Credentials for Release
-        uses: Wandalen/wretry.action@v3.8.0
+        uses: aws-actions/configure-aws-credentials@v6
         with:
-          action: aws-actions/configure-aws-credentials@v6.1.2
-          with: |
-            aws-region: us-west-2
-            role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
-            role-session-name: CI_Bot_Release
-            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          attempt_limit: 5
-          attempt_delay: 30000
+          aws-region: us-west-2
+          role-to-assume: arn:aws:iam::587316601012:role/GitHub-CI-CI-Bot-Credential-Access-Role-us-west-2
+          role-session-name: CI_Bot_Release
+          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
 
       - name: Upgrade Node
         uses: actions/setup-node@v6
@@ -80,3 +76,4 @@ jobs:
         if: ${{inputs.dry-run == 'y'}}
         run: |
           make run_semantic_release
+          

--- a/.github/workflows/test-interop-metrics.yml
+++ b/.github/workflows/test-interop-metrics.yml
@@ -44,13 +44,17 @@ jobs:
 
       # Test Vectors need to call KMS
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: InterOpTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          role-duration-seconds: 7200
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: InterOpTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+            role-duration-seconds: 7200
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
         with:
@@ -283,13 +287,17 @@ jobs:
 
       # KMS and MPL tests need to use credentials which can call KMS
       - name: Configure AWS Credentials for Tests
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
-          role-session-name: InterOpTests
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
-          role-duration-seconds: 7200
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-MPL-Dafny-Role-us-west-2
+            role-session-name: InterOpTests
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+            role-duration-seconds: 7200
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test_dbesdk_examples.yml
+++ b/.github/workflows/test_dbesdk_examples.yml
@@ -24,12 +24,16 @@ jobs:
           git config --global core.longpaths true
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          aws-region: us-west-2
-          role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
-          role-session-name: MPL-DBESDK-Examples-Test
-          special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          action: aws-actions/configure-aws-credentials@v6.1.2
+          with: |
+            aws-region: us-west-2
+            role-to-assume: arn:aws:iam::370957321024:role/GitHub-CI-DDBEC-Dafny-Role-us-west-2
+            role-session-name: MPL-DBESDK-Examples-Test
+            special-characters-workaround: "true" # Some environments (example: windowsOS) cannot tolerate special characters in a secret key.
+          attempt_limit: 5
+          attempt_delay: 30000
 
       - name: Checkout MPL
         uses: actions/checkout@v6


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
