### PR TITLE
fix(rust): align aws-lc-sys/fips-sys pins with aws-lc-rs

### DIFF
--- a/AwsCryptographicMaterialProviders/runtimes/rust/Cargo.toml
+++ b/AwsCryptographicMaterialProviders/runtimes/rust/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.17.0"}
-aws-lc-sys = { version = "0.43", optional = true }
-aws-lc-fips-sys = { version = "0.13.1", optional = true }
+aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-fips-sys = { version = "0.14", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }

--- a/AwsCryptographyPrimitives/runtimes/rust/Cargo.toml
+++ b/AwsCryptographyPrimitives/runtimes/rust/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.15.4"}
-aws-lc-sys = { version = "0.39", optional = true }
-aws-lc-fips-sys = { version = "0.13", optional = true }
+aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-fips-sys = { version = "0.14", optional = true }
 aws-smithy-runtime-api = "1.10.0"
 aws-smithy-types = "1.3.6"
 chrono = "0.4.43"

--- a/TestVectorsAwsCryptographicMaterialProviders/runtimes/rust/Cargo.toml
+++ b/TestVectorsAwsCryptographicMaterialProviders/runtimes/rust/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 aws-config = "1.8.12"
 aws-lc-rs = {version = "1.15.4"}
-aws-lc-sys = { version = "0.39", optional = true }
-aws-lc-fips-sys = { version = "0.13", optional = true }
+aws-lc-sys = { version = "0.44", optional = true }
+aws-lc-fips-sys = { version = "0.14", optional = true }
 aws-sdk-dynamodb = "1.103.0"
 aws-sdk-kms = "1.98.0"
 aws-smithy-runtime-api = {version = "1.10.0", features = ["client"] }


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
pin the same version across all the submodules.

### Verification:
Replicated the duplicate-deps check logic (`cargo tree -d`, default + fips profiles, with generated targets stubbed as the workflow does) on all three crates. Each now resolves a single `aws-lc-sys v0.44.0` / `aws-lc-fips-sys v0.14.1` with `aws-lc-rs v1.18.0` present — zero duplicate blocks.

### Squash/merge commit message, if applicable:
`fix(rust): align aws-lc-sys/fips-sys pins with aws-lc-rs`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.