### PR TITLE
ci(rust): simplify duplicate aws-lc error message

### DIFF
--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -84,25 +84,22 @@ jobs:
             awslc=$(printf '%s\n' "$dup" | awk 'BEGIN{RS="";ORS="\n\n"} /^aws-lc-(sys|fips-sys) v/' || true)
             if [ -n "$(printf '%s' "$awslc" | tr -d '[:space:]')" ]; then
               status=1
-              echo "::error::Duplicate aws-lc native crate detected ($label build). See log for how to fix."
-              echo "------------------------------------------------------------------------"
-              echo "Duplicate aws-lc native crate(s) in the $label dependency tree."
-              echo "Each version below compiles a separate copy of AWS-LC. The tree shows"
-              echo "which package pulls in each version:"
-              echo ""
-              printf '%s\n' "$awslc" | sed 's/^/    /'
-              echo "Declared directly in this crate's Cargo.toml:"
-              grep -nE '^aws-lc-(sys|fips-sys)[[:space:]]' Cargo.toml | sed 's/^/    /' || true
-              echo ""
-              echo "Why this matters: a different DIRECT -sys version forces a second copy"
-              echo "of AWS-LC to compile (~2x native C build time + larger binary), and the"
-              echo "SDK's raw FFI (aws_lc_sys_impl::*) then uses the version YOU declared"
-              echo "while aws-lc-rs uses the one it pulls in -- so the raw path can stay on a"
-              echo "stale/vulnerable AWS-LC independently of aws-lc-rs."
-              echo ""
-              echo "How to fix: set the direct version to the SAME version aws-lc-rs resolves"
-              echo "to (shown above), then confirm locally with:  cargo tree -d"
-              echo "------------------------------------------------------------------------"
+
+              # Which -sys crate is duplicated (aws-lc-sys or aws-lc-fips-sys).
+              crate=$(printf '%s\n' "$awslc" | grep -oE 'aws-lc-(sys|fips-sys)' | head -1)
+              # The version aws-lc-rs actually pulls in -- this is the one to pin to.
+              want=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
+                | grep -oE "$crate v[0-9][0-9.]*" | head -1 | grep -oE '[0-9][0-9.]*')
+              # What Cargo.toml declares directly today, with its line number.
+              cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
+              cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
+              lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
+
+              echo "::error::$crate is duplicated ($label build). Fix: pin it to $want in Cargo.toml."
+              echo "Cargo.toml line $lineno:"
+              echo "    - $crate = \"$cur\""
+              echo "    + $crate = \"$want\""
+              echo "(aws-lc-rs resolves $crate to v$want; matching it collapses the two AWS-LC builds into one.)"
             fi
           }
 

--- a/.github/workflows/rust_duplicate_deps.yml
+++ b/.github/workflows/rust_duplicate_deps.yml
@@ -90,16 +90,20 @@ jobs:
               # The version aws-lc-rs actually pulls in -- this is the one to pin to.
               want=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
                 | grep -oE "$crate v[0-9][0-9.]*" | head -1 | grep -oE '[0-9][0-9.]*')
-              # What Cargo.toml declares directly today, with its line number.
+              # The aws-lc-rs version doing the resolving.
+              rs_ver=$(cargo tree $args -p aws-lc-rs 2>/dev/null \
+                | grep -oE 'aws-lc-rs v[0-9][0-9.]*' | head -1 | grep -oE '[0-9][0-9.]*')
+              # Repo-relative path to the offending Cargo.toml, and the line to change.
+              cargo_path="$(git rev-parse --show-prefix 2>/dev/null)Cargo.toml"
               cargo_line=$(grep -nE "^$crate[[:space:]]*=" Cargo.toml | head -1)
               cur=$(printf '%s' "$cargo_line" | grep -oE '[0-9][0-9.]+' | head -1)
               lineno=$(printf '%s' "$cargo_line" | cut -d: -f1)
 
-              echo "::error::$crate is duplicated ($label build). Fix: pin it to $want in Cargo.toml."
-              echo "Cargo.toml line $lineno:"
-              echo "    - $crate = \"$cur\""
-              echo "    + $crate = \"$want\""
-              echo "(aws-lc-rs resolves $crate to v$want; matching it collapses the two AWS-LC builds into one.)"
+              echo "::error::$crate versions aren't consistent. Fix: pin it to $want in $cargo_path."
+              echo "In $cargo_path line $lineno, change"
+              echo "- $crate = \"$cur\""
+              echo "+ $crate = \"$want\""
+              echo "(aws-lc-rs v$rs_ver resolves $crate to v$want; matching it avoids inconsistencies.)"
             fi
           }
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

Replace verbose failure message slop with something useful.
ex. from actual DBESDK message log

```
Error: aws-lc-sys versions aren't consistent. Fix: pin it to 0.44.0 in DynamoDbEncryption/runtimes/rust/Cargo.toml.
In DynamoDbEncryption/runtimes/rust/Cargo.toml line 20, change
- aws-lc-sys = "0.43"
+ aws-lc-sys = "0.44.0"
(aws-lc-rs v1.18.0 resolves aws-lc-sys to v0.44.0; matching it avoids inconsistencies.)
```

_Squash/merge commit message, if applicable:_

ci(rust): simplify duplicate aws-lc error message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
