### PR TITLE
chore: use globstar pattern to find go.mod in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
 
   - package-ecosystem: "gomod"
     directories:
-      - "*/runtimes/go/*"
+      - "*/runtimes/go/**"
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
go.mod is in `*/runtimes/go/ImplementationFromDafny-go/` and `*/runtimes/go/TestsFromDafny-go`. So, we need to use globstar to catch directories recursively. 

### Squash/merge commit message, if applicable:

```
chore: use globstar pattern to find go mod recursively
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
