### PR TITLE
chore(deps): bump cryptography upperbound to <49 to allow patching GH…

### DIFF
--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -13,7 +13,7 @@ include = ["src/aws_cryptography_primitives/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-cryptography = ">=43.0.1, <47"
+cryptography = ">=43.0.1, <49"
 
 # Package testing
 


### PR DESCRIPTION

Raises the cryptography upper bound in aws-cryptography-internal-primitives from <47 to <49 so consumers can install cryptography>=48.0.1, which fixes GHSA-537c-gmf6-5ccf (HIGH, CVSS 7.5) in the OpenSSL bundled into cryptography's PyPI wheels.

The library requires Python ^3.11, so cryptography 48's raised Python 3.9 floor is a non-issue. Only SECP curves are used, so the 47.0.0 removal of binary elliptic curves does not apply. The test_ECDH_exceptions.py suite, which documents pyca's sensitive point-at-infinity failure modes, still passes unchanged against 48.0.1, and all cryptography APIs used by the extern modules were smoke-tested against 48.0.1.

Same class of change as #1800.

Fixes #1914

### Issue #, if available:

### Description of changes:

### Squash/merge commit message, if applicable:

```
<type>(dafny/java/python/dotnet/go/rust): <description>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
