### PR TITLE
chore(deps): bump cryptography upper bound to <51

### DIFF
--- a/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
+++ b/AwsCryptographyPrimitives/runtimes/python/pyproject.toml
@@ -13,7 +13,7 @@ include = ["src/aws_cryptography_primitives/internaldafny/generated/*.py"]
 [tool.poetry.dependencies]
 python = "^3.11.0"
 aws-cryptography-internal-standard-library = {path = "../../../StandardLibrary/runtimes/python"}
-cryptography = ">=43.0.1, <49"
+cryptography = ">=43.0.1, <51"
 
 # Package testing
 


### PR DESCRIPTION
  The `aws-cryptographic-material-providers-library` currently constrains `cryptography` to `>=43.0.1, <49`, which means
  downstream projects are unable to upgrade to versions that fix 3 High severity CVEs. Security scanners (e.g. Snyk)
  flag these vulnerabilities against any project that depends on this library.
  
  **Vulnerabilities blocked by the current `<49` upper bound:**
  
  | CVE | Severity | Fixed in
  |---|---|---|
  | CVE-2026-69249 | High (CVSS 8.7) | 49.0.0
  | CVE-2026-69248 | High (CVSS 8.3) | 49.0.0
  | CVE-2026-69247 | High (CVSS 8.2) | 50.0.0