### PR TITLE
chore(dependabot): modernize config with full ecosystem coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,79 @@
 version: 2
 updates:
-  - package-ecosystem: "gradle"
-    directory: "AwsCryptographicMaterialProviders/runtimes/java"
-    schedule:
-      interval: "daily"
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
+    directory: "/"
     schedule:
-      interval: "daily"
-  # STD NET
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: "gradle"
+    directories:
+      - "StandardLibrary/runtimes/java"
+      - "ComAmazonawsKms/runtimes/java"
+      - "ComAmazonawsDynamodb/runtimes/java"
+      - "AwsCryptographyPrimitives/runtimes/java"
+      - "AwsCryptographicMaterialProviders/runtimes/java"
+      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/java"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+
   - package-ecosystem: "nuget"
-    directory: "StandardLibrary/runtimes/net"
+    directories:
+      - "StandardLibrary/runtimes/net"
+      - "ComAmazonawsKms/runtimes/net"
+      - "ComAmazonawsDynamodb/runtimes/net"
+      - "AwsCryptographyPrimitives/runtimes/net"
+      - "AwsCryptographicMaterialProviders/runtimes/net"
+      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/net"
     schedule:
-      interval: "daily"
-  # KMS NET
-  - package-ecosystem: "nuget"
-    directory: "ComAmazonawsKms/runtimes/net"
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directories:
+      - "StandardLibrary/runtimes/go"
+      - "ComAmazonawsKms/runtimes/go"
+      - "ComAmazonawsDynamodb/runtimes/go"
+      - "AwsCryptographyPrimitives/runtimes/go"
+      - "AwsCryptographicMaterialProviders/runtimes/go"
+      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/go"
     schedule:
-      interval: "daily"
-  # DDB NET
-  - package-ecosystem: "nuget"
-    directory: "ComAmazonawsDynamodb/runtimes/net"
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: "pip"
+    directories:
+      - "StandardLibrary/runtimes/python"
+      - "ComAmazonawsKms/runtimes/python"
+      - "ComAmazonawsDynamodb/runtimes/python"
+      - "AwsCryptographyPrimitives/runtimes/python"
+      - "AwsCryptographicMaterialProviders/runtimes/python"
+      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/python"
     schedule:
-      interval: "daily"
-  # Crypto NET
-  - package-ecosystem: "nuget"
-    directory: "AwsCryptographyPrimitives/runtimes/net"
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+
+  - package-ecosystem: "cargo"
+    directories:
+      - "StandardLibrary/runtimes/rust"
+      - "ComAmazonawsKms/runtimes/rust"
+      - "ComAmazonawsDynamodb/runtimes/rust"
+      - "AwsCryptographyPrimitives/runtimes/rust"
+      - "AwsCryptographicMaterialProviders/runtimes/rust"
+      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/rust"
     schedule:
-      interval: "daily"
-  # MPL NET
-  - package-ecosystem: "nuget"
-    directory: "AwsCryptographicMaterialProviders/runtimes/net"
-    schedule:
-      interval: "daily"
-  # Test Vectors NET
-  - package-ecosystem: "nuget"
-    directory: "TestVectorsAwsCryptographicMaterialProviders/runtimes/net"
-    schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,12 +10,7 @@ updates:
 
   - package-ecosystem: "gradle"
     directories:
-      - "StandardLibrary/runtimes/java"
-      - "ComAmazonawsKms/runtimes/java"
-      - "ComAmazonawsDynamodb/runtimes/java"
-      - "AwsCryptographyPrimitives/runtimes/java"
-      - "AwsCryptographicMaterialProviders/runtimes/java"
-      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/java"
+      - "*/runtimes/java"
     schedule:
       interval: "weekly"
     groups:
@@ -24,12 +19,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directories:
-      - "StandardLibrary/runtimes/net"
-      - "ComAmazonawsKms/runtimes/net"
-      - "ComAmazonawsDynamodb/runtimes/net"
-      - "AwsCryptographyPrimitives/runtimes/net"
-      - "AwsCryptographicMaterialProviders/runtimes/net"
-      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/net"
+      - "*/runtimes/net"
     schedule:
       interval: "weekly"
     groups:
@@ -38,12 +28,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directories:
-      - "StandardLibrary/runtimes/go"
-      - "ComAmazonawsKms/runtimes/go"
-      - "ComAmazonawsDynamodb/runtimes/go"
-      - "AwsCryptographyPrimitives/runtimes/go"
-      - "AwsCryptographicMaterialProviders/runtimes/go"
-      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/go"
+      - "*/runtimes/go/*"
     schedule:
       interval: "weekly"
     groups:
@@ -52,12 +37,7 @@ updates:
 
   - package-ecosystem: "pip"
     directories:
-      - "StandardLibrary/runtimes/python"
-      - "ComAmazonawsKms/runtimes/python"
-      - "ComAmazonawsDynamodb/runtimes/python"
-      - "AwsCryptographyPrimitives/runtimes/python"
-      - "AwsCryptographicMaterialProviders/runtimes/python"
-      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/python"
+      - "*/runtimes/python"
     schedule:
       interval: "weekly"
     groups:
@@ -66,12 +46,7 @@ updates:
 
   - package-ecosystem: "cargo"
     directories:
-      - "StandardLibrary/runtimes/rust"
-      - "ComAmazonawsKms/runtimes/rust"
-      - "ComAmazonawsDynamodb/runtimes/rust"
-      - "AwsCryptographyPrimitives/runtimes/rust"
-      - "AwsCryptographicMaterialProviders/runtimes/rust"
-      - "TestVectorsAwsCryptographicMaterialProviders/runtimes/rust"
+      - "*/runtimes/rust"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

- Add `pip`, `cargo`, and `gomod` ecosystems for Python, Rust, and Go runtimes
- Use glob patterns (`*/runtimes/<lang>`) instead of explicit directories
- Switch from `daily` to `weekly` interval to reduce PR noise
- Add grouped updates (`patterns: ["*"]`) so each ecosystem produces one PR instead of one per directory
- Fix `github-actions` directory from `.github/workflows` to `/` (root is the correct value; Dependabot auto-discovers workflow files)

### Squash/merge commit message, if applicable:

```
chore(dependabot): modernize config with full ecosystem coverage
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
